### PR TITLE
More Grief Warnings

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -79,8 +79,17 @@
 	if(attached_device)
 		attached_device.Crossed(AM)
 
-/obj/item/transfer_valve/on_attack_hand()//Triggers mousetraps
+/obj/item/transfer_valve/on_attack_hand(mob/living/user)//Triggers mousetraps
 	. = ..()
+
+	var/turf/T = get_turf(src)
+	var/client/client = user.client
+	if (CONFIG_GET(flag/use_exp_tracking) && client && client.get_exp_living(TRUE) < 480) // Player with less than 8 hours playtime has touched a bomb valve.
+		if(client.next_valve_grief_warning < world.time)
+			client.next_valve_grief_warning = world.time + 9000 // Wait 15 minutes before alerting admins again
+			message_admins("<span class='adminhelp'>ANTI-GRIEF:</span> New player [ADMIN_LOOKUPFLW(user)] touched \a [src] at [ADMIN_VERBOSEJMP(T)].")
+			client.touched_transfer_valve = TRUE
+
 	if(.)
 		return
 	if(attached_device)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -343,6 +343,14 @@
 		ui = new(user, src, "Canister", name)
 		ui.open()
 
+		var/turf/T = get_turf(src)
+		var/client/client = user.client
+		if (CONFIG_GET(flag/use_exp_tracking) && client && client.get_exp_living(TRUE) < 480) // Player with less than 8 hours playtime is interacting with this canister.
+			if(client.next_canister_grief_warning < world.time)
+				client.next_canister_grief_warning = world.time + 9000 // Wait 15 minutes before alerting admins again
+				message_admins("<span class='adminhelp'>ANTI-GRIEF:</span> New player [ADMIN_LOOKUPFLW(user)] has touched \a [src] at [ADMIN_VERBOSEJMP(T)].")
+				client.touched_canister = TRUE
+
 /obj/machinery/portable_atmospherics/canister/ui_static_data(mob/user)
 	return list(
 		"defaultReleasePressure" = round(CAN_DEFAULT_RELEASE_PRESSURE),

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -190,6 +190,14 @@
 			ui.set_autoupdate(FALSE) //to not ruin the immersion by constantly changing the fake chemicals
 		ui.open()
 
+		var/turf/T = get_turf(src)
+		var/client/client = user.client
+		if (CONFIG_GET(flag/use_exp_tracking) && client && client.get_exp_living(TRUE) < 480) // Player with less than 8 hours playtime is using this machine.
+			if(client.next_chem_grief_warning < world.time)
+				client.next_chem_grief_warning = world.time + 9000 // Wait 15 minutes before alerting admins again
+				message_admins("<span class='adminhelp'>ANTI-GRIEF:</span> New player [ADMIN_LOOKUPFLW(user)] is using \a [src] at [ADMIN_VERBOSEJMP(T)].")
+				client.used_chem_dispenser = TRUE
+
 /obj/machinery/chem_dispenser/ui_data(mob/user)
 	var/data = list()
 	data["amount"] = amount

--- a/modular_splurt/code/modules/admin/playtimes.dm
+++ b/modular_splurt/code/modules/admin/playtimes.dm
@@ -1,5 +1,11 @@
 /client
 	var/datum/player_playtime/playtime_menu
+	var/next_valve_grief_warning = 0
+	var/next_chem_grief_warning = 0
+	var/next_canister_grief_warning = 0
+	var/touched_transfer_valve = FALSE
+	var/used_chem_dispenser = FALSE
+	var/touched_canister = FALSE
 
 /client/proc/cmd_player_playtimes()
 	set category = "Admin"
@@ -35,6 +41,9 @@
 		client["ckey"] = C.ckey
 		client["playtime"] = C.get_exp_living(TRUE)
 		client["playtime_hours"] = C.get_exp_living()
+		client["warning_valve"] = C.touched_transfer_valve
+		client["warning_chem"] = C.used_chem_dispenser
+		client["warning_canister"] = C.touched_canister
 
 		var/name = C.ckey
 		var/mob/M = C.mob
@@ -43,6 +52,7 @@
 				client["observer"] = TRUE
 
 			if(M.real_name)
+				client["ingame"] = TRUE
 				name += (" (" + M.real_name + ")")
 		client["name"] = name
 

--- a/tgui/packages/tgui/interfaces/PlayerPlaytimes.js
+++ b/tgui/packages/tgui/interfaces/PlayerPlaytimes.js
@@ -24,9 +24,31 @@ export const PlayerPlaytimes = (props, context) => {
                 <Button
                   icon={client.observer ? "ghost" : ""}
                   content={client.name}
+                  disabled={!client.ingame}
                   onClick={() => act('observe', {
                     ckey: client.ckey,
                   })} />
+                {!!client.warning_valve && (
+                  <Button
+                    icon="bomb"
+                    color="average"
+                    tooltip="This player touched a Transfer Valve."
+                  />
+                )}
+                {!!client.warning_chem && (
+                  <Button
+                    icon="flask"
+                    color="average"
+                    tooltip="This player used a Chem Dispenser."
+                  />
+                )}
+                {!!client.warning_canister && (
+                  <Button
+                    icon="spray-can"
+                    color="average"
+                    tooltip="This player touched a gas canister."
+                  />
+                )}
               </LabeledList.Item>
             ))}
           </LabeledList>


### PR DESCRIPTION
## About The Pull Request

Adds admin warning if a player with less than 8 hours playtime:

- Uses a Chemical Dispenser
- Touches a Transfer Valve
- Touches a Canister menu

(To avoid spam, these warnings will only display once every 15 minutes, per grief type, per player.)
![image](https://user-images.githubusercontent.com/59719612/148323907-e3347949-133a-4a3b-9873-901eecde1e0b.png)

These warnings also persist throughout the round on the playtime panel in the form of icons with tooltips. They will be hidden initially, and appear if the client triggers them:
![image](https://user-images.githubusercontent.com/59719612/148323811-ff21cf30-8cda-4d15-8c1f-3b24bdb88b0a.png)

## Why It's Good For The Game

Hidden chem machine bad.

## Changelog
:cl:
add: Admin grief warnings
/:cl: