### PR TITLE
Changes to alt job titles (Suggestion 70 (newer one))

### DIFF
--- a/modular_sand/code/modules/jobs/job_types/_job_alt_titles.dm
+++ b/modular_sand/code/modules/jobs/job_types/_job_alt_titles.dm
@@ -26,11 +26,11 @@
 	alt_titles = list("Firefighter", "Life Support Specialist", "Disposals Technician")
 
 /datum/job/engineer
-	alt_titles = list("Maintenance Technician", "Engine Technician", "Electrician", "Structural Engineer", "Mechanic",  "Station Architect", "Hazardous Material Operator") // "Mechanic" is also same for Roboticist.
+	alt_titles = list("Maintenance Technician", "Engine Technician", "Electrician", "Structural Engineer", "Station Architect", "Hazardous Material Operator")
 
 //Service
 /datum/job/assistant
-	alt_titles = list("Civilian", "Visitor", "Businessman", "Trader", "Entertainer", "Intern", "Morale Officer", "Stripper", "Off-Duty", "Escort", "Tourist", "Clerk") // "Entertainer" is also same for clown.
+	alt_titles = list("Civilian", "Visitor", "Businessman", "Trader", "Entertainer", "Intern", "Morale Officer", "Stripper", "Off-Duty", "Escort", "Tourist", "Clerk", "Blacksmith")
 
 /datum/job/bartender
 	alt_titles = list("Barista", "Mixologist", "Sommelier", "Bar Owner", "Barmaid", "Expediter")
@@ -39,7 +39,7 @@
 	alt_titles = list("Cult Leader", "Bishop", "Priest", "Priestess", "Prior", "Monk", "Nun", "Counselor")
 
 /datum/job/clown //The most useless role in the game, delet this
-	alt_titles = list("Entertainer", "Jester", "Comedian") // "Entertainer" is also same for assistant.
+	alt_titles = list("Jester", "Comedian")
 
 /datum/job/cook
 	alt_titles = list("Culinary Artist", "Butcher", "Nutritionist", "Chef", "Chef de partie", "Poissonier")
@@ -98,4 +98,4 @@
 	alt_titles = list("Shipping Specialist", "Delivery Manager", "Deliveries Officer", "Mail Man", "Mail Woman", "Mailroom Technician", "Logistics Technician")
 
 /datum/job/mining
-	alt_titles = list("Explorer", "Exotic Ore Miner", "Digger", "Hunter") // Add "Fauna Hunters"?
+	alt_titles = list("Explorer", "Exotic Ore Miner", "Digger", "Hunter")


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
This removes "mechanic" from engineering and "entertainer" from clowns. Also re-adds "blacksmith" alt title for Assistant.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
Less confusion.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
N/A
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog

:cl: Anonymous
add: Added "blacksmith" as an alt title for Assistant.
del: Removes "mechanic" from Station Engineer alt titles.
del: Removes "entertainer" from Clown alt titles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
