### PR TITLE
Minor boxstation medical machinery adjustments

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -33067,7 +33067,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/bloodbankgen,
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery Storage";
 	dir = 6;
@@ -33156,6 +33155,22 @@
 	},
 /obj/item/storage/box/rxglasses,
 /obj/item/hand_labeler,
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bCR" = (
@@ -34324,7 +34339,6 @@
 /area/medical/medbay/central)
 "bFx" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/limbgrower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -35507,6 +35521,7 @@
 /obj/item/hand_labeler,
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
+/obj/item/storage/box/syringes,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIk" = (
@@ -56856,6 +56871,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/side,
 /area/security/prison/upper)
+"jCZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/limbgrower,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "jDr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -61290,29 +61312,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
 "pHl" = (
-/obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = 6;
-	pixel_y = -3
-	},
 /obj/item/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 30
 	},
+/obj/machinery/bloodbankgen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pHt" = (
@@ -103619,7 +103624,7 @@ bof
 bof
 bzW
 bqQ
-bCR
+jCZ
 bGR
 bIj
 bJC


### PR DESCRIPTION
# About The Pull Request

Moves blood bank and limb grower to Medical storage. One table removed, the items on that table moved to a nearby one so as not to crowd the room.

## Why It's Good For The Game

Main reason.
Chemists can't reach the limb grower in surgery storage, this way its more likely to be filled.

Side benefit.
More likely to be upgraded by science as they pass through.


https://user-images.githubusercontent.com/5742277/152924602-b1bd8e1c-a09e-47b5-afb9-f8c33ff5ae56.PNG


## Changelog

:cl:
tweak: changed some map things on box
/:cl:

