### PR TITLE
Add Wardrobes to Perma

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -180,6 +180,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/dresser,
 /turf/open/floor/plasteel,
 /area/security/prison/cells)
 "aaz" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -10528,6 +10528,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/dresser,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMh" = (

--- a/_maps/map_files/FestiveBall/FestiveStation.dmm
+++ b/_maps/map_files/FestiveBall/FestiveStation.dmm
@@ -56060,6 +56060,10 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/edina/crew_quarters/store/pet)
+"vZM" = (
+/obj/structure/dresser,
+/turf/open/floor/wood,
+/area/security/prison)
 "wcL" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets,
@@ -96129,7 +96133,7 @@ alo
 amh
 amO
 anm
-anD
+vZM
 aoI
 apu
 aqk

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -60872,9 +60872,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/box,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -61825,9 +61822,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	name = "Prison Intercom (General)";
@@ -61839,6 +61833,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -70140,9 +70137,6 @@
 /area/engineering/atmos)
 "ciF" = (
 /obj/machinery/hydroponics/soil,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/item/seeds/sugarcane,
 /turf/open/floor/grass,
 /area/security/prison)
@@ -82560,9 +82554,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/light,
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
@@ -82570,6 +82561,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/dresser,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "cIS" = (

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -73655,6 +73655,10 @@
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
+"xWz" = (
+/obj/structure/dresser,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "xYx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -115309,7 +115313,7 @@ abA
 abV
 acn
 acn
-abT
+xWz
 afh
 ady
 ady

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -70230,6 +70230,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/dresser,
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
 "pAA" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -43719,6 +43719,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"qTh" = (
+/obj/structure/dresser,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qUQ" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -81995,7 +81999,7 @@ acH
 abR
 afh
 azi
-agG
+qTh
 aiS
 acH
 aAw
@@ -82509,7 +82513,7 @@ acH
 abT
 azi
 azi
-aep
+agG
 ajQ
 acH
 aAU

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -58571,6 +58571,11 @@
 "oMN" = (
 /turf/open/floor/plasteel/stairs/left,
 /area/maintenance/department/crew_quarters/dorms)
+"oNq" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/dresser,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "oNE" = (
 /obj/structure/chair/office/light,
 /obj/structure/sign/warning/deathsposal{
@@ -82430,7 +82435,7 @@ afq
 aga
 agx
 lem
-lem
+oNq
 sJp
 sJp
 sJp

--- a/_maps/map_files/Snaxi/Snaxi.dmm
+++ b/_maps/map_files/Snaxi/Snaxi.dmm
@@ -14446,6 +14446,10 @@
 /obj/effect/landmark/start/warden,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"cgu" = (
+/obj/structure/dresser,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cgH" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
@@ -75118,7 +75122,7 @@ kfv
 oBG
 bGu
 kfv
-bGu
+cgu
 iGd
 iVY
 mrM

--- a/_maps/map_files/SpookyStation/SpookyStation.dmm
+++ b/_maps/map_files/SpookyStation/SpookyStation.dmm
@@ -16754,6 +16754,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/eventmap/outside)
+"dim" = (
+/obj/structure/dresser,
+/turf/open/floor/spooktime/dirtpatch,
+/area/eventmap/inside)
 
 (1,1,1) = {"
 aJx
@@ -30794,7 +30798,7 @@ adN
 acy
 aLv
 aLv
-aLv
+dim
 aMf
 aLv
 aLn


### PR DESCRIPTION
## About The Pull Request

This adds a wardrobe to permabrig for every station other than Cogstation and Smolstation (the latter is so old it has minesweeper on it).

## Why It's Good For The Game

Prisoners typically don't have access to the rest of the station, so this will let them change out their underwear.

## A Port?

No

## Changelog
add: Added wardrobes to permabrig.
/:cl: