### PR TITLE
makes drinks for degenerates cleaner

### DIFF
--- a/modular_splurt/code/modules/food_and_drinks/recipes/drink_recipes.dm
+++ b/modular_splurt/code/modules/food_and_drinks/recipes/drink_recipes.dm
@@ -26,13 +26,13 @@
 	name = "Cum in a Hot Tub"
 	id = /datum/reagent/consumable/ethanol/cum_in_a_hot_tub
 	results = list(/datum/reagent/consumable/ethanol/cum_in_a_hot_tub = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 2, /datum/reagent/consumable/ethanol/white_russian = 1, /datum/reagent/consumable/ethanol/irish_cream = 0.1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 2, /datum/reagent/consumable/ethanol/white_russian = 1, /datum/reagent/consumable/ethanol/irish_cream = 1)
 
 /datum/chemical_reaction/cum_in_a_hot_tub/semen
 	name = "Cum in a Hot Tub"
 	id = /datum/reagent/consumable/ethanol/cum_in_a_hot_tub/semen
 	results = list(/datum/reagent/consumable/ethanol/cum_in_a_hot_tub/semen = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 2, /datum/reagent/consumable/semen = 1, /datum/reagent/consumable/ethanol/irish_cream = 0.1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 2, /datum/reagent/consumable/semen = 1, /datum/reagent/consumable/ethanol/irish_cream = 1)
 
 /datum/chemical_reaction/orange_creamsicle
     name = "Orange Creamsical"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

changes both recipes for cum in a hot tub to a 2 1 1 ratio from originally a 2 1 0.1

## Why It's Good For The Game

It just makes the recipe cleaner and doesn't leave extra reagents in the glass

## A Port?

No

## Changelog

:cl: Halford Steel
tweak: tweaked the cum in a hot tub recipe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
