### PR TITLE
makes random station traits a config

### DIFF
--- a/config/splurt/general.txt
+++ b/config/splurt/general.txt
@@ -5,3 +5,7 @@ ENABLE_GLOBAL_BARKS
 # Max number of infinidorms each mob can use
 # -1 for infinite, 0 to deactivate infinidorms as a whole
 MAX_INFINIDORMS 5
+
+# Weighted station traits
+# If uncommented, the server will pick random station traits according to their weight configuration
+WEIGHTED_STATION_TRAITS

--- a/modular_splurt/code/controllers/configuration/entries/splurt_general.dm
+++ b/modular_splurt/code/controllers/configuration/entries/splurt_general.dm
@@ -2,3 +2,5 @@
 
 /datum/config_entry/number/max_infinidorms
 	config_entry_value = 5
+
+/datum/config_entry/flag/weighted_station_traits

--- a/modular_splurt/code/controllers/subsystem/processing/station.dm
+++ b/modular_splurt/code/controllers/subsystem/processing/station.dm
@@ -1,0 +1,8 @@
+/datum/controller/subsystem/processing/station/SetupTraits()
+	if(fexists(FUTURE_STATION_TRAITS_FILE)) //Station traits were previously configured
+		return ..()
+
+	if(!CONFIG_GET(flag/weighted_station_traits)) //Weighted station traits are deactivated
+		return
+
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4253,6 +4253,7 @@
 #include "modular_splurt\code\controllers\subsystem\discord.dm"
 #include "modular_splurt\code\controllers\subsystem\redbot.dm"
 #include "modular_splurt\code\controllers\subsystem\ticker.dm"
+#include "modular_splurt\code\controllers\subsystem\processing\station.dm"
 #include "modular_splurt\code\datums\ai_laws.dm"
 #include "modular_splurt\code\datums\bark.dm"
 #include "modular_splurt\code\datums\dna.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
idk why this wasn't added on upstream to begin with but yeah. Toggle it off and you'll not have random traits on next rounds
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
intern. voice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
server: Adds a config to toggle random station traits each round on and off
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
