### PR TITLE
Mime + Clown masks can be examined through

### DIFF
--- a/modular_splurt/code/modules/clothing/masks/gasmask.dm
+++ b/modular_splurt/code/modules/clothing/masks/gasmask.dm
@@ -7,3 +7,13 @@
 	icon_state = "radmask"
 	item_state = "radmask"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 30, "fire" = 10, "acid" = 10)
+
+/obj/item/clothing/mask/gas/mime //Smaaalll edit here by Yawet. Makes the mime mask only hide the facial hair of an individual. Allows them to be examined (to see flavor text), and stops it from hiding ears. On request of Jglitch.
+	flags_inv = HIDEFACIALHAIR
+
+/obj/item/clothing/mask/gas/clown_hat // Not requested, but changed to allow examining too.
+	flags_inv = HIDEFACIALHAIR
+
+/obj/item/clothing/mask/gas/clown_hat_polychromic //Ditto
+	flags_inv = HIDEFACIALHAIR
+


### PR DESCRIPTION
Requested PR. One-liners.
## Changelog

:cl:
qol: Clown + Mime masks now no longer have the flags of default gas masks, nor should they have. This was fixed in more modern code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
