### PR TITLE
Swussy?

### DIFF
--- a/code/__SPLURTCODE/DEFINES/traits.dm
+++ b/code/__SPLURTCODE/DEFINES/traits.dm
@@ -7,6 +7,8 @@
 
 #define TRAIT_GFLUID_DETECT "genital_fluid_detect"
 
+#define TRAIT_ASHRESISTANCE		"TRAIT_ASHRESISTANCE"
+
 // Hyperstation traits
 #define TRAIT_PHARMA            "hepatic_pharmacokinesis"
 #define TRAIT_CHOKE_SLUT		"choke_slut"

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -87,7 +87,7 @@ GLOBAL_LIST_EMPTY(ash_storm_sounds)
 /datum/weather/ash_storm/weather_act(mob/living/L)
 	if(is_ash_immune(L))
 		return
-	if(is_species(L, /datum/species/lizard/ashwalker))
+	if(is_species(L, /datum/species/lizard/ashwalker) || HAS_TRAIT(L, TRAIT_ASHRESISTANCE))
 		if(L.getStaminaLoss() < (STAMINA_CRIT - 40))
 			L.adjustStaminaLoss(4)
 		return

--- a/modular_splurt/code/datums/traits/good.dm
+++ b/modular_splurt/code/datums/traits/good.dm
@@ -13,3 +13,23 @@
 	if(!quirk_holder)
 		return
 	quirk_holder.maxHealth *= 0.909 //close enough
+
+/datum/quirk/ashresistance
+	name = "Ashen Resistance"
+	desc = "Your form is naturally adapted to the burning sheets of ash that coat volcanic worlds."
+	value = 2 //Is not actually THAT good. Does not grant breathing and does stamina damage to the point you are unable to attack. Crippling on lavaland, but you'll survive. Is not a replacement for SEVA suits for this reason. Can be adjusted.
+	mob_trait = TRAIT_ASHRESISTANCE
+	medical_record_text = "Patient has an abnormally thick epidermis."
+	gain_text = "<span class='notice'>You feel resistant to burning brimstone.</span>"
+	lose_text = "<span class='notice'>You feel less as if your flesh is more flamamble.</span>"
+
+/* --FALLBACK SYSTEM INCASE THE TRAIT FAILS TO WORK. Do NOT enable this without editing ash_storm.dm to deal stamina damage with ash immunity.
+/datum/quirk/ashresistance/add()
+	quirk_holder.weather_immunities |= "ash"
+
+/datum/quirk/ashresistance/remove()
+	if(!quirk_holder)
+		return
+	quirk_holder.weather_immunities -= "ash"
+*/
+


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Ash resistance trait for two points.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
Flavor, and will eventually allow us to make more lavaland races that are immune to ash without our current hacky stuff.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Nay.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
add: New trait. Ash Resistance. Two points. Does what it says on the tin!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
