### PR TITLE
Security Pouches

### DIFF
--- a/modular_splurt/code/game/object/items/storage/bags.dm
+++ b/modular_splurt/code/game/object/items/storage/bags.dm
@@ -1,0 +1,18 @@
+/obj/item/storage/bag/security
+	name = "security pouch"
+	desc = "A pouch for small security items that manages to hang where you would normally put things in your pocket."
+	icon = 'icons/obj/items_and_weapons.dmi'
+	icon_state = "ammopouch"
+	slot_flags = ITEM_SLOT_POCKETS
+	w_class = WEIGHT_CLASS_BULKY
+	resistance_flags = FLAMMABLE
+
+/obj/item/storage/bag/security/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.max_combined_w_class = INFINITY
+	STR.max_items = 5
+	STR.display_numerical_stacking = TRUE
+	STR.can_hold = typecacheof(list(/obj/item/restraints/handcuffs, /obj/item/restraints/handcuffs/cable/zipties, /obj/item/assembly/flash,
+	/obj/item/reagent_containers/food/snacks/donut, /obj/item/melee/classic_baton/telescopic, /obj/item/grenade/flashbang, /obj/item/grenade/smokebomb, /obj/item/device/hailer))

--- a/modular_splurt/code/modules/vending/security.dm
+++ b/modular_splurt/code/modules/vending/security.dm
@@ -4,7 +4,8 @@
 		/obj/item/device/hailer = 10,
 		/obj/item/clothing/suit/armor/vest/peacekeeper = 5,
 		/obj/item/clothing/suit/armor/vest/metrocop = 2,
-		/obj/item/clothing/head/helmet/metrocop = 2
+		/obj/item/clothing/head/helmet/metrocop = 2,
+		/obj/item/storage/bag/security = 10
 	)
 	var/list/extra_contraband = list(
 		/obj/item/storage/belt/slut = 5,


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds a Security Pouch for holding small items such as Cuffs, Flashes, and Donuts in order to save space in pockets and bags

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game

Security needs a little extra storage space for all the small things they carry, why not have a tool pouch of their own?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?

No

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
add: Added a Security Pouch, available from SecTech Vendors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
