### PR TITLE
Permits fix

### DIFF
--- a/modular_splurt/code/modules/client/loadout/backpack.dm
+++ b/modular_splurt/code/modules/client/loadout/backpack.dm
@@ -77,8 +77,3 @@
 /datum/gear/backpack/nailpolish_purple
 	name = "Purple Nail Polish"
 	path = /obj/item/nailpolish/purple
-
-/datum/gear/backpack/weaponpermit
-	name = "Weapon Permit"
-	path = /obj/item/clothing/accessory/permit 
-	cost = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It removes permits from the loadout menu

## Why It's Good For The Game

Because not everyone should have a permit and the point of permits is to show that someone is trustworthy with weapons

## A Port?

No

## Changelog
:cl:
del: Removed weapon permits from loadouts
/:cl: