### PR TITLE
{TESTMERGE ONLY} Smithing + Lavaland fixes and changes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1600,6 +1600,7 @@
 /obj/item/circuitboard/machine/smoke_machine,
 /obj/item/circuitboard/machine/autolathe,
 /obj/item/circuitboard/machine/protolathe,
+/obj/item/storage/box/disks_plantgene,
 /obj/item/circuitboard/machine/circuit_imprinter,
 /obj/item/circuitboard/computer/rdconsole/production,
 /turf/open/floor/plasteel/dark,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1600,7 +1600,8 @@
 /obj/item/circuitboard/machine/smoke_machine,
 /obj/item/circuitboard/machine/autolathe,
 /obj/item/circuitboard/machine/protolathe,
-/obj/item/circuitboard/computer/research,
+/obj/item/circuitboard/machine/circuit_imprinter,
+/obj/item/circuitboard/computer/rdconsole/production,
 /turf/open/floor/plasteel/dark,
 /area/ruin/lavaland/unpowered/syndicate_lava_base/cargo)
 "ft" = (

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -173,7 +173,7 @@
 
 /obj/structure/anvil/proc/tryfinish(mob/user)
 	var/artifactchance = 0
-	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/5 + itemqualitymax //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
+	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/2 + itemqualitymax //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
 	if(!artifactrolled)
 		artifactchance = (1+(user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/4))/1500 //Reduced from 2500 temporarily. Should help that percentage get above 1% on the RAND()
 		//artifactrolled = TRUE --Disabled because this is a shitty mechanic.

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -174,8 +174,8 @@
 /obj/structure/anvil/proc/tryfinish(mob/user)
 	var/artifactchance = 0
 	var/stepexperience = currentsteps + currentquality
-	var/finalexperience = FLOOR((150 * (stepexperience + currentquality)),150) //A total of 16x the amount of EXP at MAX, with a minimum gain of 150, Keep in mind that this is of course only possible with a max-tier anvil and an already insanely high level. Just makes earlier levels faster.
-	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/20 + itemqualitymax //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
+	var/finalexperience = 150 *(stepexperience + currentquality)//A total of 16x the amount of EXP at MAX, with a minimum gain of 150, Keep in mind that this is of course only possible with a max-tier anvil and an already insanely high level. Just makes earlier levels faster.
+	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/10 + itemqualitymax //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
 	if(!artifactrolled)
 		artifactchance = (1+(user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/4))/1500 //Reduced from 2500 temporarily. Should help that percentage get above 1% on the RAND()
 		//artifactrolled = TRUE --Disabled because this is a shitty mechanic.
@@ -195,7 +195,10 @@
 		outrightfailchance = 1
 		artifactrolled = FALSE
 		if(user.mind.skill_holder)
-			user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, finalexperience, 500, silent = FALSE) //Made more forgiving for lower levels and terrible anvils.
+			if(currentquality <= 1)
+				user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 200, 50000, silent = FALSE)
+			else
+				user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, finalexperience, 50000, silent = FALSE) //Made more forgiving for lower levels and terrible anvils.
 	for(var/i in smithrecipes)
 		if(i == stepsdone)
 			var/turf/T = get_turf(user)
@@ -232,7 +235,10 @@
 			outrightfailchance = 1
 			artifactrolled = FALSE
 			if(user.mind.skill_holder)
-				user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, finalexperience, 5000, silent = FALSE) //Adjusted to have less... funny values
+				if(currentquality <= 1)
+					user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 200, 50000, silent = FALSE)
+				else
+					user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, finalexperience, 50000, silent = FALSE) //Made more forgiving for lower levels and terrible anvils.
 			break
 
 /obj/structure/anvil/debugsuper

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -227,7 +227,7 @@
 				if(0 to 5)
 					finisheditem.desc =  "It looks to be better than average."
 				if(6 to 8)
-					finisheditem.desc =  "It looks to be a masterpiece"
+					finisheditem.desc =  "It looks to be a masterpiece."
 				if(9 to INFINITY)
 					finisheditem.desc =  "It is positively radiant, a legendary piece."
 			workpiece_state = FALSE

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -175,7 +175,7 @@
 	var/artifactchance = 0
 	var/stepexperience = currentsteps + currentquality
 	var/finalexperience = 150 *(stepexperience + currentquality)//A total of 16x the amount of EXP at MAX, with a minimum gain of 150, Keep in mind that this is of course only possible with a max-tier anvil and an already insanely high level. Just makes earlier levels faster.
-	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/5 + itemqualitymax //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
+	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/2 + itemqualitymax //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
 	if(!artifactrolled)
 		artifactchance = (1+(user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/4))/1500 //Reduced from 2500 temporarily. Should help that percentage get above 1% on the RAND()
 		//artifactrolled = TRUE --Disabled because this is a shitty mechanic.

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -196,9 +196,9 @@
 		artifactrolled = FALSE
 		if(user.mind.skill_holder)
 			if(currentquality <= 1)
-				user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 200, 50000, silent = FALSE)
+				user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 200, 500000, silent = FALSE)
 			else
-				user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, finalexperience, 50000, silent = FALSE) //Made more forgiving for lower levels and terrible anvils.
+				user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, finalexperience, 500000, silent = FALSE) //Made more forgiving for lower levels and terrible anvils.
 	for(var/i in smithrecipes)
 		if(i == stepsdone)
 			var/turf/T = get_turf(user)
@@ -239,9 +239,9 @@
 			artifactrolled = FALSE
 			if(user.mind.skill_holder)
 				if(currentquality <= 1)
-					user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 200, 50000, silent = FALSE)
+					user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 200, 500000, silent = FALSE)
 				else
-					user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, finalexperience, 50000, silent = FALSE) //Made more forgiving for lower levels and terrible anvils.
+					user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, finalexperience, 500000, silent = FALSE) //Made more forgiving for lower levels and terrible anvils.
 			break
 
 /obj/structure/anvil/debugsuper

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -173,9 +173,7 @@
 
 /obj/structure/anvil/proc/tryfinish(mob/user)
 	var/artifactchance = 0
-	var/stepexperience = currentsteps + currentquality
-	var/finalexperience = 150 *(stepexperience + currentquality)//A total of 16x the amount of EXP at MAX, with a minimum gain of 150, Keep in mind that this is of course only possible with a max-tier anvil and an already insanely high level. Just makes earlier levels faster.
-	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/2 + itemqualitymax //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
+	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/5 + itemqualitymax //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
 	if(!artifactrolled)
 		artifactchance = (1+(user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/4))/1500 //Reduced from 2500 temporarily. Should help that percentage get above 1% on the RAND()
 		//artifactrolled = TRUE --Disabled because this is a shitty mechanic.
@@ -195,10 +193,7 @@
 		outrightfailchance = 1
 		artifactrolled = FALSE
 		if(user.mind.skill_holder)
-			if(currentquality <= 1)
-				user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 200, 500000, silent = FALSE)
-			else
-				user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, finalexperience, 500000, silent = FALSE) //Made more forgiving for lower levels and terrible anvils.
+			user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 200, 500000, silent = FALSE)
 	for(var/i in smithrecipes)
 		if(i == stepsdone)
 			var/turf/T = get_turf(user)
@@ -230,6 +225,15 @@
 					finisheditem.desc =  "It looks to be a masterpiece."
 				if(9 to INFINITY)
 					finisheditem.desc =  "It is positively radiant, a legendary piece."
+			var/stepexperience = currentsteps + finisheditem.quality
+			var/finalexperience = 150 *(stepexperience + finisheditem.quality)//A total of 16x the amount of EXP at MAX, with a minimum gain of 150, Keep in mind that this is of course only possible with a max-tier anvil and an already insanely high level. Just makes earlier levels faster.
+			if(user.mind.skill_holder)
+				if(currentquality <= 1)
+					user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 400, 500000, silent = FALSE) //Incentivises not spamming Slag
+				else
+					user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, finalexperience, 500000, silent = FALSE) //Made more forgiving for lower levels and terrible anvils.
+
+
 			workpiece_state = FALSE
 			finisheditem.set_custom_materials(workpiece_material)
 			currentquality = anvilquality
@@ -237,11 +241,6 @@
 			currentsteps = 0
 			outrightfailchance = 1
 			artifactrolled = FALSE
-			if(user.mind.skill_holder)
-				if(currentquality <= 1)
-					user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 200, 500000, silent = FALSE)
-				else
-					user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, finalexperience, 500000, silent = FALSE) //Made more forgiving for lower levels and terrible anvils.
 			break
 
 /obj/structure/anvil/debugsuper

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -175,7 +175,7 @@
 	var/artifactchance = 0
 	var/stepexperience = currentsteps + currentquality
 	var/finalexperience = FLOOR((150 * (stepexperience + currentquality)),150) //A total of 16x the amount of EXP at MAX, with a minimum gain of 150, Keep in mind that this is of course only possible with a max-tier anvil and an already insanely high level. Just makes earlier levels faster.
-	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/20 //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
+	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/20 + itemqualitymax //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
 	if(!artifactrolled)
 		artifactchance = (1+(user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/4))/1500 //Reduced from 2500 temporarily. Should help that percentage get above 1% on the RAND()
 		//artifactrolled = TRUE --Disabled because this is a shitty mechanic.

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -211,7 +211,10 @@
 				finisheditem.quality = currentquality * 3 //This isn't actually that good due to the nonlinear scale of your armor pen.
 				finisheditem.artifact = TRUE
 			else
-				finisheditem.quality = min(currentquality, combinedqualitymax) //Changed so better smiths can make better gear regardless of their anvil. WILL HAVE TO BE TWEAKED, POSSIBLY.
+				if(combinedqualitymax >= 0)
+					finisheditem.quality = min(currentquality, combinedqualitymax) //Changed so better smiths can make better gear regardless of their anvil. WILL HAVE TO BE TWEAKED, POSSIBLY.
+				else
+					finisheditem.quality = min(currentquality, itemqualitymax)
 			switch(finisheditem.quality)
 				if(-1000 to -8)
 					finisheditem.desc =  "It looks to be the most awfully made object you've ever seen."

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -175,7 +175,7 @@
 	var/artifactchance = 0
 	var/stepexperience = currentsteps + currentquality
 	var/finalexperience = 150 *(stepexperience + currentquality)//A total of 16x the amount of EXP at MAX, with a minimum gain of 150, Keep in mind that this is of course only possible with a max-tier anvil and an already insanely high level. Just makes earlier levels faster.
-	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/10 + itemqualitymax //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
+	var/combinedqualitymax = user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/5 + itemqualitymax //Makes sure that better smiths can make better items, even with a worse anvil. Encourages actually levelling up, instead of meta-rushing antag gear
 	if(!artifactrolled)
 		artifactchance = (1+(user.mind.get_skill_level(/datum/skill/level/dwarfy/blacksmithing)/4))/1500 //Reduced from 2500 temporarily. Should help that percentage get above 1% on the RAND()
 		//artifactrolled = TRUE --Disabled because this is a shitty mechanic.

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -226,7 +226,7 @@
 				if(9 to INFINITY)
 					finisheditem.desc =  "It is positively radiant, a legendary piece."
 			var/stepexperience = currentsteps + finisheditem.quality
-			var/finalexperience = 150 *(stepexperience + finisheditem.quality)//A total of 16x the amount of EXP at MAX, with a minimum gain of 150, Keep in mind that this is of course only possible with a max-tier anvil and an already insanely high level. Just makes earlier levels faster.
+			var/finalexperience = (150 *(stepexperience + finisheditem.quality))/5 //A total of 16x the amount of EXP at MAX, with a minimum gain of 150, Keep in mind that this is of course only possible with a max-tier anvil and an already insanely high level. Just makes earlier levels faster.
 			if(user.mind.skill_holder)
 				if(currentquality <= 1)
 					user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 400, 500000, silent = FALSE) //Incentivises not spamming Slag

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -8,6 +8,7 @@
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON //yeah ok
 	slot_flags = ITEM_SLOT_BELT
+	obj_flags = UNIQUE_RENAME	
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 6
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'


### PR DESCRIPTION
We do a bit of reworking.

:cl:
add: Smithing scaling mechanics! Better smiths actually make better gear...
fix: Lavaland Syndiebase now actually gets the correct boards to setup R&D.
fix: Artifact scaling was fixed.
tweak: Artifacts can now be made multiple times on the same anvil, without it being a debug.
add: Plant data disks to Syndicate lavaland's crates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
