### PR TITLE
Hotfix for borg tiles fucking dying

### DIFF
--- a/modular_splurt/code/game/object/items/stacks/tiles/tile_reskinning.dm
+++ b/modular_splurt/code/game/object/items/stacks/tiles/tile_reskinning.dm
@@ -9,7 +9,8 @@
 	if (!QDELETED(choice))	// If the tile merged with floor tiles as a borg, you're fucked.
 		if (istype(user, /mob/living/silicon/robot))	// This is where the changes start. Find out if we're a borgo
 			var/mob/living/silicon/robot/R = user		// I want intellisense, give it to me.
-			R.deselect_module(R.get_selected_module())	// Deactivate the selected module so we don't cry about it later
+			var/selected_module = R.get_selected_module()	// Store the selected module
+			R.deselect_module(selected_module)			// Deactivate the selected module so we don't cry about it later
 			moveToNullspace()							// This was breaking stuff so it's here now
 			choice.is_cyborg = 1						// Let borgos use the new tile
 			choice.custom_materials = null				// Get rid of custom materials so we don't make exploits
@@ -17,13 +18,16 @@
 			R.module.remove_module(src, TRUE)			// And remove the old one
 			R.module.add_module(choice, TRUE, TRUE)		// Add the new tile to the modules list
 			choice.doMove(R.module)						// Move the new tile to the module so it's not just on the ground
+			R.activate_module(choice)					// Activate the module so you don't have to manually
+			R.select_module(selected_module)			// Select the module to make this shit ✨seamless✨
 		else				// We're not a borg, so continue doing what the original proc does
 			moveToNullspace()							// Instead of being before anything, this is here because it was breaking stuff
 			user.put_in_active_hand(choice)
 	else	// But not really, I'm a benevolent coder
 		if (istype(user, /mob/living/silicon/robot))	// See above
 			var/mob/living/silicon/robot/R = user
-			R.deselect_module(R.get_selected_module())
+			var/selected_module = R.get_selected_module()
+			R.deselect_module(selected_module)
 			moveToNullspace()
 			choice.is_cyborg = 1
 			choice.custom_materials = null
@@ -31,4 +35,6 @@
 			R.module.remove_module(src, TRUE)
 			R.module.add_module(choice, TRUE, TRUE)
 			choice.doMove(R.module)
+			R.activate_module(choice)
+			R.select_module(selected_module)
 	qdel(src)

--- a/modular_splurt/code/game/object/items/stacks/tiles/tile_reskinning.dm
+++ b/modular_splurt/code/game/object/items/stacks/tiles/tile_reskinning.dm
@@ -1,0 +1,34 @@
+// The TRUE fix for cyborgs dropping their shit
+/obj/item/stack/tile/attack_self(mob/user)
+	if(!tile_reskin_types)
+		return ..()
+	var/obj/item/stack/tile/choice = show_radial_menu(user, src, tile_reskin_types, radius = 48, require_near = TRUE)
+	if (!choice || choice == type)
+		return
+	choice = new choice(user.drop_location(), amount)
+	if (!QDELETED(choice))	// If the tile merged with floor tiles as a borg, you're fucked.
+		if (istype(user, /mob/living/silicon/robot))	// This is where the changes start. Find out if we're a borgo
+			var/mob/living/silicon/robot/R = user		// I want intellisense, give it to me.
+			R.deselect_module(R.get_selected_module())	// Deactivate the selected module so we don't cry about it later
+			moveToNullspace()							// This was breaking stuff so it's here now
+			choice.is_cyborg = 1						// Let borgos use the new tile
+			choice.custom_materials = null				// Get rid of custom materials so we don't make exploits
+			choice.cost = 125							// A tile costs 125 materials
+			R.module.remove_module(src, TRUE)			// And remove the old one
+			R.module.add_module(choice, TRUE, TRUE)		// Add the new tile to the modules list
+			choice.doMove(R.module)						// Move the new tile to the module so it's not just on the ground
+		else				// We're not a borg, so continue doing what the original proc does
+			moveToNullspace()							// Instead of being before anything, this is here because it was breaking stuff
+			user.put_in_active_hand(choice)
+	else	// But not really, I'm a benevolent coder
+		if (istype(user, /mob/living/silicon/robot))	// See above
+			var/mob/living/silicon/robot/R = user
+			R.deselect_module(selected_module)
+			moveToNullspace()
+			choice.is_cyborg = 1
+			choice.custom_materials = null
+			choice.cost = 125
+			R.module.remove_module(src, TRUE)
+			R.module.add_module(choice, TRUE, TRUE)
+			choice.doMove(R.module)
+	qdel(src)

--- a/modular_splurt/code/game/object/items/stacks/tiles/tile_reskinning.dm
+++ b/modular_splurt/code/game/object/items/stacks/tiles/tile_reskinning.dm
@@ -23,7 +23,7 @@
 	else	// But not really, I'm a benevolent coder
 		if (istype(user, /mob/living/silicon/robot))	// See above
 			var/mob/living/silicon/robot/R = user
-			R.deselect_module(selected_module)
+			R.deselect_module(R.get_selected_module())
 			moveToNullspace()
 			choice.is_cyborg = 1
 			choice.custom_materials = null

--- a/modular_splurt/code/game/object/items/stacks/tiles/tile_types.dm
+++ b/modular_splurt/code/game/object/items/stacks/tiles/tile_types.dm
@@ -15,3 +15,7 @@
 	icon = 'modular_splurt/icons/obj/tiles.dmi'
 	icon_state = "tile-shadow_wood"
 	turf_type = /turf/open/floor/wood/shadow
+
+// Temporary fix for cyborgs losing their tiles
+/obj/item/stack/tile/plasteel/cyborg
+	tile_reskin_types = null

--- a/modular_splurt/code/game/object/items/stacks/tiles/tile_types.dm
+++ b/modular_splurt/code/game/object/items/stacks/tiles/tile_types.dm
@@ -15,7 +15,3 @@
 	icon = 'modular_splurt/icons/obj/tiles.dmi'
 	icon_state = "tile-shadow_wood"
 	turf_type = /turf/open/floor/wood/shadow
-
-// Temporary fix for cyborgs losing their tiles
-/obj/item/stack/tile/plasteel/cyborg
-	tile_reskin_types = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4280,6 +4280,7 @@
 #include "modular_splurt\code\game\object\items\robot\robot_items.dm"
 #include "modular_splurt\code\game\object\items\robot\robot_upgrades.dm"
 #include "modular_splurt\code\game\object\items\stacks\sheets\sheet_types.dm"
+#include "modular_splurt\code\game\object\items\stacks\tiles\tile_reskinning.dm"
 #include "modular_splurt\code\game\object\items\stacks\tiles\tile_types.dm"
 #include "modular_splurt\code\game\object\items\storage\backpack.dm"
 #include "modular_splurt\code\game\object\items\storage\belt.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
No longer a hotfix! We've fully fixed borg tiles fucking dying, woo!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
Borg tiles quit fucking dying
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Nah fam
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
del: The fucking stupidest bug ever for us engiborgs
fix: Borgs will no longer drop their floor tiles when they choose a different tile type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
