### PR TITLE
unmodularize 2 defines that need to be unique

### DIFF
--- a/code/__DEFINES/citadel_defines.dm
+++ b/code/__DEFINES/citadel_defines.dm
@@ -31,6 +31,7 @@
 #define GENITAL_CAN_TAUR		(1<<11)
 #define CAN_CUM_INTO 			(1<<12) //Sandstorm change
 #define HAS_EQUIPMENT			(1<<13) //nother sandstorm change
+#define GENITAL_CAN_STUFF       (1<<14) //Splurt edit, used for pregnancy
 
 
 #define DEF_VAGINA_SHAPE	"Human"

--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -16,6 +16,9 @@
 #define CHANNEL_DIGEST 1009
 #define CHANNEL_PREYLOOP 1008
 
+//SPLURT channels (idk will most likely break)
+#define CHANNEL_REACTOR_ALERT 1007 // reactor sounds
+
 ///Default range of a sound.
 #define SOUND_RANGE 17
 ///default extra range for sounds considered to be quieter

--- a/code/__SPLURTCODE/DEFINES/cit_defines.dm
+++ b/code/__SPLURTCODE/DEFINES/cit_defines.dm
@@ -4,7 +4,6 @@
 #define GEN_REMOVE_EQUIPMENT "Remove Equipment"
 #define GEN_INSERT_EQUIPMENT "Insert Equipment"
 
-#define GENITAL_CAN_STUFF (1<<14)
 #define GEN_ALLOW_EGG_STUFFING "Allows egg stuffing"
 
 GLOBAL_LIST_INIT(genitals_interactions, list(GEN_REMOVE_EQUIPMENT, GEN_INSERT_EQUIPMENT))

--- a/code/__SPLURTCODE/DEFINES/sound.dm
+++ b/code/__SPLURTCODE/DEFINES/sound.dm
@@ -1,2 +1,0 @@
-//SPLURT channels (idk will most likely break)
-#define CHANNEL_REACTOR_ALERT 1007 // reactor sounds

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -262,7 +262,6 @@
 #include "code\__SPLURTCODE\DEFINES\radiation.dm"
 #include "code\__SPLURTCODE\DEFINES\say.dm"
 #include "code\__SPLURTCODE\DEFINES\signals.dm"
-#include "code\__SPLURTCODE\DEFINES\sound.dm"
 #include "code\__SPLURTCODE\DEFINES\spans.dm"
 #include "code\__SPLURTCODE\DEFINES\species.dm"
 #include "code\__SPLURTCODE\DEFINES\subsystems.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Moves 2 defines from modular Splurt define folders to their original folders. These two(for sounds I'm guessing!) need to be unique, and by moving them elsewhere you're just asking for odd bugs. Rather than spending a few minutes resolving merge conflicts you'll face hours of debugging.
