### PR TITLE
Set pixel fixing for borg expander

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -980,6 +980,7 @@
 
 	if (hasExpanded)
 		resize = 0.5
+		pixel_y -= 16
 		hasExpanded = FALSE
 		update_transform()
 	logevent("Chassis configuration has been reset.")

--- a/modular_sand/code/game/objects/items/robot/robot_upgrades.dm
+++ b/modular_sand/code/game/objects/items/robot/robot_upgrades.dm
@@ -160,13 +160,15 @@
 			R.SetLockdown(0)
 		R.anchored = FALSE
 		R.mob_transforming = FALSE
-		R.transform = R.transform.Scale(1.25, 1.25)
+		R.transform = R.transform.Scale(2, 2)
+		R.pixel_y += 16
 		R.hasExpanded = TRUE
 
 /obj/item/borg/upgrade/expand/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)
-		R.transform = R.transform.Scale(0.8, 0.8)
+		R.transform = R.transform.Scale(0.5, 0.5)
+		R.pixel_y -= 16
 		R.hasExpanded = FALSE
 
 /obj/item/borg/upgrade/shrink


### PR DESCRIPTION
## About The Pull Request

Borg expanders have two problems, they do not expand as they used two (double size), and the sprite is off-centre (not on the floor properly), this fixes both with a **temporary** solution until I find a better way to fix this.

## Why It's Good For The Game

temporary fixes the borg expander

## A Port?

no

## Changelog
:cl:
fix: gave the borg expander and borg reset codes a pixel_y += 16 and pixel_y -= 16, temporary fix
/:cl: