### PR TITLE
Suggestion #28

### DIFF
--- a/modular_splurt/code/game/object/items/miscellaneous.dm
+++ b/modular_splurt/code/game/object/items/miscellaneous.dm
@@ -70,3 +70,7 @@
 		return 1
 	else
 		user << "The hailer is fried. You can't even fit the sequencer into the input slot."
+
+
+/obj/item/disk/data
+	max_mutations = 15


### PR DESCRIPTION
Update the Max Mutations per disk from 6 to 15

<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This was Suggestion number 28 on discord that was approved and I am finally getting around to doing it. It changes the Max Mutations from 6 to 15, nearly 3 times disk storage space. Why? Didn't the suggest say remove it? yes it did but it was hard coded in so I just upped the number to decrease disk swapping.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was approved already, but it will make genetics live a bit easier.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl: radar651
tweak: Upped Max Mutations from 6 to 15.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
