### PR TITLE
[SEMI-MODULAR] Ports old skyrat handling of borg radio

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -37,6 +37,7 @@
 	var/independent = FALSE  // If true, can say/hear on the special CentCom channel.
 	var/syndie = FALSE  // If true, hears all well-known channels automatically, and can say/hear on the Syndicate channel.
 	var/list/channels = list()  // Map from name (see communications.dm) to on/off. First entry is current department (:h).
+	var/list/extra_channels = list() //Skyrat change //Allows indivudal channels, used for borgs
 	var/list/secure_radio_connections
 
 	var/const/FREQ_LISTENING = 1
@@ -68,6 +69,12 @@
 			syndie = TRUE
 		if(keyslot.independent)
 			independent = TRUE
+	//Skyrat edit start
+	if(extra_channels)
+		for(var/ch_name in extra_channels)
+			if(!(ch_name in channels))
+				channels[ch_name] = extra_channels[ch_name]
+	//Skyrat edit end
 
 	for(var/ch_name in channels)
 		secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -37,7 +37,6 @@
 	var/independent = FALSE  // If true, can say/hear on the special CentCom channel.
 	var/syndie = FALSE  // If true, hears all well-known channels automatically, and can say/hear on the Syndicate channel.
 	var/list/channels = list()  // Map from name (see communications.dm) to on/off. First entry is current department (:h).
-	var/list/extra_channels = list() //Skyrat change //Allows indivudal channels, used for borgs
 	var/list/secure_radio_connections
 
 	var/const/FREQ_LISTENING = 1

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -16,6 +16,7 @@
 	var/list/modules = list() //holds all the usable modules
 	var/list/added_modules = list() //modules not inherient to the robot module, are kept when the module changes
 	var/list/storages = list()
+	var/list/added_channels = list() //Skyrat change //Borg radio stuffs
 
 	var/cyborg_base_icon = "robot" //produces the icon for the borg and, if no special_light_key is set, the lights
 	var/special_light_key //if we want specific lights, use this instead of copying lights in the dmi
@@ -263,6 +264,10 @@
 		R.typing_indicator_state = /obj/effect/overlay/typing_indicator/machine/dogborg
 	else
 		R.typing_indicator_state = /obj/effect/overlay/typing_indicator/machine
+	//Skyrat change start
+	R.radio.extra_channels = RM.added_channels
+	R.radio.recalculateChannels()
+	//Skyrat change stop
 	R.maxHealth = borghealth
 	R.health = min(borghealth, R.health)
 	qdel(src)
@@ -380,6 +385,7 @@
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	cyborg_base_icon = "medical"
 	moduleselect_icon = "medical"
+	added_channels = list(RADIO_CHANNEL_MEDICAL = 1) //Skyrat change
 	hat_offset = 3
 
 /obj/item/robot_module/medical/be_transformed_to(obj/item/robot_module/old_module)
@@ -570,6 +576,7 @@
 	cyborg_base_icon = "engineer"
 	moduleselect_icon = "engineer"
 	magpulsing = TRUE
+	added_channels = list(RADIO_CHANNEL_ENGINEERING = 1) //Skyrat change
 	hat_offset = -4
 
 /obj/item/robot_module/engineering/be_transformed_to(obj/item/robot_module/old_module)
@@ -743,6 +750,7 @@
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	cyborg_base_icon = "sec"
 	moduleselect_icon = "security"
+	added_channels = list(RADIO_CHANNEL_SECURITY = 1) //Skyrat change
 	hat_offset = 3
 
 /obj/item/robot_module/security/do_transform_animation()
@@ -922,6 +930,7 @@
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	cyborg_base_icon = "peace"
 	moduleselect_icon = "standard"
+	added_channels = list(RADIO_CHANNEL_SECURITY = 1) //Skyrat change
 	hat_offset = -2
 
 /obj/item/robot_module/peacekeeper/do_transform_animation()
@@ -1071,6 +1080,7 @@
 		/obj/item/clockwork/replica_fabricator/cyborg)
 	moduleselect_icon = "service"
 	cyborg_base_icon = "clown"
+	added_channels = list(RADIO_CHANNEL_SERVICE = 1) //Skyrat change
 	hat_offset = -2
 
 /obj/item/robot_module/butler
@@ -1104,6 +1114,7 @@
 	ratvar_modules = list(/obj/item/clockwork/slab/cyborg/service,
 		/obj/item/borg/sight/xray/truesight_lens)
 	moduleselect_icon = "service"
+	added_channels = list(RADIO_CHANNEL_SERVICE = 1) //Skyrat change
 	hat_offset = 0
 	clean_on_move = TRUE
 
@@ -1375,6 +1386,7 @@
 		/obj/item/borg/sight/xray/truesight_lens)
 	cyborg_base_icon = "miner"
 	moduleselect_icon = "miner"
+	added_channels = list(RADIO_CHANNEL_SUPPLY = 1) //Skyrat change
 	hat_offset = 0
 
 /obj/item/robot_module/miner/be_transformed_to(obj/item/robot_module/old_module)
@@ -1523,6 +1535,7 @@
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	cyborg_base_icon = "synd_sec"
 	moduleselect_icon = "malf"
+	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1) //Skyrat change
 	hat_offset = 3
 
 /obj/item/robot_module/syndicate/rebuild_modules()
@@ -1604,6 +1617,7 @@
 	moduleselect_icon = "malf"
 	magpulsing = TRUE
 	hat_offset = -4
+	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1) //Skyrat change
 	canDispose = TRUE
 
 /datum/robot_energy_storage

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -16,7 +16,6 @@
 	var/list/modules = list() //holds all the usable modules
 	var/list/added_modules = list() //modules not inherient to the robot module, are kept when the module changes
 	var/list/storages = list()
-	var/list/added_channels = list() //Skyrat change //Borg radio stuffs
 
 	var/cyborg_base_icon = "robot" //produces the icon for the borg and, if no special_light_key is set, the lights
 	var/special_light_key //if we want specific lights, use this instead of copying lights in the dmi
@@ -385,7 +384,6 @@
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	cyborg_base_icon = "medical"
 	moduleselect_icon = "medical"
-	added_channels = list(RADIO_CHANNEL_MEDICAL = 1) //Skyrat change
 	hat_offset = 3
 
 /obj/item/robot_module/medical/be_transformed_to(obj/item/robot_module/old_module)
@@ -576,7 +574,6 @@
 	cyborg_base_icon = "engineer"
 	moduleselect_icon = "engineer"
 	magpulsing = TRUE
-	added_channels = list(RADIO_CHANNEL_ENGINEERING = 1) //Skyrat change
 	hat_offset = -4
 
 /obj/item/robot_module/engineering/be_transformed_to(obj/item/robot_module/old_module)
@@ -750,7 +747,6 @@
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	cyborg_base_icon = "sec"
 	moduleselect_icon = "security"
-	added_channels = list(RADIO_CHANNEL_SECURITY = 1) //Skyrat change
 	hat_offset = 3
 
 /obj/item/robot_module/security/do_transform_animation()
@@ -930,7 +926,6 @@
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	cyborg_base_icon = "peace"
 	moduleselect_icon = "standard"
-	added_channels = list(RADIO_CHANNEL_SECURITY = 1) //Skyrat change
 	hat_offset = -2
 
 /obj/item/robot_module/peacekeeper/do_transform_animation()
@@ -1080,7 +1075,6 @@
 		/obj/item/clockwork/replica_fabricator/cyborg)
 	moduleselect_icon = "service"
 	cyborg_base_icon = "clown"
-	added_channels = list(RADIO_CHANNEL_SERVICE = 1) //Skyrat change
 	hat_offset = -2
 
 /obj/item/robot_module/butler
@@ -1114,7 +1108,6 @@
 	ratvar_modules = list(/obj/item/clockwork/slab/cyborg/service,
 		/obj/item/borg/sight/xray/truesight_lens)
 	moduleselect_icon = "service"
-	added_channels = list(RADIO_CHANNEL_SERVICE = 1) //Skyrat change
 	hat_offset = 0
 	clean_on_move = TRUE
 
@@ -1386,7 +1379,6 @@
 		/obj/item/borg/sight/xray/truesight_lens)
 	cyborg_base_icon = "miner"
 	moduleselect_icon = "miner"
-	added_channels = list(RADIO_CHANNEL_SUPPLY = 1) //Skyrat change
 	hat_offset = 0
 
 /obj/item/robot_module/miner/be_transformed_to(obj/item/robot_module/old_module)
@@ -1535,7 +1527,6 @@
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	cyborg_base_icon = "synd_sec"
 	moduleselect_icon = "malf"
-	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1) //Skyrat change
 	hat_offset = 3
 
 /obj/item/robot_module/syndicate/rebuild_modules()
@@ -1617,7 +1608,6 @@
 	moduleselect_icon = "malf"
 	magpulsing = TRUE
 	hat_offset = -4
-	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1) //Skyrat change
 	canDispose = TRUE
 
 /datum/robot_energy_storage

--- a/modular_sand/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_sand/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -183,7 +183,6 @@
 	cyborg_base_icon = "synd_engi"
 	moduleselect_icon = "malf"
 	magpulsing = TRUE
-	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1) //Skyrat change // Probably already handled by other code when spawned with pre-set module, but w/e
 	hat_offset = INFINITY
 	canDispose = TRUE
 

--- a/modular_sand/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_sand/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -183,6 +183,7 @@
 	cyborg_base_icon = "synd_engi"
 	moduleselect_icon = "malf"
 	magpulsing = TRUE
+	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1) //Skyrat change // Probably already handled by other code when spawned with pre-set module, but w/e
 	hat_offset = INFINITY
 	canDispose = TRUE
 

--- a/modular_splurt/code/game/object/items/devices/radio/radio.dm
+++ b/modular_splurt/code/game/object/items/devices/radio/radio.dm
@@ -1,0 +1,2 @@
+/obj/item/radio
+	var/list/extra_channels = list() //Allows indivudal channels, used for borgs

--- a/modular_splurt/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,3 +1,39 @@
+/obj/item/robot_module
+	var/list/added_channels = list() //Borg radio stuffs
+
+/obj/item/robot_module/medical
+	added_channels = list(RADIO_CHANNEL_MEDICAL = 1)
+
+/obj/item/robot_module/engineering
+	added_channels = list(RADIO_CHANNEL_ENGINEERING = 1)
+
+/obj/item/robot_module/security
+	added_channels = list(RADIO_CHANNEL_SECURITY = 1)
+
+/obj/item/robot_module/peacekeeper
+	added_channels = list(RADIO_CHANNEL_SECURITY = 1)
+
+/obj/item/robot_module/clown
+	added_channels = list(RADIO_CHANNEL_SERVICE = 1)
+
+/obj/item/robot_module/butler
+	added_channels = list(RADIO_CHANNEL_SERVICE = 1)
+
+/obj/item/robot_module/miner
+	added_channels = list(RADIO_CHANNEL_SUPPLY = 1)
+
+/obj/item/robot_module/syndicate
+	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1)
+
+/obj/item/robot_module/syndicatejack
+	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1) // Probably already handled by other code when spawned with pre-set module, but whatever.
+
+/obj/item/robot_module/syndicate_medical
+	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1)
+
+/obj/item/robot_module/saboteur
+	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1)
+
 /obj/item/robot_module/standard/be_transformed_to(obj/item/robot_module/old_module)
 	var/mob/living/silicon/robot/R = loc
 	var/static/list/stand_icons

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4205,6 +4205,7 @@
 #include "modular_splurt\code\game\object\items\circuitboards\computer_circuitboards.dm"
 #include "modular_splurt\code\game\object\items\circuitboards\machine_circuitboards.dm"
 #include "modular_splurt\code\game\object\items\devices\radio\electropack.dm"
+#include "modular_splurt\code\game\object\items\devices\radio\radio.dm"
 #include "modular_splurt\code\game\object\items\implants\implant_slaver.dm"
 #include "modular_splurt\code\game\object\items\robot\robot_upgrades.dm"
 #include "modular_splurt\code\game\object\items\stacks\sheets\sheet_types.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This makes borgs to get access to their department radio when transforming into related module, without getting required radio keys from roboticists.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Saves some headache for the borgs and robotics alike...? Citadel is weird tbh.
> If you can't justify it in words, it might not be worth adding.

¯\\_(ツ)_/¯
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Old Skyrat code.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl: Anonymous (feat. radar651)
tweak: Borgs will now get access to department radio upon transforming into respected module (e.g. security and peacekeeper modules - security channel).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
