### PR TITLE
Modularize drinking glass+shot glass icons

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -20,6 +20,7 @@
 		if(!renamedByPlayer)
 			name = R.glass_name
 			desc = R.glass_desc
+		R.glass_icon ? (icon = R.glass_icon) : (icon = initial(icon))
 		if(R.glass_icon_state)
 			icon_state = R.glass_icon_state
 		else
@@ -59,6 +60,7 @@
 		name = "filled shot glass"
 		desc = "The challenge is not taking as many as you can, but guessing what it is before you pass out."
 
+		largest_reagent.shot_glass_icon ? (icon = largest_reagent.shot_glass_icon) : (icon = initial(icon))
 		if(largest_reagent.shot_glass_icon_state)
 			icon_state = largest_reagent.shot_glass_icon_state
 		else

--- a/modular_splurt/code/modules/reagents/chemistry/reagents.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/reagents.dm
@@ -1,0 +1,3 @@
+/datum/reagent
+	var/glass_icon = null		// Set to a .dmi to use a modular icon file
+	var/shot_glass_icon = null 	// See above

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4428,6 +4428,7 @@
 #include "modular_splurt\code\modules\projectiles\projectile\bullets\cannonball.dm"
 #include "modular_splurt\code\modules\projectiles\projectile\bullets\smg.dm"
 #include "modular_splurt\code\modules\reagents\reagent_dispenser.dm"
+#include "modular_splurt\code\modules\reagents\chemistry\reagents.dm"
 #include "modular_splurt\code\modules\reagents\chemistry\reagents\alcohol_reagents.dm"
 #include "modular_splurt\code\modules\reagents\chemistry\reagents\cit_reagents.dm"
 #include "modular_splurt\code\modules\reagents\chemistry\reagents\drink_reagents.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
This PR allows coders to FINALLY use a custom icon file for drinking glasses and shot glasses through the reagent definition. Why it wasn't like this already, I don't know. That icon file is a mess. Guh.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
No effect on gameplay, but huge effect on our merge conflicts. Now there's a conflict in code instead of icons! Assuming they update the code, it's pretty unlikely to be updated beyond the change I already made here.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Not a port, it's going upstream later so expect to see it back here eventually
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog

:cl:
fix: Glass icon files can now be defined by the reagent. Thank FUCK.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
