### PR TITLE
Anti-grief part 1

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -760,6 +760,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/vape/attackby(obj/item/O, mob/user, params)
 	if(O.tool_behaviour == TOOL_SCREWDRIVER)
 		if(!screw)
+			var/turf/T = get_turf(src)
+			var/client/client = user.client
+
+			if(client && client.get_exp_living(TRUE) < 1800) // ANTI-GRIEF: Must have 30 hours (30 * 60) playtime to put custom chems in vapes.
+				to_chat(user, "<span class='red'>You do not have enough playtime on this server to put custom chemicals into e-cigs.</span>")
+				var/message = "<span class='adminhelp'>ANTI-GRIEF:</span> [ADMIN_LOOKUPFLW(user)]) attempted to put custom chemicals into \a [src] at [ADMIN_VERBOSEJMP(T)] (failed due to playtime requirement)"
+				message_admins(message)
+				return;
+
 			screw = TRUE
 			to_chat(user, "<span class='notice'>You open the cap on [src].</span>")
 			reagents.reagents_holder_flags |= OPENCONTAINER

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -189,8 +189,16 @@
 */
 /obj/item/transfer_valve/proc/toggle_valve()
 	if(!valve_open && tank_one && tank_two)
-		valve_open = TRUE
 		var/turf/bombturf = get_turf(src)
+		var/area/bombarea = get_area(bombturf)
+
+		if(!istype(bombarea, /area/science/test_area)) // ANTI-GRIEF: Can only blow up at the toxins test range.
+			var/mob/bomber = get_mob_by_key(fingerprintslast)
+			var/message = "<span class='adminhelp'>ANTI-GRIEF:</span> [ADMIN_LOOKUPFLW(bomber)]) attempted to detonate \a [src] at [ADMIN_VERBOSEJMP(bombturf)] (failed due to not being in toxins test area)"
+			message_admins(message)
+			return
+
+		valve_open = TRUE
 
 		var/attachment
 		if(attached_device)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -148,7 +148,7 @@
 
 //assembly stuff
 /obj/item/grenade/chem_grenade/receive_signal()
-	prime()
+	// prime()
 
 
 /obj/item/grenade/chem_grenade/Crossed(atom/movable/AM)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -56,6 +56,7 @@
 			if(beakers.len)
 				stage_change(READY)
 				to_chat(user, "<span class='notice'>You lock the [initial(name)] assembly.</span>")
+				custom_made = TRUE // This nade has been tampered with, its contents are now unknown. Grief check it on activation.
 				I.play_tool_sound(src, 25)
 			else
 				to_chat(user, "<span class='warning'>You need to add at least one beaker before locking the [initial(name)] assembly!</span>")

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -34,6 +34,7 @@
 	/// the higher this number, the more projectiles are created as shrapnel
 	var/shrapnel_radius
 	var/shrapnel_initialized
+	var/custom_made = FALSE // Was this nade tampered with by a player? (used to check for grief nades)
 
 /obj/item/grenade/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] primes [src], then eats it! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -99,6 +100,14 @@
 
 /obj/item/grenade/proc/preprime(mob/user, delayoverride, msg = TRUE, volume = 60)
 	var/turf/T = get_turf(src)
+	var/client/client = user.client
+
+	if(custom_made && client && client.get_exp_living(TRUE) < 1800) // ANTI-GRIEF: Must have 30 hours (30 * 60) playtime to use grenades.
+		to_chat(user, "<span class='red'>You do not have enough playtime on this server to prime custom explosives.</span>")
+		var/message = "<span class='adminhelp'>ANTI-GRIEF:</span> [ADMIN_LOOKUPFLW(user)]) attempted to arm \a [src] (customised) for detonation at [ADMIN_VERBOSEJMP(T)] (failed due to playtime requirement)"
+		message_admins(message)
+		return;
+
 	log_grenade(user, T) //Inbuilt admin procs already handle null users
 	if(user)
 		add_fingerprint(user)

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -49,8 +49,8 @@
 	return BRUTELOSS
 
 /obj/item/grenade/deconstruct(disassembled = TRUE)
-	if(!disassembled)
-		prime()
+	// if(!disassembled)
+	// 	prime()
 	if(!QDELETED(src))
 		qdel(src)
 


### PR DESCRIPTION
I am sick of getting bombed. Let's fix that.

## About The Pull Request

**Toxins bombs**: Can now only blow up in the toxins test range. (Do all maps use /area/science/test_area ?)
**Grenades**: If the grenade is custom made (has been screwdriver'd at any point), it requires 30 hours playtime on the user to actually set it off.
**Vaping**: You cannot add custom chems to a e-cig unless you have 30 hours playtime

## Why It's Good For The Game

Bombing is -5000 social credit

## Changelog
:cl:
tweak: Toxins bombs now only blow up in the toxins test range
tweak: Custom grenades can only be primed if you have 30 hours playtime
tweak: Vape sticks can only get custom chemicals if you have 30 hours playtime
/:cl: