### PR TITLE
Buffed Hiero Club, Chipped King Goat

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1223,8 +1223,8 @@
 	attack_verb = list("clubbed", "beat", "pummeled")
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	actions_types = list(/datum/action/item_action/vortex_recall, /datum/action/item_action/toggle_unfriendly_fire)
-	var/cooldown_time = 20 //how long the cooldown between non-melee ranged attacks is
-	var/chaser_cooldown = 81 //how long the cooldown between firing chasers at mobs is
+	var/cooldown_time = 15 //how long the cooldown between non-melee ranged attacks is
+	var/chaser_cooldown = 60 //how long the cooldown between firing chasers at mobs is
 	var/chaser_timer = 0 //what our current chaser cooldown is
 	var/chaser_speed = 0.8 //how fast our chasers are
 	var/timer = 0 //what our current cooldown is
@@ -1275,7 +1275,7 @@
 			if(isliving(target) && chaser_timer <= world.time) //living and chasers off cooldown? fire one!
 				chaser_timer = world.time + chaser_cooldown
 				var/obj/effect/temp_visual/hierophant/chaser/C = new(get_turf(user), user, target, chaser_speed, friendly_fire_check)
-				C.damage = 15
+				C.damage = 25
 				C.monster_damage_boost = TRUE
 				log_combat(user, target, "fired a chaser at", src)
 			else
@@ -1392,10 +1392,10 @@
 		new /obj/effect/temp_visual/hierophant/telegraph/teleport(source, user)
 		for(var/t in RANGE_TURFS(1, T))
 			var/obj/effect/temp_visual/hierophant/blast/B = new /obj/effect/temp_visual/hierophant/blast(t, user, TRUE) //blasts produced will not hurt allies
-			B.damage = 15
+			B.damage = 25
 		for(var/t in RANGE_TURFS(1, source))
 			var/obj/effect/temp_visual/hierophant/blast/B = new /obj/effect/temp_visual/hierophant/blast(t, user, TRUE) //but absolutely will hurt enemies
-			B.damage = 15
+			B.damage = 25
 		for(var/mob/living/L in range(1, source))
 			INVOKE_ASYNC(src, .proc/teleport_mob, source, L, T, user) //regardless, take all mobs near us along
 		sleep(6) //at this point the blasts detonate
@@ -1456,7 +1456,7 @@
 		if(!J)
 			return
 		var/obj/effect/temp_visual/hierophant/blast/B = new(J, user, friendly_fire_check)
-		B.damage = 15
+		B.damage = 25
 		B.monster_damage_boost = TRUE
 		previousturf = J
 		J = get_step(previousturf, dir)
@@ -1469,7 +1469,7 @@
 	sleep(2)
 	for(var/t in RANGE_TURFS(1, T))
 		var/obj/effect/temp_visual/hierophant/blast/B = new(t, user, friendly_fire_check)
-		B.damage = 15 //keeps monster damage boost due to lower damage (now added to all damage due to reduction to 15, 30dmg 50AP isn't cool)
+		B.damage = 25
 
 
 //Just some minor stuff

--- a/modular_sand/code/modules/mob/living/simple_animal/hostile/megafauna/king_of_goats.dm
+++ b/modular_sand/code/modules/mob/living/simple_animal/hostile/megafauna/king_of_goats.dm
@@ -66,6 +66,17 @@ Difficulty: Insanely Hard
 	glorythreshold = 50
 	crusher_loot = list(/obj/item/crusher_trophy/king_goat)
 
+
+/mob/living/simple_animal/hostile/megafauna/king/Initialize(mapload)
+	. = ..()
+	internal = new /obj/item/gps/internal/king(src)
+
+/obj/item/gps/internal/king
+	icon_state = null
+	gpstag = "Regal Signal"
+	desc = "Must lead to a true king."
+	invisibility = 100
+
 /mob/living/simple_animal/hostile/megafauna/king/ex_act(severity, target, origin)
 	switch (severity)
 		if (1)


### PR DESCRIPTION
# About The Pull Request

Added +10 damage to all of the hierophant clubs attacks and lowered their cooldown by a few seconds, this was needed as the hierophant club was hot ass previously.

Brought the King Goat to the vet and chipped him, he can now be found on any GPS with the "Regal Signal"

## Why It's Good For The Game

There's no downside to adding a GPS signal to king goat, just makes him a lot less annoying to find. The hierophant club was absolutely unusable in any lavaland fights, I didn't make it overpowered, just... Less unusable...

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl: 567Turtle
add: King Goat GPS Signal (Regal Signal)
balance: Balanced the hierophant club so its now decent
:cl:
