### PR TITLE
adv plasm cutter is now correctly classified

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -195,6 +195,7 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
 	module_type = list(/obj/item/robot_module/miner)
+	module_flags = BORG_MODULE_MINER
 
 /obj/item/borg/upgrade/advcutter/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()


### PR DESCRIPTION
# About The Pull Request
what it says on the tin
fixes #152
## Changelog

:cl:
tweak: the cyborg advanced plasma cutter is now under mining instead of "general"
/:cl:
