### PR TITLE
Add typing indicators to subtle

### DIFF
--- a/code/__SPLURTCODE/DEFINES/say.dm
+++ b/code/__SPLURTCODE/DEFINES/say.dm
@@ -1,2 +1,8 @@
 //Spans. Robot speech, italics, etc. Applied in compose_message().
 #define SPAN_SMALL "small"
+
+//If the message passed to the emote matches this specific strings we apply typing indicators. Otherwise we don't.
+//This was sadly needed because I cannot think of a simpler way(other than a var on /mob/living) to communicate
+//to the emote code if we want typing indicators or not.
+//Used in say_vr.dm
+#define MAGIC_TYPING_INDICATOR_VALUE "flznmvciwzdhgiewlsfofd"

--- a/code/modules/keybindings/keybind/communication.dm
+++ b/code/modules/keybindings/keybind/communication.dm
@@ -55,7 +55,7 @@
 
 /datum/keybinding/client/communication/subtle_with_indicator/down(client/user)
 	var/mob/M = user.mob
-	M.subtle_typing_indicator()
+	M.subtle_with_indicator()
 	return TRUE
 
 /datum/keybinding/client/communication/subtler

--- a/code/modules/keybindings/keybind/communication.dm
+++ b/code/modules/keybindings/keybind/communication.dm
@@ -48,6 +48,16 @@
 	full_name = "Subtle Emote"
 	clientside = "subtle"
 
+/datum/keybinding/client/communication/subtle_with_indicator
+	hotkey_keys = list("Ctrl5")
+	name = "subtle_with_indicator"
+	full_name = "Subtle with Typing Indicator"
+
+/datum/keybinding/client/communication/subtle_with_indicator/down(client/user)
+	var/mob/M = user.mob
+	M.subtle_typing_indicator()
+	return TRUE
+
 /datum/keybinding/client/communication/subtler
 	hotkey_keys = list("6")
 	name = "Subtler"

--- a/code/modules/keybindings/keybind/communication.dm
+++ b/code/modules/keybindings/keybind/communication.dm
@@ -43,13 +43,13 @@
 	return TRUE
 
 /datum/keybinding/client/communication/subtle
-	hotkey_keys = list("5")
+	hotkey_keys = list("Ctrl5")
 	name = "Subtle"
 	full_name = "Subtle Emote"
 	clientside = "subtle"
 
 /datum/keybinding/client/communication/subtle_with_indicator
-	hotkey_keys = list("Ctrl5")
+	hotkey_keys = list("5")
 	name = "subtle_with_indicator"
 	full_name = "Subtle with Typing Indicator"
 

--- a/code/modules/keybindings/keybind/communication.dm
+++ b/code/modules/keybindings/keybind/communication.dm
@@ -54,7 +54,7 @@
 	full_name = "Subtle with Typing Indicator"
 
 /datum/keybinding/client/communication/subtle_with_indicator/down(client/user)
-	var/mob/M = user.mob
+	var/mob/living/M = user.mob
 	M.subtle_with_indicator()
 	return TRUE
 

--- a/code/modules/mob/living/silicon/robot/update_icons.dm
+++ b/code/modules/mob/living/silicon/robot/update_icons.dm
@@ -1,5 +1,7 @@
 /// this is bad code
 /mob/living/silicon/robot/update_icons()
+	var/typing_indicator_backup = typing_indicator_current //SPLURT EDIT
+
 	cut_overlays()
 	icon_state = module.cyborg_base_icon
 	//Citadel changes start here - Allows modules to use different icon files, and allows modules to specify a pixel offset
@@ -63,3 +65,7 @@
 			icon_state = "[module.cyborg_base_icon]"
 
 	SEND_SIGNAL(src, COMSIG_ROBOT_UPDATE_ICONS)
+
+	//SPLURT EDITS
+	if(typing_indicator_backup)
+		add_overlay(typing_indicator_backup)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -35,6 +35,7 @@
 	return FALSE
 
 /datum/emote/living/subtle/run_emote(mob/user, params, type_override = null)
+	//We use indicators if the message matches the indicator, normally supplied by subtle verbs.
 	var/using_indicators = (params && params == MAGIC_INDICATOR_STRING)
 	if(jobban_isbanned(user, "emote"))
 		to_chat(user, "You cannot send subtle emotes (banned).")
@@ -46,8 +47,8 @@
 		if(using_indicators)
 			user.display_typing_indicator()
 		var/subtle_emote = stripped_multiline_input_or_reflect(user, "Choose an emote to display.", "Subtle", null, MAX_MESSAGE_LEN)
-		if(using_indicators)
-			user.clear_typing_indicator()
+		//We might as well clear indicators regardless, unnecessary clears should not be a problem, and help with stuck indicators.
+		user.clear_typing_indicator()
 		if(subtle_emote && !check_invalid(user, subtle_emote))
 			message = subtle_emote
 		else

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -165,7 +165,7 @@
 
 ///////////////// VERB CODE
 
-/mob/verb/subtle_typing_indicator()
+/mob/living/verb/subtle_typing_indicator()
 	set name = "Subtle_with_indicator"
 	set category = "IC"
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -14,11 +14,6 @@
 		return M.get_top_level_mob()
 	return S
 
-//If the message passed to the emote matches this specific strings we apply typing indicators. Otherwise we don't.
-//This was sadly needed because I cannot think of a simpler way(other than a var on /mob/living) to communicate
-// to the emote code if we want typing indicators or not.
-#define MAGIC_INDICATOR_STRING "flznmvciwzdhgiewlsfofd"
-
 ///////////////// EMOTE CODE
 // Maybe making this as an emote is less messy?
 // It was - ktccd
@@ -36,7 +31,7 @@
 
 /datum/emote/living/subtle/run_emote(mob/user, params, type_override = null)
 	//We use indicators if the message matches the indicator, normally supplied by subtle verbs.
-	var/using_indicators = (params && params == MAGIC_INDICATOR_STRING)
+	var/using_indicators = (params && params == MAGIC_TYPING_INDICATOR_VALUE)
 	if(jobban_isbanned(user, "emote"))
 		to_chat(user, "You cannot send subtle emotes (banned).")
 		return FALSE
@@ -176,7 +171,7 @@
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
-	usr.emote("subtle", message = MAGIC_INDICATOR_STRING)
+	usr.emote("subtle", message = MAGIC_TYPING_INDICATOR_VALUE)
 
 /mob/living/verb/subtle()
 	set name = "Subtle"

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -165,7 +165,7 @@
 
 ///////////////// VERB CODE
 
-/mob/living/verb/subtle_typing_indicator()
+/mob/living/verb/subtle_with_indicator()
 	set name = "Subtle_with_indicator"
 	set category = "IC"
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This PR adds a verb "Subtle-with-indicator", equivalent to subtle but with typing indicators. 
Fixes #494

## Why It's Good For The Game

Typing indicators are essential for long-winded RP to let the other person know that you are working on your post. Should someone not want them they can always use the regular Subtle verb, which this PR does not touch.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
add: Typing indicators have been added to subtle! Note that you may need to update your keybindings to use them(To do so: Character Settings->Keybindings, and then either reset to default at the bottom, or manually bind things to your liking, the new verb is found under the communication group.)
:fix: Borg Typing indicators work again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
