### PR TITLE
Fix pleasuremaw harddel

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -42,7 +42,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	if(delete_after_roundstart)
 		qdel(src)
 
-/obj/effect/landmark/start/New()
+/obj/effect/landmark/start/Initialize(mapload)
 	GLOB.start_landmarks_list += src
 	if(jobspawn_override)
 		if(!GLOB.jobspawn_overrides[name])

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -42,7 +42,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	if(delete_after_roundstart)
 		qdel(src)
 
-/obj/effect/landmark/start/Initialize(mapload)
+/obj/effect/landmark/start/New()
 	GLOB.start_landmarks_list += src
 	if(jobspawn_override)
 		if(!GLOB.jobspawn_overrides[name])

--- a/modular_splurt/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
@@ -400,6 +400,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 
 /obj/item/milking_machine/pleasuremaw/Destroy()
 	STOP_PROCESSING(SSobj, src) //please no
+	QDEL_NULL(inserted_item)
 	borg_self = null
 	. = ..()
 


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Pleasuremaw harddel fix.
Related output of reftracker on localhost, with no borgs spawned, map: Kilostation (I don't know why pleasuremaw typepaths exist without any borgs being spawned, but evidently they do!)
> [2022-08-27 11:33:34.540] ## REF SEARCH Found /obj/item/robot_module [0x200e906] in /obj/item/reagent_containers/glass/beaker/large's [0x200e904] loc var. World -> /obj/item/reagent_containers/glass/beaker/large
> [2022-08-27 11:33:34.544] ## REF SEARCH Found /obj/item/robot_module [0x200e906] in list World -> /obj/item/reagent_containers/glass/beaker/large [0x200e904] -> locs (list).

And then another one of these for a second pleasuremaw.

I haven't tested this beyond ensuring this stops the harddel, in particular I haven't tested borgs, but I don't see how this would break anything.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:Zirok
fix: Fixed something related to borg's pleasuremaw. Please report any issues with it!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
