### PR TITLE
New Boxstation random engines!

### DIFF
--- a/_maps/RandomRuins/StationRuins/Box/Engine/splurt/diy.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/splurt/diy.dmm
@@ -417,6 +417,13 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"su" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/radio/intercom{
+	pixel_x = -25
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "sA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -481,6 +488,12 @@
 "uE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"we" = (
+/obj/item/radio/intercom{
+	pixel_x = 25
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -602,6 +615,13 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"Dt" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "Dy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -651,6 +671,9 @@
 "Hu" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
+	},
+/obj/item/radio/intercom{
+	pixel_y = -25
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -771,6 +794,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"Qq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "Qr" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -783,6 +814,9 @@
 /obj/item/flashlight{
 	pixel_x = 1;
 	pixel_y = 5
+	},
+/obj/item/radio/intercom{
+	pixel_y = -25
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -1210,7 +1244,7 @@ kh
 kn
 cx
 uE
-qc
+su
 UY
 bu
 bu
@@ -1319,7 +1353,7 @@ dO
 Sn
 gC
 dx
-Yg
+Qq
 Yg
 Yg
 Yg
@@ -1605,12 +1639,12 @@ TR
 ji
 bu
 bu
-bu
+Dt
 lG
 bu
 bu
 bu
-bu
+we
 qV
 Ng
 zS

--- a/_maps/RandomRuins/StationRuins/Box/Engine/splurt/diy.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/splurt/diy.dmm
@@ -1,0 +1,1736 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/engineering/main)
+"am" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/engineering/main)
+"aB" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/stack/cable_coil/yellow{
+	pixel_y = 10
+	},
+/obj/item/stack/cable_coil/yellow{
+	pixel_y = 5
+	},
+/obj/item/stack/cable_coil/yellow,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"aW" = (
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engineering/main)
+"bu" = (
+/turf/open/floor/plating,
+/area/engineering/main)
+"bG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/engineering/main)
+"bV" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"bY" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"cn" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/box,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"cx" = (
+/turf/closed/wall,
+/area/engineering/main)
+"cH" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/engineering/main)
+"cY" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"dx" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"dB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"dO" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/engineering/main)
+"eq" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"ez" = (
+/obj/structure/cable,
+/obj/machinery/power/floodlight,
+/turf/open/floor/plating,
+/area/engineering/main)
+"eF" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"eG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "boxengine_diyshutters_equipment";
+	name = "Shutter Control";
+	pixel_y = -20;
+	req_access_txt = "10"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "boxengine_diyshutters_equipment"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"gg" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"gC" = (
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engineering/main)
+"iA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"iP" = (
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate/engineering/electrical{
+	name = "solar panel crate"
+	},
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/cable_coil/yellow,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"iV" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/engineering/main)
+"iX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plating,
+/area/engineering/main)
+"ji" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"jI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"jK" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"kh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"kn" = (
+/obj/structure/table,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/item/construction/rld/mini,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"kD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"kR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"ld" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"lG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"lO" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"mn" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 5
+	},
+/obj/item/tank/internals/emergency_oxygen/double,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"mt" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"mO" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 40
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"nw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"nL" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"op" = (
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate/secure/engineering,
+/obj/item/construction/rcd/loaded/upgraded{
+	custom_range = 2;
+	matter = 200;
+	max_matter = 200;
+	name = "Super RCD";
+	pixel_y = -5;
+	ranged = 1
+	},
+/obj/item/construction/rcd/loaded/upgraded{
+	custom_range = 2;
+	matter = 200;
+	max_matter = 200;
+	name = "Super RCD";
+	ranged = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"pj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"qc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/engineering/main)
+"qV" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"rh" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"ry" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"rH" = (
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate/solarpanel_small,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/machinery/light/small,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/cable_coil/yellow,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"rO" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/rglass{
+	amount = 50
+	},
+/obj/item/stack/sheet/rglass{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plating,
+/area/engineering/main)
+"rS" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"sj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = 5
+	},
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"sn" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"sA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"sH" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"sV" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"to" = (
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"tw" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"tE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"tJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"tM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"tV" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/engineering/main)
+"ur" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"uE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"wC" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/plating,
+/area/engineering/main)
+"xc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Generation";
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"xj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"xX" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"yk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"yN" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"zH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"zL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"zN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"zS" = (
+/turf/open/space/basic,
+/area/space)
+"Be" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/engineering/main)
+"Cc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Cm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Ct" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"CB" = (
+/obj/machinery/space_heater,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"CP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Dd" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Dy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"DL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"DX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
+"Eh" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"EI" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/engineering/main)
+"Fl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Gc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"GG" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Hu" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Ie" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Generation";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"In" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Ka" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Kh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "boxengine_diyshutters_equipment"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Kz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engineering/main)
+"Le" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
+"Lg" = (
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Mp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"MD" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-6"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"MO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Nd" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/engineering/main)
+"Ng" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"NP" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Oj" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
+"OV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"Qr" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"QX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Rh" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
+"RG" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
+"RY" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Sn" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"SL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/engineering/main)
+"SO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"Td" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/engineering/main)
+"TR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Un" = (
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"UY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"VN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Generation";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"XN" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/welding{
+	pixel_x = -9;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/cola{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"XX" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Yg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engineering/main)
+"YZ" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space/nearstation)
+"Zp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Zt" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engineering/main)
+"Zz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plating,
+/area/engineering/main)
+"ZA" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"ZF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"ZT" = (
+/turf/template_noop,
+/area/template_noop)
+
+(1,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+zS
+Rh
+zS
+zS
+Rh
+zS
+zS
+Rh
+zS
+zS
+zS
+YZ
+YZ
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(2,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+zS
+tw
+zS
+zS
+tw
+zS
+zS
+tw
+zS
+zS
+zS
+YZ
+Oj
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(3,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+Le
+tw
+tw
+tw
+tw
+tw
+tw
+tw
+tw
+Rh
+Rh
+YZ
+Oj
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(4,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+Le
+tw
+Le
+Le
+tw
+Le
+Le
+tw
+Le
+Le
+tw
+YZ
+Oj
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(5,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+Le
+tw
+tw
+tw
+tw
+tw
+tw
+tw
+tw
+Rh
+Rh
+YZ
+Oj
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(6,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+Le
+tw
+Le
+Le
+tw
+Le
+Le
+tw
+Le
+Le
+tw
+YZ
+Oj
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(7,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+cx
+cx
+to
+Le
+tw
+tw
+tw
+tw
+tw
+tw
+tw
+tw
+Rh
+Rh
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+zS
+"}
+(8,1,1) = {"
+ZT
+ZT
+mt
+Qr
+cx
+Be
+to
+Le
+tw
+Le
+Le
+tw
+Le
+Le
+tw
+Le
+Le
+tw
+YZ
+YZ
+YZ
+tw
+zS
+zS
+zS
+zS
+"}
+(9,1,1) = {"
+ZT
+ZT
+rh
+Un
+gg
+bY
+rS
+Le
+tw
+tw
+tw
+tw
+tw
+tw
+tw
+tw
+Rh
+Rh
+Rh
+zS
+tw
+zS
+zS
+zS
+zS
+zS
+"}
+(10,1,1) = {"
+ZT
+sA
+ZF
+ld
+cx
+cx
+to
+to
+ry
+aa
+aa
+SO
+aa
+aa
+aa
+SO
+SO
+tE
+zS
+zS
+Rh
+zS
+zS
+zS
+zS
+zS
+"}
+(11,1,1) = {"
+Cc
+Ka
+ZF
+kh
+kn
+cx
+uE
+qc
+UY
+bu
+bu
+bV
+bu
+bu
+bu
+bu
+bu
+tJ
+zS
+RG
+YZ
+RG
+zS
+zS
+zS
+zS
+"}
+(12,1,1) = {"
+xX
+NP
+dB
+cY
+aB
+tV
+am
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+Nd
+tJ
+tw
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+"}
+(13,1,1) = {"
+yk
+Ka
+jI
+Un
+Eh
+cx
+zH
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+zN
+zS
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+"}
+(14,1,1) = {"
+bG
+EI
+xc
+dO
+cx
+cx
+kD
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+iX
+Cm
+tw
+YZ
+Oj
+YZ
+Rh
+zS
+zS
+zS
+"}
+(15,1,1) = {"
+dO
+Sn
+gC
+dx
+Yg
+Yg
+Yg
+Yg
+Yg
+DL
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+DX
+zS
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+"}
+(16,1,1) = {"
+Ie
+zL
+QX
+Lg
+ez
+mO
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+aW
+to
+tw
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+"}
+(17,1,1) = {"
+dO
+zL
+QX
+GG
+Td
+wC
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+DX
+zS
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+"}
+(18,1,1) = {"
+cx
+eq
+MD
+eF
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+DX
+tw
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+"}
+(19,1,1) = {"
+dO
+Dy
+QX
+jK
+iV
+wC
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+DX
+zS
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+"}
+(20,1,1) = {"
+Ie
+Dy
+QX
+xj
+bu
+bu
+bu
+rO
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+aW
+to
+tw
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+"}
+(21,1,1) = {"
+dO
+Dy
+sV
+yN
+qc
+qc
+qc
+qc
+qc
+Ct
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+DX
+zS
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+"}
+(22,1,1) = {"
+cx
+SL
+VN
+dO
+cx
+cx
+kD
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+Zz
+Mp
+tw
+YZ
+Oj
+YZ
+Rh
+zS
+zS
+zS
+"}
+(23,1,1) = {"
+CB
+sj
+Cc
+Un
+mn
+cx
+Fl
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+MO
+zS
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+"}
+(24,1,1) = {"
+Un
+kR
+CP
+Zp
+Gc
+Zt
+cH
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+Nd
+Ng
+tw
+YZ
+Oj
+YZ
+zS
+zS
+zS
+zS
+"}
+(25,1,1) = {"
+Un
+ur
+Cc
+In
+XN
+cx
+TR
+ji
+bu
+bu
+bu
+lG
+bu
+bu
+bu
+bu
+qV
+Ng
+zS
+YZ
+YZ
+YZ
+zS
+zS
+zS
+zS
+"}
+(26,1,1) = {"
+iA
+tM
+pj
+ld
+cx
+cx
+cx
+Kh
+eG
+bG
+nw
+nw
+Kz
+Kz
+Kz
+nw
+nw
+OV
+zS
+zS
+Rh
+zS
+zS
+zS
+zS
+zS
+"}
+(27,1,1) = {"
+ZT
+ZT
+ZT
+RY
+nL
+cx
+sH
+ZA
+ZA
+lO
+to
+zS
+zS
+zS
+tw
+zS
+tw
+tw
+Rh
+Rh
+Rh
+zS
+zS
+zS
+zS
+zS
+"}
+(28,1,1) = {"
+ZT
+ZT
+ZT
+sn
+Dd
+cx
+cn
+op
+iP
+rH
+to
+zS
+zS
+zS
+tw
+zS
+Rh
+zS
+Rh
+YZ
+YZ
+Rh
+zS
+zS
+zS
+zS
+"}
+(29,1,1) = {"
+ZT
+ZT
+ZT
+XX
+Hu
+to
+to
+to
+to
+to
+to
+zS
+zS
+zS
+Rh
+Rh
+Rh
+Rh
+Rh
+Oj
+YZ
+zS
+zS
+zS
+zS
+zS
+"}

--- a/_maps/RandomRuins/StationRuins/Box/Engine/splurt/diy_sm.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/splurt/diy_sm.dmm
@@ -72,6 +72,7 @@
 	pixel_y = 5
 	},
 /obj/item/flashlight,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "at" = (
@@ -83,11 +84,10 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "av" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "aA" = (
@@ -186,6 +186,7 @@
 /area/space/nearstation)
 "dD" = (
 /obj/machinery/power/rad_collector,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "ej" = (
@@ -275,12 +276,11 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "in" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -298,6 +298,9 @@
 	name = "Cable Toolbox";
 	pixel_y = -4
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "iD" = (
@@ -309,9 +312,6 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "jg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/machinery/power/rad_collector,
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -331,12 +331,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "kA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
 	req_access_txt = "10"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/engineering/main)
 "kW" = (
@@ -383,10 +383,11 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "mU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "mX" = (
@@ -400,7 +401,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "nR" = (
@@ -438,6 +441,9 @@
 /obj/machinery/power/rad_collector,
 /obj/effect/turf_decal/box/corners{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
@@ -514,20 +520,12 @@
 /area/space/nearstation)
 "tJ" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "uR" = (
 /obj/structure/fluff/railing{
 	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engineering/main)
-"vN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -544,12 +542,14 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "wt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/closet/radiation,
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
 /obj/item/geiger_counter,
 /obj/item/clothing/glasses/meson,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "wG" = (
@@ -568,6 +568,12 @@
 "wS" = (
 /turf/open/space,
 /area/space/nearstation)
+"xe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
 "xo" = (
 /obj/item/construction/rcd/loaded/upgraded{
 	custom_range = 2;
@@ -662,6 +668,9 @@
 	dir = 4;
 	name = "Output Release"
 	},
+/obj/item/radio/intercom{
+	pixel_y = -25
+	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "CH" = (
@@ -689,6 +698,9 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "Ef" = (
@@ -709,7 +721,6 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "Es" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -722,6 +733,25 @@
 "Ex" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"ED" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 25
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -750,6 +780,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "GB" = (
@@ -779,6 +810,9 @@
 	c_tag = "Engineering Supermatter Port";
 	dir = 4;
 	network = list("ss13","engine")
+	},
+/obj/item/radio/intercom{
+	pixel_x = -25
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -821,6 +855,9 @@
 "Jn" = (
 /obj/machinery/light,
 /obj/machinery/power/rad_collector,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "JV" = (
@@ -843,10 +880,12 @@
 	pixel_y = 5
 	},
 /obj/item/stack/cable_coil/yellow,
+/obj/item/radio/intercom{
+	pixel_y = -25
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "Kv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -880,6 +919,13 @@
 "LS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating/airless,
+/area/engineering/main)
+"My" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/engineering/main)
 "ME" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -928,11 +974,15 @@
 /obj/item/stack/rods/fifty,
 /obj/item/stack/rods/fifty,
 /obj/item/stack/rods/fifty,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "NZ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
+	},
+/obj/item/radio/intercom{
+	pixel_y = -25
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -941,6 +991,11 @@
 /area/space/nearstation)
 "Ok" = (
 /turf/open/floor/plasteel,
+/area/engineering/main)
+"OB" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
 /area/engineering/main)
 "OK" = (
 /obj/structure/cable{
@@ -954,6 +1009,12 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
+/area/engineering/main)
+"Pp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "Py" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -1029,6 +1090,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"Uo" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
 "Uq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1036,7 +1104,6 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "Ur" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -1065,6 +1132,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"VG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "WB" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -1075,6 +1153,12 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
+/area/engineering/main)
+"WP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "XA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1402,7 +1486,7 @@ oC
 GB
 UN
 sn
-sn
+VG
 ad
 sn
 GK
@@ -1679,7 +1763,7 @@ yf
 "}
 (21,1,1) = {"
 MP
-Bl
+ED
 QD
 MJ
 MJ
@@ -1790,7 +1874,7 @@ YZ
 yf
 "}
 (25,1,1) = {"
-iD
+My
 mU
 in
 Ur
@@ -1801,7 +1885,7 @@ Ur
 Ur
 Ur
 Ur
-vN
+Ur
 nz
 In
 Ub
@@ -1821,11 +1905,11 @@ yf
 wt
 av
 kA
-iD
-MP
+OB
+xe
 MP
 ag
-Uu
+WP
 kg
 bI
 Uu
@@ -1851,12 +1935,12 @@ ZT
 ZT
 ou
 DC
-iD
+OB
 ah
-Uu
+Pp
 tJ
 NK
-Uu
+ZH
 dD
 Jn
 MP
@@ -1881,7 +1965,7 @@ OU
 Ok
 CH
 GI
-Uu
+Uo
 TB
 gQ
 Uu

--- a/_maps/RandomRuins/StationRuins/Box/Engine/splurt/diy_sm.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/splurt/diy_sm.dmm
@@ -1,0 +1,1931 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"ab" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"ac" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plating,
+/area/engineering/main)
+"ad" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"af" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"ag" = (
+/obj/structure/rack,
+/obj/item/pipe_dispenser{
+	pixel_y = 5
+	},
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser{
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"ah" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 5
+	},
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/flashlight,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"at" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/cartridge/atmos,
+/turf/open/floor/plating,
+/area/engineering/main)
+"av" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
+"aA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"aV" = (
+/obj/structure/fluff/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"aX" = (
+/obj/structure/fluff/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"bH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "Output to Waste"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"bI" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/plasmarglass{
+	amount = 50
+	},
+/obj/item/stack/sheet/plasmarglass{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 50
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"bT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"ck" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"cp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"cP" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"cS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/safety_eye_protection,
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"dl" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"dw" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space/nearstation)
+"dD" = (
+/obj/machinery/power/rad_collector,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"ej" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engineering/main)
+"ey" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Aft";
+	dir = 1;
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"ez" = (
+/obj/structure/reflector/box{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"fj" = (
+/obj/machinery/power/emitter{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"fq" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"fK" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/power/emitter{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"fW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"gf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"gQ" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"hJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"in" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"iC" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/artistic{
+	icon_state = "yellow";
+	item_state = "toolbox_yellow";
+	name = "Cable Toolbox";
+	pixel_y = 6
+	},
+/obj/item/storage/toolbox/artistic{
+	icon_state = "yellow";
+	item_state = "toolbox_yellow";
+	name = "Cable Toolbox";
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"iD" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
+"iJ" = (
+/obj/structure/fluff/railing/corner,
+/turf/open/floor/plating,
+/area/engineering/main)
+"jg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/power/rad_collector,
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"jp" = (
+/obj/structure/fluff/railing,
+/obj/effect/turf_decal/caution,
+/turf/open/floor/plating,
+/area/engineering/main)
+"kg" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"kA" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
+"kW" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/structure/closet/crate/large,
+/obj/item/tank/internals/plasma/full,
+/obj/item/tank/internals/plasma/full,
+/obj/item/tank/internals/plasma/full,
+/obj/item/tank/internals/plasma/full,
+/obj/item/tank/internals/plasma/full,
+/obj/item/tank/internals/plasma/full,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"ln" = (
+/obj/machinery/power/rad_collector,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"lw" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"mj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"mH" = (
+/obj/structure/sign/poster/official/safety_eye_protection,
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"mU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
+"mX" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/engineering/main)
+"nz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engineering/main)
+"nR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
+"ou" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"oC" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
+"oS" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
+"qc" = (
+/obj/machinery/power/rad_collector,
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"qe" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"qr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"rJ" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/engineering/main)
+"rY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"sn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"so" = (
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"td" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"tn" = (
+/obj/machinery/power/supermatter_crystal/engine,
+/turf/open/floor/plating,
+/area/engineering/main)
+"tw" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"tJ" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"uR" = (
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"vN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"vX" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"wt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/closet/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"wG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"wS" = (
+/turf/open/space,
+/area/space/nearstation)
+"xo" = (
+/obj/item/construction/rcd/loaded/upgraded{
+	custom_range = 2;
+	matter = 200;
+	max_matter = 200;
+	name = "Super RCD";
+	ranged = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"yd" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"yf" = (
+/turf/open/space/basic,
+/area/space/nearstation)
+"yD" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"zh" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"zF" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"zS" = (
+/turf/open/space/basic,
+/area/space)
+"Ab" = (
+/obj/structure/rack,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"AH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
+"Bc" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/main)
+"Bl" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"BD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 4;
+	name = "Output Release"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"CH" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"CT" = (
+/obj/structure/fluff/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"DC" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Ef" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Ei" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Es" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Ex" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"EL" = (
+/turf/closed/wall,
+/area/engineering/main)
+"EM" = (
+/obj/item/wrench,
+/obj/structure/rack,
+/obj/item/weldingtool/hugetank{
+	toolspeed = 0.5
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"FG" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"GB" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
+"GI" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"GK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Port";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"GX" = (
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/engineering/main)
+"Hn" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engineering/main)
+"Hz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"In" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"IE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Jn" = (
+/obj/machinery/light,
+/obj/machinery/power/rad_collector,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"JV" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Ke" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil/yellow{
+	pixel_y = 10
+	},
+/obj/item/stack/cable_coil/yellow{
+	pixel_y = 5
+	},
+/obj/item/stack/cable_coil/yellow,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Kv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Lg" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Lw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"LJ" = (
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engineering/main)
+"LS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plating/airless,
+/area/engineering/main)
+"ME" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
+"MI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"MJ" = (
+/turf/open/floor/plating,
+/area/engineering/main)
+"MP" = (
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"Ne" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
+"Np" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"ND" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"NK" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"NZ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Oj" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
+"Ok" = (
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"OK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"OU" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/engineering/main)
+"Py" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/engineering/main)
+"Qn" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/engineering/main)
+"QD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Rh" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
+"SR" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"SX" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Tk" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/engineering/main)
+"TB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Starboard";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"TC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Ub" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"Uq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"Ur" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Uu" = (
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"UM" = (
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"UN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"Vn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"WB" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
+"WI" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"XA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/main)
+"XK" = (
+/obj/machinery/power/rad_collector,
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"YB" = (
+/obj/structure/cable{
+	icon_state = "0-5"
+	},
+/obj/machinery/power/floodlight,
+/turf/open/floor/plating,
+/area/engineering/main)
+"YX" = (
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plating,
+/area/engineering/main)
+"YZ" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space/nearstation)
+"Zn" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"ZH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"ZT" = (
+/turf/template_noop,
+/area/template_noop)
+
+(1,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+yf
+Rh
+yf
+yf
+Rh
+yf
+yf
+Rh
+yf
+yf
+yf
+YZ
+YZ
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(2,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+Rh
+Rh
+Rh
+Rh
+Rh
+Rh
+Rh
+Rh
+Rh
+yf
+yf
+YZ
+Oj
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(3,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+Rh
+Rh
+YZ
+Oj
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(4,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+yf
+yf
+YZ
+Oj
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(5,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+Rh
+Rh
+YZ
+Oj
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(6,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+ZT
+wS
+dw
+Rh
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+yf
+yf
+YZ
+Oj
+YZ
+ZT
+ZT
+ZT
+ZT
+ZT
+"}
+(7,1,1) = {"
+ZT
+ZT
+ZT
+ZT
+EL
+EL
+MP
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+Rh
+Rh
+YZ
+Oj
+YZ
+yf
+yf
+yf
+yf
+zS
+"}
+(8,1,1) = {"
+ZT
+ZT
+cP
+Ke
+EL
+Tk
+MP
+wS
+dw
+Rh
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+yf
+yf
+YZ
+Oj
+YZ
+yf
+yf
+Rh
+yf
+yf
+"}
+(9,1,1) = {"
+ZT
+ZT
+dl
+Ok
+ND
+Zn
+Ei
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+Rh
+dw
+Rh
+Rh
+Rh
+YZ
+YZ
+YZ
+tw
+Rh
+Rh
+Rh
+yf
+"}
+(10,1,1) = {"
+ZT
+nR
+AH
+iD
+MP
+MP
+MP
+MP
+aA
+rJ
+gf
+rJ
+rJ
+td
+yf
+yf
+yf
+yf
+Rh
+yf
+yf
+yf
+yf
+Rh
+yf
+yf
+"}
+(11,1,1) = {"
+oC
+GB
+UN
+sn
+sn
+ad
+sn
+GK
+wG
+TC
+mj
+fW
+at
+XA
+td
+MP
+MP
+MP
+MP
+MP
+MP
+yf
+WB
+YZ
+WB
+yf
+"}
+(12,1,1) = {"
+cS
+hJ
+qe
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+yD
+Ex
+ck
+iC
+ez
+kW
+ez
+EM
+MP
+yf
+YZ
+Oj
+YZ
+yf
+"}
+(13,1,1) = {"
+ME
+qr
+Hz
+GX
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+QD
+SR
+SX
+Vn
+Vn
+cp
+Uu
+Uu
+MP
+yf
+YZ
+Oj
+YZ
+yf
+"}
+(14,1,1) = {"
+Ne
+yd
+QD
+MJ
+MJ
+MJ
+MJ
+MJ
+YX
+MJ
+MJ
+MJ
+WI
+IE
+JV
+Bc
+MJ
+MJ
+MJ
+LJ
+MP
+Rh
+YZ
+Oj
+YZ
+Rh
+"}
+(15,1,1) = {"
+MP
+zh
+QD
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+Ef
+iD
+MJ
+MJ
+MJ
+MJ
+MJ
+MP
+yf
+YZ
+Oj
+YZ
+yf
+"}
+(16,1,1) = {"
+MP
+Bl
+QD
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+ej
+MP
+Lw
+MJ
+MJ
+MJ
+MJ
+MP
+Rh
+YZ
+Oj
+YZ
+yf
+"}
+(17,1,1) = {"
+oS
+Bl
+QD
+MJ
+MJ
+MJ
+iJ
+so
+aV
+MJ
+MJ
+MJ
+MJ
+Py
+iD
+MJ
+MJ
+MJ
+MJ
+MJ
+MP
+yf
+YZ
+Oj
+YZ
+yf
+"}
+(18,1,1) = {"
+iD
+aa
+QD
+YX
+MJ
+MJ
+jp
+tn
+uR
+MJ
+MJ
+MJ
+ac
+ey
+iD
+MJ
+MJ
+xo
+MJ
+MJ
+MP
+yf
+YZ
+Oj
+YZ
+yf
+"}
+(19,1,1) = {"
+oS
+Bl
+QD
+MJ
+MJ
+MJ
+CT
+UM
+aX
+MJ
+MJ
+MJ
+MJ
+Py
+iD
+MJ
+MJ
+MJ
+MJ
+MJ
+MP
+Rh
+YZ
+Oj
+YZ
+yf
+"}
+(20,1,1) = {"
+MP
+Bl
+QD
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+ej
+MP
+Lw
+MJ
+MJ
+MJ
+MJ
+MP
+Rh
+YZ
+Oj
+YZ
+yf
+"}
+(21,1,1) = {"
+MP
+Bl
+QD
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+Np
+Ef
+iD
+MJ
+MJ
+MJ
+MJ
+MJ
+MP
+yf
+YZ
+Oj
+YZ
+yf
+"}
+(22,1,1) = {"
+iD
+Bl
+QD
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+MJ
+YX
+MJ
+lw
+bH
+JV
+Bc
+MJ
+MJ
+MJ
+LJ
+MP
+Rh
+YZ
+Oj
+YZ
+Rh
+"}
+(23,1,1) = {"
+iD
+vX
+Hz
+GX
+MJ
+MJ
+MJ
+YB
+MJ
+MJ
+MJ
+MJ
+rY
+Qn
+ab
+ZH
+ZH
+MI
+Uu
+Uu
+MP
+Rh
+YZ
+Oj
+YZ
+yf
+"}
+(24,1,1) = {"
+mH
+bT
+Lg
+OK
+OK
+OK
+af
+OK
+OK
+OK
+OK
+OK
+mX
+BD
+Uq
+zF
+fj
+fK
+fj
+Ab
+MP
+Rh
+YZ
+Oj
+YZ
+yf
+"}
+(25,1,1) = {"
+iD
+mU
+in
+Ur
+Es
+Kv
+Ur
+Ur
+Ur
+Ur
+Ur
+vN
+nz
+In
+Ub
+MP
+MP
+MP
+MP
+MP
+MP
+yf
+YZ
+YZ
+YZ
+yf
+"}
+(26,1,1) = {"
+wt
+av
+kA
+iD
+MP
+MP
+ag
+Uu
+kg
+bI
+Uu
+jg
+qc
+fq
+LS
+Hn
+dw
+yf
+Rh
+yf
+yf
+yf
+yf
+Rh
+yf
+yf
+"}
+(27,1,1) = {"
+ZT
+ZT
+ZT
+ou
+DC
+iD
+ah
+Uu
+tJ
+NK
+Uu
+dD
+Jn
+MP
+dw
+dw
+dw
+Rh
+Rh
+Rh
+Rh
+tw
+Rh
+Rh
+Rh
+Rh
+"}
+(28,1,1) = {"
+ZT
+ZT
+ZT
+OU
+Ok
+CH
+GI
+Uu
+TB
+gQ
+Uu
+ln
+XK
+MP
+yf
+yf
+Rh
+yf
+Rh
+Oj
+YZ
+yf
+yf
+Rh
+yf
+yf
+"}
+(29,1,1) = {"
+ZT
+ZT
+ZT
+FG
+NZ
+MP
+MP
+MP
+MP
+MP
+iD
+iD
+iD
+MP
+Rh
+Rh
+Rh
+Rh
+Rh
+Oj
+YZ
+yf
+yf
+Rh
+yf
+zS
+"}

--- a/config/entries/general.txt
+++ b/config/entries/general.txt
@@ -485,15 +485,17 @@ DYNAMIC_CONFIG_ENABLED
 ## Choose which Engine to start the round with. Weight is after the comma. Setting the weight to 0 removes the engine from rotation.
 BOX_RANDOM_ENGINE Box SM,3
 BOX_RANDOM_ENGINE Box Tesla,3
-BOX_RANDOM_ENGINE Box Singulo,3
-BOX_RANDOM_ENGINE Box SM 1x3,1
-BOX_RANDOM_ENGINE Box SM 5x5,1
+BOX_RANDOM_ENGINE Box Singulo,2
+BOX_RANDOM_ENGINE Box SM 1x3,0
+BOX_RANDOM_ENGINE Box SM 5x5,0
 BOX_RANDOM_ENGINE Box SM 3x,0
-BOX_RANDOM_ENGINE Box TEG,3
+BOX_RANDOM_ENGINE Box TEG,2
 BOX_RANDOM_ENGINE Box Empty,0
-BOX_RANDOM_ENGINE Box Antimatter,1
-BOX_RANDOM_ENGINE Box P.A.C.M.A.N,1
+BOX_RANDOM_ENGINE Box Antimatter,0
+BOX_RANDOM_ENGINE Box P.A.C.M.A.N,0
 BOX_RANDOM_ENGINE Box RBMK,0
+BOX_RANDOM_ENGINE Box DIY,2
+BOX_RANDOM_ENGINE Box DIY_SM,1
 
 
 ## Whether the suicide verb is allowed.

--- a/modular_splurt/code/datums/ruins/station.dm
+++ b/modular_splurt/code/datums/ruins/station.dm
@@ -1,0 +1,12 @@
+// Boxstation
+	// Engine
+
+/datum/map_template/ruin/station/box/engine/diy
+	id = "engine_diy"
+	suffix = "Box/Engine/splurt/diy.dmm"
+	name = "Box DIY"
+
+/datum/map_template/ruin/station/box/engine/diy_sm
+	id = "engine_diysm"
+	suffix = "Box/Engine/splurt/diy_sm.dmm"
+	name = "Box DIY_SM"


### PR DESCRIPTION
# About The Pull Request
• Adds in a DIY engine. It's a blank area filled with materials, stripped bare so it's ready for construction as soon as the round starts!
• Adds in a DIY supermatter engine. It's basically a supermatter in an empty blank room.

## Why It's Good For The Game
Replacement for getting rid of the PACMAN meme engine that's nothing but an annoyance for engineers and a kick in the balls for station crew when power runs out because the engineers have to spend thirty minutes ripping out the SMES unit.
Build-a-SM is something the moths will flutter like crazy over.

## Config Changes
```
BOX_RANDOM_ENGINE Box SM,3
BOX_RANDOM_ENGINE Box Tesla,3
BOX_RANDOM_ENGINE Box Singulo,2
BOX_RANDOM_ENGINE Box SM 1x3,0
BOX_RANDOM_ENGINE Box SM 5x5,0
BOX_RANDOM_ENGINE Box SM 3x,0
BOX_RANDOM_ENGINE Box TEG,2
BOX_RANDOM_ENGINE Box Empty,0
BOX_RANDOM_ENGINE Box Antimatter,0
BOX_RANDOM_ENGINE Box P.A.C.M.A.N,0
BOX_RANDOM_ENGINE Box RBMK,0
BOX_RANDOM_ENGINE Box DIY,2
BOX_RANDOM_ENGINE Box DIY_SM,1
```
PACMAN disabled.
TEG from 3 to 2.
Singulo from 3 to 2, as it irradiates all of engineering and there's no way to actually stop it.
Antimatter engined disabled.
New DIY engine to 2. It has a lot of starting equipment. Included lots of spare solars, in case engineers aren't too confident.
New DIY supermatter engine to 1, it's a lot of work to achieve similar results to the normal SM.

### Config changes required server-side for it to work.

## A Port?
Nope!

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
del: PACMAN Boxstation Engine
add: DIY Boxstation Engine
add: DIY Supermatter Boxstation Engine
/:cl:
