### PR TITLE
{TESTMERGE ONLY FOR NOW} Flavortext hide bypasses

### DIFF
--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		var/unknown = L.get_visible_name() == "Unknown"
 		if(!unknown && iscarbon(target))
 			var/mob/living/carbon/C = L
-			unknown = (C.wear_mask && (C.wear_mask.flags_inv & HIDEFACE)) || (C.head && (C.head.flags_inv & HIDEFACE))
+			unknown = (C.wear_mask && (C.wear_mask.flags_inv & HIDEFACE) && !isobserver(user)) || (C.head && (C.head.flags_inv & HIDEFACE) && !isobserver(user)) //MASSIVE nonmodular edit. Has to be done here - Yawet330 / Making ghosts ignore gas-masks
 			if(show_on_naked && ishuman(C))
 				var/mob/living/carbon/human/H = C
 				unknown = (unknown || (H.w_uniform || H.wear_suit))


### PR DESCRIPTION
Title.
## Changelog

:cl:
qol: Ghosts can now bypass ANY requirement for seeing flavortext and OOC notes
admin: Staff when aghosting get the same things, so you can easily see peoples OOC notes if disputes come up, and they're in something that prevents examines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
