### PR TITLE
Lavaland Syndi-Base Area Fix

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -3088,7 +3088,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/space)
+/area/ruin/lavaland/unpowered/syndicate_lava_base/main)
 "iy" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"


### PR DESCRIPTION
Fixes mapping error.

## Changelog

:cl:
fix: Lavaland syndie base no-gravity spot fixed
/:cl: