### PR TITLE
Safety wheels for discord

### DIFF
--- a/modular_splurt/code/modules/discord/accountlink.dm
+++ b/modular_splurt/code/modules/discord/accountlink.dm
@@ -26,10 +26,10 @@
 
 
 	else
-		var/existing_id = SSdiscord.lookup_id(usr?.ckey)
+		var/datum/discord_link_record/existing_link = SSdiscord.find_discord_link_by_ckey(usr?.ckey, FALSE)
 		//Do not create a new entry if they already have a linked account
-		if(existing_id)
-			message = "You already have a linked account with discord ID ([existing_id]). If you desire to change your account please contact staff."
+		if(existing_link?.discord_id)
+			message = "You already have a linked account with discord ID ([existing_link.discord_id]) linked on [existing_link.timestamp]. If you desire to change your account please contact staff."
 		// Will generate one if an expired one doesn't exist already, otherwise will grab existing token
 		else
 			var/one_time_token = SSdiscord.get_or_generate_one_time_token_for_ckey(ckey)

--- a/modular_splurt/code/modules/discord/accountlink.dm
+++ b/modular_splurt/code/modules/discord/accountlink.dm
@@ -26,10 +26,15 @@
 
 
 	else
+		var/existing_id = SSdiscord.lookup_id(usr?.ckey)
+		//Do not create a new entry if they already have a linked account
+		if(existing_id)
+			message = "You already have a linked account with discord ID ([existing_id]). If you desire to change your account please contact staff."
 		// Will generate one if an expired one doesn't exist already, otherwise will grab existing token
-		var/one_time_token = SSdiscord.get_or_generate_one_time_token_for_ckey(ckey)
-		SSdiscord.reverify_cache[usr.ckey] = one_time_token
-		message = "Your one time token is: \"[one_time_token]\". You can now verify yourself in discord by using the command <span class='warning'>\"[prefix][command] [one_time_token]\"</span>"
+		else
+			var/one_time_token = SSdiscord.get_or_generate_one_time_token_for_ckey(ckey)
+			SSdiscord.reverify_cache[usr.ckey] = one_time_token
+			message = "Your one time token is: \"[one_time_token]\". You can now verify yourself in discord by using the command <span class='warning'>\"[prefix][command] [one_time_token]\"</span>"
 
 	//Now give them a browse window so they can't miss whatever we told them
 	var/datum/browser/window = new/datum/browser(usr, "discordverification", "Discord verification")


### PR DESCRIPTION
should've done this way before

<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Makes it so that people cannot make a new entry in the discord links database with the link account button if they already have a verified account.
This is both to stop people from accidentally locking themselves out of the game and also to avoid any possible exploits with unchecked account changes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
some people are very dumb, I swear
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog

:cl:
tweak: you'll no longer create a new verification entry if you already linked your discord, and It'll show the id of the current account instead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
