### PR TITLE
Add RTC

### DIFF
--- a/modular_splurt/code/game/object/items/RCD.dm
+++ b/modular_splurt/code/game/object/items/RCD.dm
@@ -1,0 +1,95 @@
+/obj/item/construction/tables
+	name = "Rapid Table Constructor"
+	desc = "A poorly modified RCD outfitted to construct only tables. Reload with metal, glass and plasteel."
+	icon = 'icons/obj/tools.dmi'
+	icon_state = "arcd"
+	item_state = "oldrcd"
+	custom_price = PRICE_ABOVE_EXPENSIVE
+	custom_premium_price = PRICE_ALMOST_ONE_GRAND
+	item_flags = NO_MAT_REDEMPTION | NOBLUDGEON
+	has_ammobar = FALSE
+	matter = 200
+	max_matter = 200
+
+	// Type of table
+	var/blueprint = null
+	// Index, used in the attack self to get the type
+	var/list/choices = list()
+	// Index, used in the attack self to get the type
+	var/list/name_to_type = list()
+
+	var/list/structure_data = list("cost" = list(), "delay" = list())
+
+
+/obj/item/construction/tables/attack_self(mob/user)
+	..()
+	if (!choices.len)
+		choices = list(
+			"Standard" = image(icon = 'icons/obj/smooth_structures/table.dmi', icon_state = "table"),
+			"Reinforced" = image(icon = 'icons/obj/smooth_structures/reinforced_table.dmi', icon_state = "r_table"),
+			"Glass" = image(icon = 'icons/obj/smooth_structures/glass_table.dmi', icon_state = "glass_table"),
+		)
+
+	var/choice = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE, tooltips = TRUE)
+	if (!check_menu(user))
+		return
+	switch(choice)
+		if ("Standard")
+			blueprint = /obj/structure/table
+			if (!structure_data["cost"][blueprint])
+				structure_data["cost"][blueprint] = 5
+			if (!structure_data["delay"][blueprint])
+				structure_data["cost"][blueprint] = 20
+		if ("Reinforced")
+			blueprint = /obj/structure/table/reinforced
+			if (!structure_data["cost"][blueprint])
+				structure_data["cost"][blueprint] = 5
+			if (!structure_data["delay"][blueprint])
+				structure_data["cost"][blueprint] = 20
+		if ("Glass")
+			blueprint = /obj/structure/table/glass
+			if (!structure_data["cost"][blueprint])
+				structure_data["cost"][blueprint] = 5
+			if (!structure_data["delay"][blueprint])
+				structure_data["cost"][blueprint] = 20
+
+	playsound(src, 'sound/effects/pop.ogg', 50, FALSE)
+	to_chat(user, "<span class='notice'>You change [name]s blueprint to '[choice]'.</span>")
+
+// Also pretty much rcd_create but named differently. I'm shameless, fuck you.
+/obj/item/construction/tables/proc/create_table(atom/A, mob/user)
+	if (!structure_data || !isopenturf(A))
+		return FALSE
+
+	if (checkResource(structure_data["cost"][blueprint], user) && blueprint)
+		if (do_after(user, structure_data["delay"][blueprint], target = A))
+			if (checkResource(structure_data["cost"][blueprint], user) && canPlace(A))
+				useResource(structure_data["cost"][blueprint], user)
+				activate()
+				playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
+				new blueprint(A, FALSE, FALSE)
+				return TRUE
+
+/obj/item/construction/tables/proc/canPlace(turf/T)
+	if (!isopenturf(T))
+		return FALSE
+	. = TRUE
+	for (var/obj/O in T.contents)
+		if (O.density)	// Let's not put a table over anything dense, like you. That's just stupid.
+			return FALSE
+
+/obj/item/construction/tables/afterattack(atom/A, mob/user)
+	. = ..()
+	if (!range_check(A, user))
+		return
+	if (istype(A, /obj/structure/table))
+		var/obj/structure/table/T = A
+		if (do_after(user, 20, target = T))
+			qdel(T)	// You don't get shit back. That would be no bueno.
+			playsound(get_turf(src), 'sound/machines/click.ogg', 50, TRUE)	// CLICK.
+	else
+		create_table(A, user)
+
+/obj/item/construction/tables/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] sets the RTC to 'Glass Table' and points it down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide.</span>")
+	return (BRUTELOSS)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4221,6 +4221,7 @@
 #include "modular_splurt\code\game\object\items\cosmetics.dm"
 #include "modular_splurt\code\game\object\items\granters.dm"
 #include "modular_splurt\code\game\object\items\mesmetron.dm"
+#include "modular_splurt\code\game\object\items\RCD.dm"
 #include "modular_splurt\code\game\object\items\miscellaneous.dm"
 #include "modular_splurt\code\game\object\items\circuitboards\computer_circuitboards.dm"
 #include "modular_splurt\code\game\object\items\circuitboards\machine_circuitboards.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
This was originally meant as a joke but y'know, I kinda liked the idea. Right now it's admin-spawn only due to being unbalanced, maybe if a CE asks nicely they'll get one.
The Rapid Table Constructor is essentially an RCD that... makes tables. Tabletide stationwide, friends, for the material cost is currently probably stupidly low AND you can construct glass tables. Here's what's up with some seemingly odd things in the actual code:
- `structure_data` is defined within the switch statement for a choice, and added if it doesn't exist when a choice is made. I could improve this by specifically defining the list after generating the choices, but no. I would rather copy/paste `structure_data["cost"][blueprint]`/`structure_data["delay"][blueprint]` than I would the entire path a couple times. This can be modified if someone else doesn't like it I guess, it's literally the same but written different.
- There's no fancy construction mesh yet. Part of why it's admin only, it's legitimately just not "complete" in a way. It fully functions, but doesn't look great. It doesn't even use its own icon, it's the advanced RCD icon the plumbing RCD uses.
- Yes, potential tables to construct are manually defined. I couldn't figure out how to automatically pull tables based on a `var/rtc_constructable` variable within them like some of the other constructors do, but this is actually the method used by the RCD itself. Yeah, feel free to look if you don't believe me, the path is `code/game/objects/items/RCD.dm`.
- Custom suicide message because I'm fancy like that and felt kinda cheeky at the time.

Additional things I was considering:
- Item description is a bit dull. `A poorly modified RCD outfitted to construct only tables. Reload with metal, glass and plasteel.` doesn't roll off the tongue, potentially could just be a joke or something. Fuck if I know.
- Obviously material costs and construction delays are all the same. This potentially needs changed later (and probably should be), for now they're all low cost at a decent delay. You can make like, 40 tables on a full reload of the device but it takes some time to do all of them. Granted there's no click delay so uh. It can be gone pretty quick.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
Tabletide stationwide! In all reality, having a long-range constructor that takes just about any material as input and can shit out tables just about anywhere can make cosmetic repairs pretty quick. In and out, back to dorms with engineers. Or the bar, I guess, if publicity is your thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Not that I know of? Maybe? idfk.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog

:cl:
add: Added Rapid Table Constructor
admin: RTC is currently admin-spawn only
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
