### PR TITLE
Decreases Midround Antags

### DIFF
--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -1,9 +1,10 @@
 /datum/round_event_control/abductor
 	name = "Abductors"
 	typepath = /datum/round_event/ghost_role/abductor
-	weight = 10
+	weight = 3
 	max_occurrences = 1
 	min_players = 30
+	earliest_start = 30 MINUTES
 	dynamic_should_hijack = TRUE
 
 /datum/round_event/ghost_role/abductor

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/blob
 	name = "Blob"
 	typepath = /datum/round_event/ghost_role/blob
-	weight = 10
+	weight = 3
 	max_occurrences = 1
 
 	earliest_start = 40 MINUTES

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -4,7 +4,7 @@
 	weight = 3
 	max_occurrences = 1
 
-	earliest_start = 40 MINUTES
+	earliest_start = 60 MINUTES
 	min_players = 35
 	dynamic_should_hijack = TRUE
 

--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -1,8 +1,9 @@
 /datum/round_event_control/space_dragon
 	name = "Spawn Space Dragon"
 	typepath = /datum/round_event/ghost_role/space_dragon
-	weight = 8
+	weight = 5
 	max_occurrences = 1
+	earliest_start = 30 MINUTES
 	min_players = 20
 	dynamic_should_hijack = TRUE
 
@@ -13,7 +14,7 @@
 
 /datum/round_event/ghost_role/space_dragon/announce(fake)
 	priority_announce("A large organic energy flux has been recorded near of [station_name()], please stand-by.", "Lifesign Alert")
-	
+
 /datum/round_event/ghost_role/space_dragon/spawn_role()
 	var/list/spawn_locs = list()
 	for(var/obj/effect/landmark/carpspawn/carp_spawn in GLOB.landmarks_list)
@@ -24,11 +25,11 @@
 	if(!spawn_locs.len)
 		message_admins("No valid spawn locations found, aborting...")
 		return MAP_ERROR
-	
+
 	var/list/candidates = get_candidates(ROLE_SPACE_DRAGON, null, ROLE_SPACE_DRAGON)
 	if(!candidates.len)
 		return NOT_ENOUGH_PLAYERS
-	
+
 	var/mob/dead/selected = pick_n_take(candidates)
 
 	var/datum/mind/player_mind = new /datum/mind(selected.key)

--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/space_dragon
 	name = "Spawn Space Dragon"
 	typepath = /datum/round_event/ghost_role/space_dragon
-	weight = 5
+	weight = 3
 	max_occurrences = 1
 	earliest_start = 30 MINUTES
 	min_players = 20

--- a/code/modules/events/space_ninja.dm
+++ b/code/modules/events/space_ninja.dm
@@ -2,8 +2,8 @@
 	name = "Spawn Space Ninja"
 	typepath = /datum/round_event/ghost_role/space_ninja
 	max_occurrences = 1
-	weight = 10
-	earliest_start = 20 MINUTES
+	weight = 3
+	earliest_start = 30 MINUTES
 	min_players = 15
 	dynamic_should_hijack = TRUE
 


### PR DESCRIPTION
# About The Pull Request

It Decreased some mid-round antag spawns so we're not facing abductors, ninjas, and dragons every round.

## Why It's Good For The Game
There's too many space dragons, ninjas, and abductors being created.

## A Port?

Nope

## Changelog

:cl: Curiosity
balance: Reduced Mid-round antags that are commonly spawning
/:cl:
