### PR TITLE
Fix fluid infuser emagging action

### DIFF
--- a/modular_splurt/code/game/object/items/implants/implant_gfluid.dm
+++ b/modular_splurt/code/game/object/items/implants/implant_gfluid.dm
@@ -67,13 +67,33 @@
 
 /obj/item/implant/genital_fluid/emag_act()
 	. = ..()
+	name = "hacked genital fluid implant"
 	use_blacklist = FALSE
+	obj_flags |= EMAGGED
 
 /obj/item/implanter/genital_fluid
 	name = "implanter (genital fluid)"
 	imp_type = /obj/item/implant/genital_fluid
 
+/obj/item/implanter/genital_fluid/hacked
+	name = "implanter (genital fluid (hacked))"
+
+/obj/item/implanter/genital_fluid/hacked/New()
+	. = ..()
+	if(istype(imp, /obj/item/implant/genital_fluid))
+		var/obj/item/implant/genital_fluid/I = imp
+		I.emag_act()
+
 /obj/item/implantcase/genital_fluid
 	name = "implant case - 'Genital Fluid'"
-	desc = "A glass case containing a Genital FLuid Infuser implant."
+	desc = "A glass case containing a Genital Fluid Infuser implant."
 	imp_type = /obj/item/implant/genital_fluid
+
+/obj/item/implantcase/genital_fluid/hacked
+	name = "implant case - 'Genital Fluid (Hacked)'"
+
+/obj/item/implantcase/genital_fluid/hacked/New()
+	. = ..()
+	if(istype(imp, /obj/item/implant/genital_fluid))
+		var/obj/item/implant/genital_fluid/I = imp
+		I.emag_act()

--- a/modular_splurt/code/game/object/items/implants/implantcase.dm
+++ b/modular_splurt/code/game/object/items/implants/implantcase.dm
@@ -1,0 +1,11 @@
+
+/obj/item/implantcase/emag_act(mob/user)
+	. = ..()
+	if(istype(imp, /obj/item/implant/genital_fluid))
+		var/obj/item/implant/genital_fluid/I = imp
+		if(I.obj_flags & EMAGGED)
+			to_chat(user, "<span class='warning'>[src] has no functional safeties to emag.</span>")
+			return
+		to_chat(user, "<span class='notice'>You short out [src]'s safeties.</span>")
+		name = "implant case - 'Genital Fluid (Hacked)'"
+		I.emag_act()

--- a/modular_splurt/code/game/object/items/implants/implantcase.dm
+++ b/modular_splurt/code/game/object/items/implants/implantcase.dm
@@ -1,4 +1,3 @@
-
 /obj/item/implantcase/emag_act(mob/user)
 	. = ..()
 	if(istype(imp, /obj/item/implant/genital_fluid))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4351,6 +4351,7 @@
 #include "modular_splurt\code\game\object\items\implants\implant_gfluid.dm"
 #include "modular_splurt\code\game\object\items\implants\implant_slave.dm"
 #include "modular_splurt\code\game\object\items\implants\implant_slaver.dm"
+#include "modular_splurt\code\game\object\items\implants\implantcase.dm"
 #include "modular_splurt\code\game\object\items\implants\radio_implant.dm"
 #include "modular_splurt\code\game\object\items\lewd_items\leash.dm"
 #include "modular_splurt\code\game\object\items\lewd_items\lewd.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Makes it so the fluid infuser implant is *actually emaggable*. Also adds in hacked versions of the fluid implant for ease of adminbus.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game

The emag action for the implant itself was already in the code, it was just unreachable due to the fact the implant itself was never an item one would see in-game, since it was always contained within either an implant case, implanter, or body. Now emagging an implant case containing the implant will call the emag action on the implant.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?

No.

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
fix: made it so emagging an implant case containing the gfluid implant will call the emag function on the implant
add: pre-emagged variants of the implanter/implant case for adminbus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
