### PR TITLE
Another smol donator batch

### DIFF
--- a/code/__SPLURTCODE/DEFINES/is_helpers.dm
+++ b/code/__SPLURTCODE/DEFINES/is_helpers.dm
@@ -1,4 +1,7 @@
 #define isclownjob(x) (_isclownjob(x))
+
+#define isqareen(A) (istype(A, /mob/living/simple_animal/qareen))
+
 // Hyperstation Stuff
 #define iswendigo(A) (istype(A, /mob/living/carbon/wendigo))
 

--- a/config/entries/donator.txt
+++ b/config/entries/donator.txt
@@ -8,4 +8,4 @@
 
 #TIER_2_DONATORS test_ckey
 
-TIER_3_DONATORS mosleyif
+#TIER_3_DONATORS test_ckey

--- a/config/entries/donator.txt
+++ b/config/entries/donator.txt
@@ -8,4 +8,4 @@
 
 #TIER_2_DONATORS test_ckey
 
-#TIER_3_DONATORS test_ckey
+TIER_3_DONATORS mosleyif

--- a/modular_splurt/code/_DEFINES/is_helpers.dm
+++ b/modular_splurt/code/_DEFINES/is_helpers.dm
@@ -1,1 +1,0 @@
-#define isqareen(A) (istype(A, /mob/living/simple_animal/qareen))

--- a/modular_splurt/code/modules/client/loadout/donator/first_tier.dm
+++ b/modular_splurt/code/modules/client/loadout/donator/first_tier.dm
@@ -1,11 +1,26 @@
-/datum/gear/donator/hospitaller
+//Misc
+/datum/gear/donator/portallight
+	name = "Portal Fleshlight and Underwear"
+	path = /obj/item/storage/box/portallight
+	ckeywhitelist = list()
+	donator_group_id = DONATOR_GROUP_TIER_1
+
+//Suits
+/datum/gear/donator/suit
+	slot = ITEM_SLOT_OCLOTHING
+
+/datum/gear/donator/suit/hospitaller
 	name = "Crusader costume"
 	slot = ITEM_SLOT_OCLOTHING
 	path = /obj/item/clothing/suit/armor/riot/chaplain/hospitaller/loadout
 	ckeywhitelist = list()
 	donator_group_id = DONATOR_GROUP_TIER_1
 
-/datum/gear/donator/crown/fancy
+//Head
+/datum/gear/donator/head
+	slot = ITEM_SLOT_HEAD
+
+/datum/gear/donator/head/crown/fancy
 	name = "magnificent crown"
 	slot = ITEM_SLOT_HEAD
 	path = /obj/item/clothing/head/crown/fancy

--- a/modular_splurt/code/modules/client/loadout/donator/first_tier.dm
+++ b/modular_splurt/code/modules/client/loadout/donator/first_tier.dm
@@ -4,3 +4,10 @@
 	path = /obj/item/clothing/suit/armor/riot/chaplain/hospitaller/loadout
 	ckeywhitelist = list()
 	donator_group_id = DONATOR_GROUP_TIER_1
+
+/datum/gear/donator/crown/fancy
+	name = "magnificent crown"
+	slot = ITEM_SLOT_HEAD
+	path = /obj/item/clothing/head/crown/fancy
+	ckeywhitelist = list()
+	donator_group_id = DONATOR_GROUP_TIER_1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4212,7 +4212,6 @@
 #include "modular_splurt\code\__HELPERS\icons.dm"
 #include "modular_splurt\code\__HELPERS\matrices.dm"
 #include "modular_splurt\code\__HELPERS\unsorted.dm"
-#include "modular_splurt\code\_DEFINES\is_helpers.dm"
 #include "modular_splurt\code\_globalvars\lists\global_lewd.dm"
 #include "modular_splurt\code\_globalvars\lists\mapping.dm"
 #include "modular_splurt\code\_globalvars\lists\mobs.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
adds some more donator thingies
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
yes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
add: added two new items to the donator loadout, one of them being a portal fleshlight pack
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
