### PR TITLE
Maps 2 Electric Boogaloo

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -438,6 +438,10 @@ SUBSYSTEM_DEF(vote)
 					var/datum/map_config/targetmap = config.maplist[M]
 					if(!istype(targetmap))
 						continue
+					/* SPLURT change */
+					if(targetmap.map_name == SSmapping.config.map_name)	// Second now because I did a stupid with types
+						continue
+					/* END SPLURT change */
 					if(!targetmap.voteweight)
 						continue
 					if((targetmap.config_min_users && players < targetmap.config_min_users) || (targetmap.config_max_users && players > targetmap.config_max_users))

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -439,7 +439,7 @@ SUBSYSTEM_DEF(vote)
 					if(!istype(targetmap))
 						continue
 					/* SPLURT change */
-					if(targetmap.map_name == SSmapping.config.map_name)	// Second now because I did a stupid with types
+					if(CONFIG_GET(flag/no_repeats) && targetmap.map_name == SSmapping.config.map_name)	// Second now because I did a stupid with types
 						continue
 					/* END SPLURT change */
 					if(!targetmap.voteweight)

--- a/config/config.txt
+++ b/config/config.txt
@@ -46,3 +46,4 @@ $include splurt/fetish_content.txt
 $include splurt/discord.txt
 $include splurt/general.txt
 $include splurt/comms.txt
+$include splurt/maps.txt

--- a/config/splurt/maps.txt
+++ b/config/splurt/maps.txt
@@ -1,0 +1,3 @@
+# Allow map repeats in the mapvote
+# Comment this line to allow them
+NO_REPEATS

--- a/modular_splurt/code/controllers/configuration/entries/splurt_maps.dm
+++ b/modular_splurt/code/controllers/configuration/entries/splurt_maps.dm
@@ -1,0 +1,1 @@
+/datum/config_entry/flag/no_repeats

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4203,6 +4203,7 @@
 #include "modular_splurt\code\controllers\configuration\entries\splurt_discord.dm"
 #include "modular_splurt\code\controllers\configuration\entries\splurt_fetish_content.dm"
 #include "modular_splurt\code\controllers\configuration\entries\splurt_general.dm"
+#include "modular_splurt\code\controllers\configuration\entries\splurt_maps.dm"
 #include "modular_splurt\code\controllers\subsystem\discord.dm"
 #include "modular_splurt\code\controllers\subsystem\redbot.dm"
 #include "modular_splurt\code\datums\mind.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Down with the box purgatory! This PR denies choosing the same map with every map vote. Yeah, I'm salty enough to add this in.
### NOTE TO MAINTAINERS:
This PR **modifies a subsystem file.** This change is in the file itself to avoid having to copy/paste large swaths of code to a modular file. It's a total of four lines that were changed, and while this shouldn't cause many (if any) conflicts, it MAY cause them in the future. Coder beware.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
Box gets kinda boring sometimes ngl.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Nah.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
tweak: Removed the ability to vote for the same map over and over. It's too OP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
