### PR TITLE
Gun tweaks

### DIFF
--- a/code/modules/cargo/packs/armory.dm
+++ b/code/modules/cargo/packs/armory.dm
@@ -59,6 +59,16 @@
 					/obj/item/gun/energy/e_gun/dragnet)
 	crate_name = "anti riot net guns crate"
 
+/datum/supply_pack/security/armory/pmcenergy
+		name = "PMC guns crate"
+	desc = "Contains three advanced PMC Energy Guns, capable of firing nonlethal disablers, tasers and lethal blasts of light. Requires Armory access to open."
+	cost = 5000
+	contains = list(/obj/item/gun/energy/e_gun/stun,
+					/obj/item/gun/energy/e_gun/stun,
+					/obj/item/gun/energy/e_gun/stun)
+	crate_name = "Tactical Energy Guns"
+	crate_type = /obj/structure/closet/crate/secure/plasma
+
 /datum/supply_pack/security/armory/energy
 	name = "Energy Guns Crate"
 	desc = "Contains three Energy Guns, capable of firing both nonlethal and lethal blasts of light. Requires Armory access to open."

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -28,10 +28,10 @@
 
 /obj/item/gun/energy/e_gun/stun
 	name = "tactical energy gun"
-	desc = "Military issue energy gun, is able to fire stun rounds."
+	desc = "Military issue energy gun, very robust for security forces."
 	icon_state = "energytac"
 	ammo_x_offset = 2
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode/spec, /obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
+	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
 
 /obj/item/gun/energy/e_gun/old
 	name = "prototype energy gun"

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -46,6 +46,7 @@
 	can_flashlight = 1
 	flight_x_offset = 18
 	flight_y_offset = 12
+	ammo_type = list(/obj/item/projectile/beam/pulse/shotgun, /obj/item/projectile/energy/electrode/security/hos, /obj/item/ammo_casing/energy/laser)
 
 /obj/item/gun/energy/pulse/carbine/loyalpin
 	pin = /obj/item/firing_pin/implant/mindshield
@@ -58,6 +59,7 @@
 	icon_state = "pulse_pistol"
 	item_state = "gun"
 	cell_type = "/obj/item/stock_parts/cell/pulse/pistol"
+	ammo_type = list(/obj/item/projectile/beam/pulse/shotgun, /obj/item/projectile/energy/electrode/security/hos, /obj/item/ammo_casing/energy/laser)
 
 /obj/item/gun/energy/pulse/pistol/loyalpin
 	pin = /obj/item/firing_pin/implant/mindshield

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -98,7 +98,7 @@
 /obj/item/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"
-	damage = 50
+	damage = 65
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 	tracer_type = /obj/effect/projectile/tracer/pulse
@@ -116,6 +116,7 @@
 
 /obj/item/projectile/beam/pulse/heavy
 	name = "heavy pulse laser"
+	damage = 90
 	icon_state = "pulse1_bl"
 	var/life = 20
 

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -2,12 +2,12 @@
 	name = "electrode"
 	icon_state = "spark"
 	color = "#FFFF00"
-	nodamage = TRUE
 	knockdown = 60
 	knockdown_stamoverride = 36
 	knockdown_stam_max = 50
 	stutter = 10
 	jitter = 20
+	stamina = 140
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 14
 	pixels_per_second = TILES_TO_PIXELS(16.667)
@@ -52,7 +52,7 @@
 /obj/item/projectile/energy/electrode/security/hos
 	tase_duration = 20
 	knockdown = 0
-	stamina = 40
+	stamina = 50
 	knockdown_stamoverride = 36
 	knockdown_stam_max = 50
 	strong_tase = FALSE


### PR DESCRIPTION
Adjustments to taser shots, pulse weapons, and bringing back the missed tactical E-guns to cargo.


A PR related to pulse weapons and tasers, the lesser pulse weapons are made slightly less combat viable, but more ideal as stun options, while the "real deal" is a far deadlier option that's now available to admins and certain ERTs.


## Why It's Good For The Game

It tweaks the weapons and provides a few more weapon alternatives for security, also slightly buffs the Head of Security's taser to be slightly better than normal tasers to encourage its use.

## A Port?

Not a port

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
tweak: tweaked old code and current weapons.
balance: rebalanced the weapons.
fix: fixed some of the broken references
wip: Prone to further tweaks.
experiment: experimental for testing.


:cl:Jasmine:cl:
