### PR TITLE
Adds a Gloss body marking

### DIFF
--- a/modular_splurt/code/modules/mob/dead/new_player/sprite_accesories/body_markings.dm
+++ b/modular_splurt/code/modules/mob/dead/new_player/sprite_accesories/body_markings.dm
@@ -58,3 +58,8 @@
 	icon_state = "bug3tone"
 	recommended_species = list("insect")
 	covered_limbs = list("Chest" = MATRIX_GREEN_BLUE)
+//splurt changes
+/datum/sprite_accessory/mam_body_markings/eros/gloss
+	name = "Body Gloss"
+	icon_state = "gloss"
+	covered_limbs = list("Chest" = MATRIX_RED)


### PR DESCRIPTION
# About The Pull Request

Adds a body marking that gives a your character glossy skin w/ some other adjustments

## Why It's Good For The Game

Because shiny skin is always best skin. Also, heel slowdown was a mistake. 

## A Port?

The sprite work is completely original.

## Changelog

:cl: Curiosity
add: New Gloss Body Marking
tweak: With recent advancements, Heel slowdown was removed.
add: The latex bodysuit is added to the loadout.
/:cl:
