### PR TITLE
Pirority Fix for several weapons

### DIFF
--- a/modular_splurt/code/modules/cargo/packs/armory.dm
+++ b/modular_splurt/code/modules/cargo/packs/armory.dm
@@ -70,7 +70,7 @@
 					/obj/item/gun/grenadelauncher)
 	crate_name = "riot gun crate"
 
-/datum/supply_pack/security/armory/enfrocer
+/datum/supply_pack/security/armory/enforcer
 	name = "Enforcer pistol crate"
 	desc = "Contains 3 Enforcer handguns. Requires Armory access to open."
 	cost = 3500
@@ -78,3 +78,19 @@
 					/obj/item/gun/ballistic/automatic/pistol/enforcer,
 					/obj/item/gun/ballistic/automatic/pistol/enforcer)
 	crate_name = "enfocer pistol crate"
+
+/datum/supply_pack/security/armory/cap_e45 // I am mad I even have to do this. -Radar Fuckers keep exploting this, moved it to the armory section
+	name = "Captain's Enforcer .45"
+	desc = "A gold handgun meant for the Captain."
+	access = ACCESS_CAPTAIN
+	cost = 6000
+	contains = list(/obj/item/gun/ballistic/automatic/pistol/enforcergold,
+    /obj/item/ammo_box/magazine/e45/lethal,
+    /obj/item/ammo_box/magazine/e45/lethal,
+    /obj/item/ammo_box/magazine/e45,
+    /obj/item/ammo_box/magazine/e45,
+    /obj/item/ammo_box/magazine/e45,
+    /obj/item/ammo_box/magazine/e45/taser,
+    /obj/item/ammo_box/magazine/e45/taser,
+    /obj/item/ammo_box/magazine/e45/taser)
+	crate_name = "captain's .45"

--- a/modular_splurt/code/modules/cargo/packs/goodies.dm
+++ b/modular_splurt/code/modules/cargo/packs/goodies.dm
@@ -69,7 +69,7 @@
 	contains = list(/obj/item/gunpart/shotgunstock, /obj/item/gunpart/shotgunbarrelsawn, /obj/item/storage/box/rubbershot)
 
 /datum/supply_pack/goody/dbshotgun_single
-	name = "Sawn-off Double Barrel Shotgun Single-Pack"
+	name = "Double Barrel Shotgun Single-Pack"
 	desc = "Contains a parts kit to assemble a double barrel shotgun."
 	cost = 700
 	contains = list(/obj/item/gunpart/shotgunstock, /obj/item/gunpart/shotgunbarrel, /obj/item/storage/box/rubbershot)

--- a/modular_splurt/code/modules/cargo/packs/misc.dm
+++ b/modular_splurt/code/modules/cargo/packs/misc.dm
@@ -1,20 +1,3 @@
-/datum/supply_pack/misc/cap_e45 // I am mad I even have to do this. -Radar
-	name = "Captain's Enforcer .45"
-	desc = "A gold handgun meant for the Captain."
-	access = ACCESS_CAPTAIN
-	cost = 6000
-	contains = list(/obj/item/gun/ballistic/automatic/pistol/enforcergold,
-    /obj/item/ammo_box/magazine/e45/lethal,
-    /obj/item/ammo_box/magazine/e45/lethal,
-    /obj/item/ammo_box/magazine/e45,
-    /obj/item/ammo_box/magazine/e45,
-    /obj/item/ammo_box/magazine/e45,
-    /obj/item/ammo_box/magazine/e45/taser,
-    /obj/item/ammo_box/magazine/e45/taser,
-    /obj/item/ammo_box/magazine/e45/taser)
-	crate_name = "captain's .45"
-	crate_type = /obj/structure/closet/crate/secure/weapon
-
 /datum/supply_pack/misc/m1911s
 	name = "M1911s"
 	desc = "A pack of 3 M1911s with 9 mags of rubber."

--- a/modular_splurt/code/modules/projectiles/guns/energy/lasers.dm
+++ b/modular_splurt/code/modules/projectiles/guns/energy/lasers.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/energy/civilian
-	name = "civlian energy pistol"
-	desc = "A cheap energy pistol produced by Wattz and Hertz. Has no external ammo indicator. It looks easily modfiable"
+	name = "civilian energy pistol"
+	desc = "A cheap energy pistol produced by Wattz and Hertz. Has no external ammo indicator. It looks easily modifiable"
 	icon = 'modular_splurt/icons/obj/guns/energy.dmi'
 	icon_state = "wattz1000"
 	item_state = "caplaser"
@@ -12,13 +12,13 @@
 	can_flashlight = 0
 
 /obj/item/gun/energy/civilian/lethal
-	name = "moddfied civlian energy pistol"
+	name = "moddfied civilian energy pistol"
 	desc = "A cheap energy pistol produced by Wattz and Hertz. Has no external ammo indicator. It has been modded to shoot lethal lasers, somehow."
 	icon_state = "magnetowattz"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser)
 
 /obj/item/gunpart/civilianlaserframe
-	name = "civlian energy pistol frame"
+	name = "civilian energy pistol frame"
 	desc = "a civilian energy pistol frame"
 	icon_state = "wattz1000frame"
 


### PR DESCRIPTION
Priority update due to exploits. Even by an admin at this point.

<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
A priority fix for several weapons due to an exploit spreading. This was suppose to be a slower update but now I have to prioritize this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
Several fixes from spelling glitches to the Captain's .45 being private purchase. I hate oversights.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No a fix
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog

:cl: radar651
fix: fixes the Captain's .45 for being bought privately. This was going to be fixed later but its gotten out of hand.
spellcheck: The double barrel shotgun sharing the title with the sawed off in private purchase panel.
spellcheck: Fix a spelling mistake in the civilian energy gun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
