### PR TITLE
Removes the straight razor from the loadout

### DIFF
--- a/modular_sand/code/game/objects/items/cosmetics.dm
+++ b/modular_sand/code/game/objects/items/cosmetics.dm
@@ -39,7 +39,7 @@
 		H.facial_hair_style = new_style
 		H.update_hair()
 
-/obj/item/razor/straightrazor
+/obj/item/razor/straightrazor1
 	name = "straight razor"
 	icon = 'modular_sand/icons/obj/items_and_weapons.dmi'
 	icon_state = "straightrazor"

--- a/modular_sand/code/modules/client/loadout/hands.dm
+++ b/modular_sand/code/modules/client/loadout/hands.dm
@@ -10,9 +10,3 @@
 	description = "For styling people's (or your own when next to a mirror) hair and beard."
 	path = /obj/item/razor
 	cost = 2
-
-/datum/gear/hands/straightrazor
-	name = "Straight razor"
-	description = "Everything the electric razor does plus getting executed by security for slitting someone's throat with this."
-	path = /obj/item/razor/straightrazor
-	cost = 8


### PR DESCRIPTION
## About The Pull Request

Removes the straight razor from the loadout. No fun allowed.

## Why It's Good For The Game

It does 17 brute damage and is a knife weapon. It can de-organ people, does more damage to a toolbox, and generally people are abusing it and valid hunting. We should not allow round start weapons inside the loadout.

