### PR TITLE
Combat cursor: Adds preference to disable it.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -95,6 +95,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/preferred_map = null
 	var/preferred_chaos = null
 	var/be_victim = null
+	var/disable_combat_cursor = FALSE
 	var/pda_style = MONO
 	var/pda_color = "#808000"
 	var/pda_skin = PDA_SKIN_ALT
@@ -1052,6 +1053,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			dat += "<h2>Splurt Preferences</h2>"
 			dat += "<b>Be Antagonist Victim:</b> <a href='?_src_=prefs;preference=be_victim;task=input'>[be_victim ? be_victim : BEVICTIM_ASK]</a><br>"
+			dat += "<b>Disable combat mode cursor:</b> <a href='?_src_=prefs;preference=disable_combat_cursor'>[disable_combat_cursor?"Yes":"No"]</a><br>"
 			dat += "<br>"
 
 			dat += "</td>"
@@ -2913,6 +2915,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 									to_chat(user, "<span class='danger'>Invalid color. Your color is not bright enough.</span>")
 		else
 			switch(href_list["preference"])
+				if("disable_combat_cursor")
+					disable_combat_cursor = !disable_combat_cursor
 				//CITADEL PREFERENCES EDIT - I can't figure out how to modularize these, so they have to go here. :c -Pooj
 				if("genital_colour")
 					features["genitals_use_skintone"] = !features["genitals_use_skintone"]

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -442,7 +442,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	// Splurt
 	S["be_victim"]			>> be_victim
-
+	S["disable_combat_cursor"]		>> disable_combat_cursor
 	//favorite outfits
 	S["favorite_outfits"]	>> favorite_outfits
 
@@ -626,6 +626,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	// Splurt
 	WRITE_FILE(S["be_victim"], be_victim)
+	WRITE_FILE(S["disable_combat_cursor"], disable_combat_cursor)
 
 	var/mob/living/carbon/human/H = parent.mob
 	if(istype(H))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -913,7 +913,8 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 	else if(throw_cursor_icon && in_throw_mode != 0)
 		client.mouse_pointer_icon = throw_cursor_icon
 	else if(combat_cursor_icon && SEND_SIGNAL(usr, COMSIG_COMBAT_MODE_CHECK, COMBAT_MODE_ACTIVE))
-		client.mouse_pointer_icon = combat_cursor_icon
+		if(!client.prefs || !client.prefs.disable_combat_cursor) // Don't show the combat cursor for people who have it disabled in prefs.
+			client.mouse_pointer_icon = combat_cursor_icon
 	else if(examine_cursor_icon && client.keys_held["Shift"]) //mouse shit is hardcoded, make this non hard-coded once we make mouse modifiers bindable
 		client.mouse_pointer_icon = examine_cursor_icon
 	else if (ismecha(loc))


### PR DESCRIPTION
# About The Pull Request

Adds an option in game preferences to disable the special mouse cursor when in combat mode. Default option is to use the combat cursor.

## Why It's Good For The Game

It's hard to see in certain situations and makes people not want to use combat mode for that very reason.

## Changelog

:cl:
add: Adds a game preference option to disable the special combat mode cursor.
/:cl: