### PR TITLE
[Semi-modular]Shambler mask nerf.

### DIFF
--- a/modular_sand/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/modular_sand/code/modules/mining/equipment/kinetic_crusher.dm
@@ -102,7 +102,7 @@
 	desc = "It really doesn't seem like it could be worn. Suitable as a crusher trophy."
 	icon = 'modular_sand/icons/obj/lavaland/artefacts.dmi'
 	icon_state = "miner_mask"
-	bonus_value = 10
+	bonus_value = 5 //SPLURT edit, Original: 10
 	denied_type = /obj/item/crusher_trophy/blaster_tubes/mask
 
 /obj/item/crusher_trophy/blaster_tubes/mask/effect_desc()


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Nerfs the Shambling Miner's Mask trophy so it can be now a cheaper and weaker version of the Colossus' Blaster Tubes.

## Why It's Good For The Game

Because yes, this trophy is very fucky, but also too very generous at giving easy extra melee damage for killing some lavaland miner hobo with the crushie so reducing the bonus melee damage seems reasonable.

## A Port?

No.

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog

:cl:
balance: nerfed Mask of Shambling Miner's mask bonus melee damage from 10 to 5.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
