### PR TITLE
Minor boxstation medical machinery adjustments

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -33067,7 +33067,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/bloodbankgen,
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery Storage";
 	dir = 6;
@@ -33156,6 +33155,22 @@
 	},
 /obj/item/storage/box/rxglasses,
 /obj/item/hand_labeler,
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bCR" = (
@@ -34324,7 +34339,6 @@
 /area/medical/medbay/central)
 "bFx" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/limbgrower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -35507,6 +35521,7 @@
 /obj/item/hand_labeler,
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
+/obj/item/storage/box/syringes,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIk" = (
@@ -61290,29 +61305,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
 "pHl" = (
-/obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = 6;
-	pixel_y = -3
-	},
 /obj/item/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 30
 	},
+/obj/machinery/bloodbankgen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pHt" = (
@@ -65395,6 +65393,13 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"vAg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/limbgrower,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "vAl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
@@ -103619,7 +103624,7 @@ bof
 bof
 bzW
 bqQ
-bCR
+vAg
 bGR
 bIj
 bJC

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -18,7 +18,7 @@ export NODE_VERSION_PRECISE=12.22.4
 export SPACEMAN_DMM_VERSION=suite-1.7
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.6.8
+export PYTHON_VERSION=3.7.9
 
 # Auxmos git tag
 export AUXMOS_VERSION=v0.3.0

--- a/tools/bootstrap/python.bat
+++ b/tools/bootstrap/python.bat
@@ -1,1 +1,2 @@
-@call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0\python_.ps1" %*
+@echo off
+call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0\python_.ps1" %*

--- a/tools/bootstrap/python37._pth
+++ b/tools/bootstrap/python37._pth
@@ -1,4 +1,4 @@
-python36.zip
+python37.zip
 .
 ..\..\..
 

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -50,7 +50,7 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
 	# Copy a ._pth file without "import site" commented, so pip will work
-	Copy-Item "$Bootstrap/python36._pth" $PythonDir `
+	Copy-Item "$Bootstrap/python37._pth" $PythonDir `
 		-ErrorAction Stop
 
 	Remove-Item $Archive


### PR DESCRIPTION
# About The Pull Request

Moves blood bank and limb grower to Medical storage. One table removed, the items on that table moved to a nearby one so as not to crowd the room.

<img width="258" alt="Changes" src="https://user-images.githubusercontent.com/5742277/152924602-b1bd8e1c-a09e-47b5-afb9-f8c33ff5ae56.PNG">

## Why It's Good For The Game

Main reason.
Chemists can't reach the limb grower in surgery storage, this way its more likely to be filled.

Side benefit.
More likely to be upgraded by science as they pass through.

## Changelog

:cl:
tweak: tweaked a few things
/:cl:


