### PR TITLE
Makes the space hotel's pool functional.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -2205,6 +2205,7 @@
 	dir = 1
 	},
 /obj/item/crowbar,
+/obj/item/vending_refill/kink,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/hotel/workroom)
 "gI" = (
@@ -4093,10 +4094,10 @@
 /area/ruin/space/has_grav/hotel/pool)
 "li" = (
 /obj/effect/light_emitter,
-/turf/open/floor/plating/beach/water,
+/turf/open/pool,
 /area/ruin/space/has_grav/hotel/pool)
 "lj" = (
-/turf/open/floor/plating/beach/water,
+/turf/open/pool,
 /area/ruin/space/has_grav/hotel/pool)
 "lk" = (
 /obj/structure/chair{
@@ -4388,7 +4389,7 @@
 /area/ruin/space/has_grav/hotel/security)
 "lP" = (
 /obj/item/bikehorn/rubberducky,
-/turf/open/floor/plating/beach/water,
+/turf/open/pool,
 /area/ruin/space/has_grav/hotel/pool)
 "lQ" = (
 /obj/structure/table,
@@ -5004,6 +5005,18 @@
 /obj/effect/baseturf_helper/space,
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/pool)
+"or" = (
+/obj/item/toy/poolnoodle/yellow,
+/turf/open/pool,
+/area/ruin/space/has_grav/hotel/pool)
+"oB" = (
+/obj/machinery/vending/kink,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/hotel)
+"pc" = (
+/obj/structure/pool/Lboard,
+/turf/open/pool,
+/area/ruin/space/has_grav/hotel/pool)
 "sN" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable/yellow{
@@ -5014,6 +5027,101 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/power)
+"vC" = (
+/obj/structure/pool/ladder{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/pool,
+/area/ruin/space/has_grav/hotel/pool)
+"yH" = (
+/obj/item/toy/poolnoodle/blue,
+/turf/open/pool,
+/area/ruin/space/has_grav/hotel/pool)
+"DO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/toy/poolnoodle/yellow,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/hotel/pool)
+"Fw" = (
+/obj/structure/closet/athletic_mixed,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/hotel/pool)
+"FI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/toy/poolnoodle/blue,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/hotel/pool)
+"GG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/pool/controller,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/hotel/pool)
+"JS" = (
+/obj/structure/pool/ladder{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/open/pool,
+/area/ruin/space/has_grav/hotel/pool)
+"Nm" = (
+/obj/item/toy/poolnoodle/red,
+/turf/open/pool,
+/area/ruin/space/has_grav/hotel/pool)
+"Qo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/pool/filter{
+	pixel_y = -17
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/hotel/pool)
+"Sm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/pool/Rboard,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/hotel/pool)
+"TP" = (
+/obj/machinery/pool/drain,
+/turf/open/pool,
+/area/ruin/space/has_grav/hotel/pool)
 
 (1,1,1) = {"
 aa
@@ -7095,9 +7203,9 @@ jR
 jR
 kQ
 jR
-jR
-jR
-jR
+Fw
+Fw
+Fw
 jR
 kQ
 jR
@@ -7156,7 +7264,7 @@ cF
 cF
 cF
 cF
-eT
+oB
 am
 cJ
 jt
@@ -7307,7 +7415,7 @@ kD
 kD
 kD
 kD
-kD
+FI
 kD
 kD
 kD
@@ -7443,13 +7551,13 @@ jt
 jT
 jR
 kE
-kD
+Qo
 lj
 lj
 lj
 lj
 lj
-lj
+yH
 lj
 lj
 lj
@@ -7514,6 +7622,7 @@ jU
 jR
 kE
 kD
+JS
 lj
 lj
 lj
@@ -7521,8 +7630,7 @@ lj
 lj
 lj
 lj
-lj
-lj
+vC
 kD
 mC
 jR
@@ -7728,7 +7836,7 @@ lj
 lj
 lj
 lj
-lj
+TP
 lj
 lj
 lj
@@ -7801,7 +7909,7 @@ lj
 li
 lj
 lj
-lj
+or
 lj
 kD
 mC
@@ -7866,7 +7974,7 @@ kF
 kR
 lj
 lj
-lj
+Nm
 lj
 lj
 lj
@@ -8074,6 +8182,7 @@ jU
 jR
 kE
 kS
+JS
 lj
 lj
 lj
@@ -8081,8 +8190,7 @@ lj
 lj
 lj
 lj
-lj
-lj
+vC
 kD
 mC
 jR
@@ -8218,7 +8326,7 @@ li
 lj
 lj
 lj
-lj
+pc
 lj
 lj
 lj
@@ -8288,10 +8396,10 @@ kD
 kD
 kD
 kD
+Sm
 kD
 kD
-kD
-kD
+DO
 kD
 kD
 kD
@@ -8493,7 +8601,7 @@ jt
 jR
 jR
 jR
-kU
+GG
 ll
 lt
 ll


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
why hasnt this been done before
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
no?
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
fix: hotel's pool is functional
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
