### PR TITLE
Slave antag patch 2

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6853,6 +6853,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"pA" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/slavers)
 "pB" = (
 /obj/machinery/light{
 	dir = 1
@@ -6879,6 +6885,12 @@
 	name = "door"
 	},
 /turf/open/floor/plasteel,
+/area/slavers)
+"pF" = (
+/obj/structure/sign/poster/contraband/yes_erp{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/freezer,
 /area/slavers)
 "pG" = (
 /obj/machinery/biogenerator,
@@ -7435,6 +7447,12 @@
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"qL" = (
+/obj/structure/sign/poster/official/obey{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/slavers)
 "qP" = (
 /obj/structure/bed/matress,
 /turf/open/floor/plating,
@@ -8088,6 +8106,7 @@
 /area/syndicate_mothership)
 "sj" = (
 /obj/machinery/vending/assist,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel,
 /area/slavers)
 "sk" = (
@@ -12388,6 +12407,9 @@
 "BT" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/obj/structure/sign/poster/contraband/lizard{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/slavers)
@@ -18036,6 +18058,15 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/holding)
+"OP" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/slavers)
 "OQ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/rag/towel/syndicate,
@@ -18767,11 +18798,9 @@
 	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
-"RT" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
+"RV" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel,
 /area/slavers)
 "RW" = (
 /obj/effect/turf_decal/stripes/white/line,
@@ -19037,6 +19066,12 @@
 	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
+"SX" = (
+/obj/structure/sign/poster/contraband/bountyhunters{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/slavers)
 "SY" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
@@ -19050,10 +19085,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/slavers)
-"Tb" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
 /area/slavers)
 "Td" = (
 /obj/structure/fireplace,
@@ -19227,6 +19258,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/slavers)
 "TM" = (
@@ -19281,6 +19313,12 @@
 /obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"TW" = (
+/obj/structure/sign/poster/contraband/syndicate_recruitment{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/slavers)
 "TY" = (
 /obj/structure/bedsheetbin/color,
 /turf/open/indestructible/hotelwood,
@@ -19831,6 +19869,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"Wd" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plating,
+/area/slavers)
 "We" = (
 /obj/machinery/vending/coffee,
 /turf/open/indestructible/hotelwood,
@@ -19876,10 +19923,7 @@
 /area/syndicate_mothership)
 "Wk" = (
 /obj/structure/table,
-/obj/item/paper{
-	info = "Kidnap crew, attach a slave collar around their neck, set a price with the computer, wait for the station to pay the ransom, put slave in the green area and 'export' them with the computer";
-	name = "dummies guide to the slave trade"
-	},
+/obj/machinery/recharger,
 /turf/open/floor/plasteel/dark,
 /area/slavers)
 "Wn" = (
@@ -20206,6 +20250,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/syndicate_mothership)
+"XF" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/semen,
+/turf/open/floor/plasteel/freezer,
+/area/slavers)
 "XI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -20591,6 +20645,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/slavers)
 "Zv" = (
@@ -79324,7 +79379,7 @@ aa
 sm
 QZ
 Zm
-Zm
+RV
 Rj
 sm
 FY
@@ -79579,7 +79634,7 @@ aa
 aa
 aa
 sm
-Zm
+SX
 Zm
 Zm
 Zm
@@ -80620,7 +80675,7 @@ PC
 Qf
 RW
 sm
-RB
+TW
 RB
 RB
 RB
@@ -81650,7 +81705,7 @@ AC
 sm
 sm
 CV
-CV
+pA
 CV
 sm
 ZD
@@ -81906,9 +81961,9 @@ Zm
 Zm
 UR
 sm
-RT
 PB
-Tb
+CV
+PB
 sm
 vs
 ZD
@@ -82932,7 +82987,7 @@ Zm
 Zm
 Zm
 Zm
-Zm
+qL
 ZE
 Zm
 Zm
@@ -83435,7 +83490,7 @@ aa
 aa
 aa
 sm
-AF
+XF
 sm
 AF
 sm
@@ -83696,7 +83751,7 @@ Rd
 sm
 Rd
 sm
-Yj
+pF
 Yj
 Yj
 sm
@@ -83957,13 +84012,13 @@ Yj
 Yj
 Lk
 sm
-TK
+OP
 qP
 sm
 TK
 qP
 sm
-TK
+Wd
 qP
 sm
 Co

--- a/_maps/shuttles/slaveship_basic.dmm
+++ b/_maps/shuttles/slaveship_basic.dmm
@@ -110,6 +110,9 @@
 /area/shuttle/slaveship)
 "le" = (
 /obj/structure/bed/roller,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 28
+	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "ph" = (

--- a/_maps/shuttles/slaveship_basic.dmm
+++ b/_maps/shuttles/slaveship_basic.dmm
@@ -1,22 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "af" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/slaver,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "ak" = (
 /obj/machinery/computer/shuttle/slaver,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "ax" = (
@@ -24,12 +12,6 @@
 /area/shuttle/slaveship)
 "ay" = (
 /obj/machinery/computer/camera_advanced/syndie,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "aA" = (
@@ -41,69 +23,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
-"bK" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
-"bN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
 "bP" = (
 /obj/machinery/computer/med_data/syndie,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "bV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/turretid{
 	pixel_x = -32;
 	req_access = null
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
-"cc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
-"ct" = (
-/turf/open/floor/plating,
-/area/shuttle/slaveship)
 "cy" = (
 /obj/structure/shuttle/engine/propulsion/left,
 /turf/open/floor/plating,
 /area/shuttle/slaveship)
 "cO" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/button/door{
 	id = "slaveshipshutters";
 	name = "Cockpit Shutter Control";
@@ -111,21 +46,7 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
-"ev" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/slaveship)
 "fI" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/item/radio,
 /obj/item/radio,
@@ -144,30 +65,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
-"hR" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
 "iP" = (
 /obj/item/storage/firstaid/regular{
 	pixel_x = 3;
 	pixel_y = 3
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/toxin{
 	pixel_x = -3;
@@ -203,33 +106,10 @@
 /obj/item/stack/medical/mesh,
 /obj/item/stack/medical/gauze,
 /obj/item/stack/medical/suture,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "le" = (
 /obj/structure/bed/roller,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
-"mA" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "ph" = (
@@ -239,13 +119,6 @@
 	},
 /obj/item/storage/firstaid/fire,
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/item/storage/firstaid/brute{
 	pixel_x = -3;
 	pixel_y = -3
@@ -277,13 +150,6 @@
 /obj/machinery/sleeper{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "qT" = (
@@ -299,12 +165,6 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "sn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -323,39 +183,18 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/shuttle/slaveship)
 "um" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
-"uy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plating,
 /area/shuttle/slaveship)
 "uZ" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle,
-/obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "vV" = (
 /obj/machinery/computer/crew/syndie,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "wl" = (
@@ -364,34 +203,14 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "xr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/slaveship)
-"xX" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+"yH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/item/gun/energy/ionrifle,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
-"yJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/suit_storage_unit/mining/eva,
-/turf/open/floor/mineral/plastitanium,
 /area/shuttle/slaveship)
 "zI" = (
 /obj/machinery/door/poddoor{
@@ -424,12 +243,6 @@
 /area/shuttle/slaveship)
 "Aw" = (
 /obj/machinery/door/window/westright,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "Bt" = (
@@ -445,145 +258,41 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/shuttle/slaveship)
 "Cd" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/slaveship)
-"Cj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/slaveship)
-"CM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
-"Dj" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/slaveship)
 "DB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /turf/open/floor/plating,
-/area/shuttle/slaveship)
+/area/shuttle/slaveship/brig)
 "Ey" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/shuttle/slaveship)
-"Fm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/suit_storage_unit/mining/eva,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/slaveship)
 "FG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/rack,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
-"Gj" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
 "Go" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
-"GC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/slaveship)
 "GG" = (
 /obj/machinery/light,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
-"Iw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/bed/matress,
-/turf/open/floor/plating,
 /area/shuttle/slaveship)
 "JG" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shuttle/slaveship)
+/area/shuttle/slaveship/brig)
 "Lr" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
-"LG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plating,
 /area/shuttle/slaveship)
 "MJ" = (
 /turf/template_noop,
@@ -599,22 +308,6 @@
 /area/shuttle/slaveship)
 "Qd" = (
 /obj/machinery/computer/mech_bay_power_console,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/slaveship)
-"Qz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "Rv" = (
@@ -623,48 +316,21 @@
 	},
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "RD" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "RL" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "Sv" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
@@ -672,47 +338,20 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
-"TF" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/slaveship)
 "Uo" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder/red,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "Uv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/light,
 /turf/open/floor/plating,
-/area/shuttle/slaveship)
+/area/shuttle/slaveship/brig)
 "UL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/bed/matress,
 /turf/open/floor/plating,
-/area/shuttle/slaveship)
+/area/shuttle/slaveship/brig)
 "Vy" = (
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "152"
@@ -729,13 +368,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/item/multitool,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
@@ -743,10 +375,6 @@
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/item/extinguisher/mini{
 	pixel_x = 4
 	},
@@ -756,10 +384,6 @@
 "Wi" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/combat,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/light,
 /obj/item/flashlight/seclite,
 /obj/item/flashlight/seclite{
@@ -775,7 +399,6 @@
 /area/shuttle/slaveship)
 "WK" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
 "Xl" = (
@@ -784,15 +407,8 @@
 "XG" = (
 /obj/structure/bed/matress,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plating,
-/area/shuttle/slaveship)
+/area/shuttle/slaveship/brig)
 "XN" = (
 /obj/structure/shuttle/engine/heater,
 /obj/effect/spawner/structure/window/plastitanium/pirate,
@@ -803,13 +419,6 @@
 /area/shuttle/slaveship)
 "Yh" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/item/pickaxe,
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
@@ -824,12 +433,6 @@
 "ZZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/slaveship)
@@ -874,7 +477,7 @@ ax
 ax
 ax
 ax
-Iw
+UL
 DB
 DB
 XG
@@ -892,15 +495,15 @@ MJ
 MJ
 MJ
 ax
-yJ
-Fm
+Cd
+Cd
 xr
-Fm
+Cd
 Cd
 ax
 JG
-ct
-ct
+DB
+DB
 Uv
 XN
 zT
@@ -920,11 +523,11 @@ sn
 aA
 aA
 aA
-CM
+pl
 ax
-LG
-ct
-uy
+DB
+DB
+DB
 UL
 XN
 cy
@@ -934,7 +537,7 @@ MJ
 ax
 bP
 bV
-bK
+aA
 ax
 ax
 ax
@@ -942,7 +545,7 @@ ax
 ax
 um
 aA
-xX
+aA
 aA
 FG
 ax
@@ -958,7 +561,7 @@ MJ
 pj
 vV
 sv
-bN
+pl
 ax
 iP
 kG
@@ -982,9 +585,9 @@ cy
 pj
 af
 aA
-cc
+aA
 ax
-hR
+aA
 aA
 aA
 aA
@@ -1019,8 +622,8 @@ Xl
 aA
 Wk
 aA
-ev
-TF
+Xl
+Xl
 aA
 pl
 XN
@@ -1032,7 +635,7 @@ ay
 aA
 cO
 ax
-hR
+aA
 aA
 aA
 aA
@@ -1046,17 +649,17 @@ aA
 Xl
 Xl
 aA
-wl
+yH
 XN
 cy
 "}
 (10,1,1) = {"
 pj
-Qz
+Go
 bj
 Lr
 ax
-mA
+qc
 le
 qc
 ax
@@ -1088,7 +691,7 @@ WK
 aA
 aA
 aA
-Gj
+sv
 ax
 Rv
 Aw
@@ -1133,10 +736,10 @@ MJ
 MJ
 ax
 WK
-Cj
-Dj
-GC
-Gj
+Xl
+Xl
+Xl
+sv
 ax
 gc
 Sw

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1101,7 +1101,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/adding_hud = !has_antag_hud()
 
-	for(var/hudtype in list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED)) // add data huds
+	for(var/hudtype in list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED, DATA_HUD_ANTAGTARGET)) // add data huds
 		var/datum/atom_hud/H = GLOB.huds[hudtype]
 		(adding_hud) ? H.add_hud_to(usr) : H.remove_hud_from(usr)
 	for(var/datum/atom_hud/antag/H in GLOB.huds) // add antag huds

--- a/modular_splurt/code/game/areas/shuttles.dm
+++ b/modular_splurt/code/game/areas/shuttles.dm
@@ -3,3 +3,8 @@
 /area/shuttle/slaveship
 	name = "Slave Trader Shuttle"
 	canSmoothWithAreas = /area/shuttle/slaveship
+
+/area/shuttle/slaveship/brig
+	name = "Slave Trader Shuttle Brig"
+	canSmoothWithAreas = null
+	icon_state = "brig"

--- a/modular_splurt/code/game/data_huds.dm
+++ b/modular_splurt/code/game/data_huds.dm
@@ -20,7 +20,7 @@
 		return
 
 	var/datum/antagonist/slaver/S = locate() in H.mind.antag_datums
-	if(S) // Is a slave antag. Slavers do not need to see eachother's consent prefs.
+	if(S) // Is a slaver antag. Slavers do not need to see eachother's consent prefs.
 		holder.icon_state = null
 		return
 

--- a/modular_splurt/code/game/machinery/research_table.dm
+++ b/modular_splurt/code/game/machinery/research_table.dm
@@ -162,6 +162,7 @@
 /obj/machinery/research_table/slaver
 	slaver_mode = TRUE
 	point_type = POINT_TYPE_CARGO
+	configured = TRUE
 
 #undef POINT_TYPE_CARGO
 #undef POINT_TYPE_SCIENCE

--- a/modular_splurt/code/game/object/structures/crates_lockers/closets/slaver.dm
+++ b/modular_splurt/code/game/object/structures/crates_lockers/closets/slaver.dm
@@ -18,6 +18,7 @@
 	new /obj/item/melee/classic_baton/telescopic(src)
 	new /obj/item/reagent_containers/hypospray/medipen/survival(src)
 	new /obj/item/pen/sleepy(src)
+	new /obj/item/slaver/gizmo(src)
 
 //Copy of above in crate version
 /obj/structure/closet/crate/slaver_loadout
@@ -38,3 +39,4 @@
 	new /obj/item/melee/classic_baton/telescopic(src)
 	new /obj/item/reagent_containers/hypospray/medipen/survival(src)
 	new /obj/item/pen/sleepy(src)
+	new /obj/item/slaver/gizmo(src)

--- a/modular_splurt/code/modules/antagonists/slaver/equipment/orderable_gear.dm
+++ b/modular_splurt/code/modules/antagonists/slaver/equipment/orderable_gear.dm
@@ -67,7 +67,7 @@ GLOBAL_LIST_INIT(slaver_gear, subtypesof(/datum/slaver_gear))
 	name = "Policing Kit"
 	description = "Strobe shield x 1. Strobe replacement bulbs x 2. Stunbaton x 1. Box of handcuffs x 1. Electrostaff x 1."
 	id = "policing"
-	build_path = /obj/structure/closet/crate/policing_shipment
+	build_path = /obj/item/storage/backpack/duffelbag/syndie/policing_shipment
 	category = "Slaving"
 	cost = 2000
 
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(slaver_gear, subtypesof(/datum/slaver_gear))
 	name = "Combat Hardsuits"
 	description = "Military suit supplied by our Syndicate sponsors x 2."
 	id = "hardsuits"
-	build_path = /obj/structure/closet/crate/slaver_hardsuits
+	build_path = /obj/item/storage/backpack/duffelbag/syndie/slaver_hardsuits
 	category = "Advanced"
 	cost = 4500
 
@@ -115,7 +115,7 @@ GLOBAL_LIST_INIT(slaver_gear, subtypesof(/datum/slaver_gear))
 	name = "Riot Kit"
 	description = "Toy L6 SAW with riot darts."
 	id = "riot"
-	build_path = /obj/structure/closet/crate/l6saw_shipment
+	build_path = /obj/item/storage/backpack/duffelbag/syndie/l6saw_shipment
 	category = "Advanced"
 	cost = 2000
 
@@ -137,26 +137,138 @@ GLOBAL_LIST_INIT(slaver_gear, subtypesof(/datum/slaver_gear))
 	category = "Advanced"
 	cost = 2500
 
+/datum/slaver_gear/smg
+	name = "SMG Kit"
+	description = "WT-550 Semi-Automatic SMG. Spare magazine x 3."
+	id = "smg"
+	build_path = /obj/item/storage/backpack/duffelbag/syndie/smg
+	category = "Firearms"
+	cost = 5000
+
+/datum/slaver_gear/smg_rubber
+	name = "SMG Kit (rubber)"
+	description = "WT-550 Semi-Automatic SMG with rubber munitions. Spare magazine x 3."
+	id = "smg_rubber"
+	build_path = /obj/item/storage/backpack/duffelbag/syndie/smg_rubber
+	category = "Firearms"
+	cost = 3000
+
+/datum/slaver_gear/ion
+	name = "Ion carbines"
+	description = "Ion carbine x 2."
+	id = "ion"
+	build_path = /obj/item/storage/backpack/duffelbag/syndie/ion
+	category = "Firearms"
+	cost = 3000
+
 /datum/slaver_gear/marksman
 	name = "Marksman Kit"
 	description = ".50 cal sniper rifle with sleep-inducing rounds."
 	id = "marksman"
-	build_path = /obj/structure/closet/crate/slaver_marksman
-	category = "Advanced"
+	build_path = /obj/item/storage/backpack/duffelbag/syndie/slaver_marksman
+	category = "Firearms"
 	cost = 10000
 
 /datum/slaver_gear/mech
 	name = "Gygax 'Riot-Control' Exosuit"
-	description = "A lightweight, agile mecha. This one comes with a taser cannon, clusterbang launcher and breaching missiles. Must be self-assembled."
+	description = "A lightweight, agile mecha. Weapons sold separately."
 	id = "mech"
-	build_path = /obj/structure/closet/crate/slaver_mech
+	build_path = /obj/mecha/combat/gygax
 	category = "Mech"
-	cost = 40000
+	cost = 30000
 
-/datum/slaver_gear/mech_ammo
-	name = "Gygax Exosuit Ammo"
-	description = "A shipment of ammo for the Gygax 'Riot-Control' Exosuit. Clusterbang x 3, breaching missile x 6."
-	id = "mech_ammo"
-	build_path = /obj/structure/closet/crate/slaver_mech_ammo
+/datum/slaver_gear/mech_taser
+	name = "PBT \"Pacifier\" Mounted Taser"
+	description = "Shoots non-lethal stunning electrodes."
+	id = "mech_taser"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser
 	category = "Mech"
-	cost = 10000
+	cost = 3000
+
+/datum/slaver_gear/mech_ion
+	name = "MKIV Ion Heavy Cannon"
+	description = "Shoots technology-disabling ion beams. Don't catch yourself in the blast!"
+	id = "mech_ion"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion
+	category = "Mech"
+	cost = 3000
+
+/datum/slaver_gear/mech_shotgun
+	name = "LBX AC 10 \"Scattershot\""
+	description = "Shoots a spread of pellets."
+	id = "mech_shotgun"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
+	category = "Mech"
+	cost = 3000
+
+/datum/slaver_gear/mech_shotgun_ammo
+	name = "LBX AC 10 \"Scattershot\" Ammo"
+	description = "Buckshot for the LBX AC 10 \"Scattershot\" x 40."
+	id = "mech_shotgun_ammo"
+	build_path = /obj/item/mecha_ammo/scattershot
+	category = "Mech"
+	cost = 1000
+
+/datum/slaver_gear/mech_lmg
+	name = "Ultra AC 2"
+	description = "Shoots a rapid, three shot burst."
+	id = "mech_lmg"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
+	category = "Mech"
+	cost = 3000
+
+/datum/slaver_gear/mech_lmg_ammo
+	name = "Ultra AC 2 Ammo"
+	description = "Rounds for the Ultra AC 2 x 300."
+	id = "mech_lmg_ammo"
+	build_path = /obj/item/mecha_ammo/lmg
+	category = "Mech"
+	cost = 1000
+
+/datum/slaver_gear/mech_laser
+	name = "CH-LC \"Solaris\" Laser Cannon"
+	description = "Shoots heavy lasers."
+	id = "mech_laser"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
+	category = "Mech"
+	cost = 3000
+
+/datum/slaver_gear/mech_missiles
+	name = "BRM-6 Missile Rack"
+	description = "Launches low-explosive breaching missiles designed to explode only when striking a sturdy target."
+	id = "mech_missiles"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/breaching
+	category = "Mech"
+	cost = 1500
+
+/datum/slaver_gear/mech_missiles_ammo
+	name = "BRM-6 Missile Rack Ammo"
+	description = "Missiles for the BRM-6 missile rack x 6."
+	id = "mech_missiles_ammo"
+	build_path = /obj/item/mecha_ammo/missiles_br
+	category = "Mech"
+	cost = 500
+
+/datum/slaver_gear/mech_cluster
+	name = "SOB-3 Grenade Launcher"
+	description = "Launches primed clusterbangs. You monster."
+	id = "mech_cluster"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/clusterbang
+	category = "Mech"
+	cost = 3000
+
+/datum/slaver_gear/mech_cluster_ammo
+	name = "SOB-3 Grenade Launcher Ammo"
+	description = "Grenades for the SOB-3 grenade launcher x 3"
+	id = "mech_cluster_ammo"
+	build_path = /obj/item/mecha_ammo/clusterbang
+	category = "Mech"
+	cost = 1000
+
+/datum/slaver_gear/mech_repair
+	name = "Exosuit Repair Droid"
+	description = "An automated repair droid for exosuits. Scans for damage and repairs it. Can fix almost all types of external or internal damage."
+	id = "mech_repair"
+	build_path = /obj/item/mecha_parts/mecha_equipment/repair_droid
+	category = "Mech"
+	cost = 1500

--- a/modular_splurt/code/modules/antagonists/slaver/equipment/slaver_items.dm
+++ b/modular_splurt/code/modules/antagonists/slaver/equipment/slaver_items.dm
@@ -1,3 +1,51 @@
+/obj/item/slaver
+	icon = 'icons/obj/abductor.dmi'
+	lefthand_file = 'icons/mob/inhands/antag/abductor_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/antag/abductor_righthand.dmi'
+
+/obj/item/slaver/gizmo
+	name = "Collection tool"
+	desc = "A short-range teleportation device. Use on another creature to instantly beam them to your ship."
+	icon_state = "silencer"
+	item_state = "gizmo"
+
+/obj/item/slaver/gizmo/attack(mob/living/M, mob/user)
+	var/datum/antagonist/slaver/S = locate() in user.mind.antag_datums
+	if(!S) // Is not a slaver antag.
+		to_chat(user, "<span class='warning'>You aren't sure how to use this tech!</span>")
+		return
+
+	if(user == M)
+		to_chat(user, "<span class='warning'>You can't teleport yourself!</span>")
+		return
+
+	// Find a location to teleport to
+	var/list/turf/L = list()
+	for(var/turf/T in get_area_turfs(/area/shuttle/slaveship/brig))
+		L+=T
+	if(!L || !L.len)
+		to_chat(user, "Error: No slaveship detected (Tell a coder!).")
+		return
+	var/turf/teleportDestination = pick(L)
+	var/turf/mobLocation = get_turf(M)
+
+	// Check we are in range of the destination
+	if(!mobLocation || mobLocation.z != teleportDestination.z)
+		to_chat(user, "<span class='warning'>The mothership is out of range, you need to be on the same z-level!</span>")
+		return
+
+	user.visible_message("<span class='notice'>[user] begins scanning [M] with \the [src].</span>", "<span class='notice'>You begin scanning [M] with \the [src].</span>")
+	if(do_mob(user, M, 15 SECONDS))
+		// Teleport!
+		playsound(get_turf(M.loc), 'sound/magic/blink.ogg', 50, 1)
+		M.visible_message("<span class='notice'>[M] vanishes from sight!</span>", \
+					"<span class='notice'>You feel a rush of energy as you are beamed to the slaver mothership!</span>")
+		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(M), M.dir)
+		M.forceMove(teleportDestination)
+	else
+		to_chat(user, "<span class='warning'>You need to stand still and uninterrupted for 15 seconds!</span>")
+
+// Buyable gear kits at the slaver console
 /obj/item/storage/box/slaver_teleport
 	name = "boxed emergency teleport implants (x2)"
 
@@ -18,10 +66,10 @@
 	new /obj/item/electropack/shockcollar/slave(src)
 	new /obj/item/electropack/shockcollar/slave(src)
 
-/obj/structure/closet/crate/slaver_marksman
+/obj/item/storage/backpack/duffelbag/syndie/slaver_marksman
 	name = "marksman gear shipment"
 
-/obj/structure/closet/crate/slaver_marksman/PopulateContents()
+/obj/item/storage/backpack/duffelbag/syndie/slaver_marksman/PopulateContents()
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
@@ -56,54 +104,40 @@
 	new /obj/item/clothing/gloves/krav_maga/combatglovesplus(src)
 	new /obj/item/clothing/gloves/krav_maga/combatglovesplus(src)
 
-/obj/structure/closet/crate/slaver_hardsuits
+/obj/item/storage/backpack/duffelbag/syndie/slaver_hardsuits
 	name = "combat hardsuits"
 
-/obj/structure/closet/crate/slaver_hardsuits/PopulateContents()
+/obj/item/storage/backpack/duffelbag/syndie/slaver_hardsuits/PopulateContents()
 	new /obj/item/clothing/suit/space/hardsuit/syndi(src)
 	new /obj/item/clothing/suit/space/hardsuit/syndi(src)
 
-/obj/structure/closet/crate/slaver_mech
-	name = "mech parts"
+/obj/item/storage/backpack/duffelbag/syndie/smg_rubber
+	name = "SMG kit (rubber)"
 
-/obj/structure/closet/crate/slaver_mech/PopulateContents()
-	new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/clusterbang(src)
-	new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/breaching(src)
-	new /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser(src)
+/obj/item/storage/backpack/duffelbag/syndie/smg_rubber/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/wt550/wtrubber(src)
+	new /obj/item/ammo_box/magazine/wt550m9/wtrubber(src)
+	new /obj/item/ammo_box/magazine/wt550m9/wtrubber(src)
+	new /obj/item/ammo_box/magazine/wt550m9/wtrubber(src)
 
-	new /obj/item/mecha_parts/part/gygax_armor(src)
-	new /obj/item/stack/sheet/metal/five(src)
+/obj/item/storage/backpack/duffelbag/syndie/smg
+	name = "SMG kit"
 
-	new /obj/item/stock_parts/cell/bluespace(src)
-	new /obj/item/stock_parts/capacitor/quadratic(src)
-	new /obj/item/stock_parts/scanning_module/triphasic(src)
+/obj/item/storage/backpack/duffelbag/syndie/smg/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/wt550(src)
+	new /obj/item/ammo_box/magazine/wt550m9(src)
+	new /obj/item/ammo_box/magazine/wt550m9(src)
+	new /obj/item/ammo_box/magazine/wt550m9(src)
 
-	new /obj/item/circuitboard/mecha/gygax/peripherals(src)
-	new /obj/item/circuitboard/mecha/gygax/targeting(src)
-	new /obj/item/circuitboard/mecha/gygax/main(src)
+/obj/item/storage/backpack/duffelbag/syndie/ion
+	name = "Ion carbine kit"
 
-	new /obj/item/mecha_parts/part/gygax_torso(src)
-	new /obj/item/mecha_parts/part/gygax_head(src)
-	new /obj/item/mecha_parts/part/gygax_left_arm(src)
-	new /obj/item/mecha_parts/part/gygax_right_arm(src)
-	new /obj/item/mecha_parts/part/gygax_left_leg(src)
-	new /obj/item/mecha_parts/part/gygax_right_leg(src)
-	new /obj/item/mecha_parts/chassis/gygax(src)
-
-/obj/structure/closet/crate/slaver_mech_ammo
-	name = "mech ammo"
-
-/obj/structure/closet/crate/slaver_mech_ammo/PopulateContents()
-	new /obj/item/mecha_ammo/missiles_br(src)
-	new /obj/item/mecha_ammo/clusterbang(src)
+/obj/item/storage/backpack/duffelbag/syndie/ion/PopulateContents()
+	new /obj/item/gun/energy/ionrifle/carbine/with_pin(src)
+	new /obj/item/gun/energy/ionrifle/carbine/with_pin(src)
 
 /obj/item/storage/box/syndie_kit/sleeper
 	name = "boxed chemical kit"
-
-// /obj/item/storage/box/syndie_kit/sleeper/ComponentInitialize()
-// 	. = ..()
-// 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-// 	STR.max_items = 7
 
 /obj/item/storage/box/syndie_kit/sleeper/PopulateContents()
 	new /obj/item/reagent_containers/glass/bottle/mutetoxin(src)
@@ -122,19 +156,19 @@
 	new /obj/item/grenade/plastic/x4(src)
 	new /obj/item/grenade/plastic/x4(src)
 
-/obj/structure/closet/crate/l6saw_shipment
+/obj/item/storage/backpack/duffelbag/syndie/l6saw_shipment
 	name = "L6 saw shipment"
 
-/obj/structure/closet/crate/l6saw_shipment/PopulateContents()
+/obj/item/storage/backpack/duffelbag/syndie/l6saw_shipment/PopulateContents()
 	new /obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted/riot(src)
 	new /obj/item/ammo_box/magazine/toy/m762/riot(src)
 	new /obj/item/ammo_box/foambox/riot(src)
 	new /obj/item/ammo_box/foambox/riot(src)
 
-/obj/structure/closet/crate/policing_shipment
+/obj/item/storage/backpack/duffelbag/syndie/policing_shipment
 	name = "policing shipment"
 
-/obj/structure/closet/crate/policing_shipment/PopulateContents()
+/obj/item/storage/backpack/duffelbag/syndie/policing_shipment/PopulateContents()
 	new /obj/item/shield/riot/flash(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/assembly/flash/handheld(src)

--- a/modular_splurt/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/modular_splurt/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1,3 +1,8 @@
 /obj/item/gun/ballistic/automatic/sniper_rifle/sleepy
 	desc = "A second-hand .50 cal sniper rifle. This one only seems to be capable of firing soporific rounds."
 	mag_type = /obj/item/ammo_box/magazine/sniper_rounds/soporific
+
+/obj/item/gun/ballistic/automatic/wt550/wtrubber
+	name = "security semi-auto PDW (rubber)"
+	desc = "An outdated personal defence weapon. Uses 4.6x30mm rounds and is designated the WT-550 Semi-Automatic SMG. This one seems to only fire rubber bullets."
+	mag_type = /obj/item/ammo_box/magazine/wt550m9/wtrubber

--- a/modular_splurt/code/modules/projectiles/guns/energy/special.dm
+++ b/modular_splurt/code/modules/projectiles/guns/energy/special.dm
@@ -1,0 +1,2 @@
+/obj/item/gun/energy/ionrifle/carbine/with_pin
+	pin = /obj/item/firing_pin

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4319,6 +4319,7 @@
 #include "modular_splurt\code\modules\projectiles\guns\ballistic\pistol.dm"
 #include "modular_splurt\code\modules\projectiles\guns\ballistic\revolver.dm"
 #include "modular_splurt\code\modules\projectiles\guns\ballistic\shotgun.dm"
+#include "modular_splurt\code\modules\projectiles\guns\energy\special.dm"
 #include "modular_splurt\code\modules\projectiles\guns\misc\grenade_launcher.dm"
 #include "modular_splurt\code\modules\projectiles\projectile\bullets\cannonball.dm"
 #include "modular_splurt\code\modules\projectiles\projectile\bullets\smg.dm"


### PR DESCRIPTION
## About The Pull Request

- Antag target HUD test was successful. Admins can now see it when combo HUD is enabled.
- Adds new 'Collection Tool' item to the starting loadouts that removes the need to drag kidnapped crew through space to the shuttle. They can now be safely teleported to the shuttle as long as the shuttle is on the same z-level.
- Adds more buyable gear (ion weapons, lethal weapons, etc.).
- Removes most of the use of crates when buying new gear, they just flooded the hideout with useless boxes. Duffel bags are now the usual container.
- Buyable mech now comes pre-built, with many more options for customisation now.
- Removes the need to configure the slaver sex table before use.
- And other changes.

## Changelog
:cl:
add: antag consent HUD added to admin HUD
add: new 'collection tool' to teleport crew to the slaver shuttle, removing the need to drag them through space
add: supply shop changes
tweak: other misc slaver changes
/:cl: