### PR TITLE
Fixes a few Nav destinations for the pathfinder system

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -9294,7 +9294,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/command/nuke_storage)
 "aFY" = (
@@ -10359,6 +10358,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLq" = (
@@ -12676,6 +12676,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXd" = (
@@ -16428,7 +16429,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination/research,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "biW" = (
@@ -18985,6 +18985,7 @@
 	id = "hop";
 	name = "Privacy Shutters"
 	},
+/obj/effect/landmark/navigate_destination/hop,
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/hop)
 "bpb" = (
@@ -19579,7 +19580,6 @@
 /area/command/heads_quarters/hop)
 "bqB" = (
 /obj/machinery/holopad/secure,
-/obj/effect/landmark/navigate_destination/hop,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
 "bqD" = (
@@ -20955,6 +20955,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/teleporter,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "btP" = (
@@ -39767,7 +39768,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/filled/corner,
-/obj/effect/landmark/navigate_destination/bar,
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
 "csc" = (
@@ -48909,7 +48909,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/landmark/navigate_destination/gateway,
 /turf/open/floor/plasteel/dark,
 /area/command/gateway)
 "hqc" = (
@@ -51059,6 +51058,10 @@
 	dir = 8
 	},
 /area/security/prison/upper)
+"jpz" = (
+/obj/effect/landmark/navigate_destination/chapel,
+/turf/open/floor/grass,
+/area/service/chapel/main)
 "jqv" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -51980,7 +51983,6 @@
 /area/maintenance/starboard)
 "kgP" = (
 /obj/structure/flora/tree/jungle,
-/obj/effect/landmark/navigate_destination/chapel,
 /turf/open/floor/grass,
 /area/service/chapel/main)
 "kgY" = (
@@ -53410,6 +53412,16 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/wood,
 /area/command/bridge)
+"lpn" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/landmark/navigate_destination/hydro,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "lpr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Isolation Cell";
@@ -54290,6 +54302,13 @@
 "mbC" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
+"mbH" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/navigate_destination/bar,
+/turf/open/floor/wood,
+/area/service/bar)
 "mbQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light_switch{
@@ -61468,6 +61487,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/prison/aft)
+"sLA" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/landmark/navigate_destination/research,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "sMu" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -63413,6 +63440,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uzc" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/navigate_destination/kitchen,
+/turf/open/floor/plasteel/dark,
+/area/service/bar)
 "uzg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -63434,10 +63468,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
-"uzI" = (
-/obj/effect/landmark/navigate_destination/hydro,
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
 "uAB" = (
 /obj/machinery/shower{
 	pixel_y = 16
@@ -64546,6 +64576,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/landmark/navigate_destination/gateway,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "vCt" = (
@@ -65426,7 +65457,6 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
-/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/carpet/royalblack,
 /area/command/bridge)
 "wdr" = (
@@ -65694,13 +65724,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"wnY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/navigate_destination/teleporter,
-/turf/open/floor/plasteel,
-/area/command/teleporter)
 "wof" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/carpet/royalblack,
@@ -66423,13 +66446,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"xbA" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/landmark/navigate_destination/kitchen,
-/turf/open/floor/plasteel/cafeteria,
-/area/service/kitchen)
 "xcl" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -99540,7 +99556,7 @@ boa
 bpm
 bqH
 bsn
-wnY
+btL
 buY
 buY
 bqH
@@ -103114,7 +103130,7 @@ khZ
 rWK
 gcQ
 qGA
-acN
+mbH
 aKR
 iHG
 iNe
@@ -105431,7 +105447,7 @@ wgU
 gdJ
 aVz
 faV
-wEk
+uzc
 jVS
 tjV
 jVS
@@ -105942,7 +105958,7 @@ aJI
 mUH
 xGg
 mvN
-xbA
+vAI
 aVz
 cTl
 wEk
@@ -108003,7 +108019,7 @@ aJI
 kKE
 kck
 aRJ
-uzI
+aRJ
 aRJ
 gkS
 vjn
@@ -109035,7 +109051,7 @@ efq
 aKU
 aTl
 vwm
-ikm
+lpn
 aYV
 aYV
 tvt
@@ -113922,7 +113938,7 @@ aCR
 aYV
 aXq
 aYV
-bfX
+sLA
 bhB
 bgp
 bhU
@@ -115199,7 +115215,7 @@ cRd
 jcL
 uaO
 kgP
-uaO
+jpz
 rwH
 mWr
 uaY

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -53110,18 +53110,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"lah" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/landmark/start/chemist,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/landmark/navigate_destination/chemfactory,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "laq" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -102632,7 +102620,7 @@ aYV
 tkB
 bfF
 bhd
-lah
+bis
 bjR
 bis
 bmI

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -18183,6 +18183,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byt" = (
@@ -19731,6 +19732,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
+/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bFj" = (
@@ -20414,6 +20416,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/engineering,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bIn" = (
@@ -22887,7 +22890,6 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/effect/landmark/navigate_destination/det,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bRj" = (
@@ -24359,6 +24361,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/landmark/navigate_destination/det,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bVc" = (
@@ -26635,6 +26638,7 @@
 "bZJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/navigate_destination/sec,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bZK" = (
@@ -26656,7 +26660,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bZM" = (
@@ -30593,7 +30596,6 @@
 /obj/machinery/holopad,
 /obj/effect/landmark/start/lawyer,
 /obj/effect/turf_decal/bot,
-/obj/effect/landmark/navigate_destination/court,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "cka" = (
@@ -33343,6 +33345,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/landmark/navigate_destination/tcomms,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "csy" = (
@@ -44868,7 +44871,6 @@
 	},
 /obj/effect/landmark/start/chemist,
 /obj/effect/turf_decal/bot,
-/obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "dbf" = (
@@ -72705,7 +72707,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/landmark/navigate_destination/engineering,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "eXW" = (
@@ -85432,23 +85433,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/kitchen)
-"jgw" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/landmark/navigate_destination/tcomms,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
 "jgV" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Access"
@@ -89045,6 +89029,16 @@
 "koj" = (
 /turf/closed/wall/r_wall,
 /area/engineering/break_room)
+"kou" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/landmark/navigate_destination/gateway,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "koN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -93109,6 +93103,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"lKH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/navigate_destination/court,
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "lKL" = (
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/glasses/meson/engine,
@@ -104092,7 +104100,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/landmark/navigate_destination/gateway,
 /turf/open/floor/plasteel/dark,
 /area/command/gateway)
 "pyp" = (
@@ -112190,7 +112197,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/command/nuke_storage)
 "slC" = (
@@ -119636,7 +119642,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "uNy" = (
@@ -168321,7 +168326,7 @@ caX
 ccI
 cez
 cgm
-jgw
+caX
 cjG
 bWZ
 cmF
@@ -171937,7 +171942,7 @@ wlE
 qYH
 tXY
 oGl
-cIE
+kou
 bqU
 cMa
 cNz
@@ -174747,7 +174752,7 @@ ccY
 ceO
 ceO
 cim
-ccW
+lKH
 clj
 ceO
 ceO

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -7549,6 +7549,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/navigate_destination/det,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "axu" = (
@@ -8239,7 +8240,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/navigate_destination/det,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "azT" = (
@@ -10698,7 +10698,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/landmark/navigate_destination/court,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "aOk" = (
@@ -10836,7 +10835,6 @@
 /obj/machinery/ai_slipper{
 	uses = 8
 	},
-/obj/effect/landmark/navigate_destination/aiupload,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aPx" = (
@@ -12639,6 +12637,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/landmark/navigate_destination/aiupload,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXH" = (
@@ -13694,6 +13693,7 @@
 	icon_state = "cleanbot1";
 	name = "Mopficcer Sweepsky"
 	},
+/obj/effect/landmark/navigate_destination/janitor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "baK" = (
@@ -16562,6 +16562,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/landmark/navigate_destination/engineering,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bno" = (
@@ -19727,6 +19728,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "bDh" = (
@@ -27854,7 +27856,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "ciy" = (
@@ -51650,7 +51651,6 @@
 	name = "Blueshield";
 	req_access_txt = "72"
 	},
-/obj/effect/landmark/navigate_destination/blueshield,
 /turf/open/floor/wood,
 /area/command/blueshieldoffice)
 "fvo" = (
@@ -57943,7 +57943,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/landmark/navigate_destination/janitor,
 /turf/open/floor/plasteel,
 /area/service/janitor)
 "iWG" = (
@@ -59632,7 +59631,6 @@
 	req_access_txt = "76"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination/psychologist,
 /turf/open/floor/plasteel,
 /area/medical/psychology)
 "jQR" = (
@@ -59746,7 +59744,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/landmark/navigate_destination/lawyer,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "jSx" = (
@@ -63193,6 +63190,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/effect/landmark/navigate_destination/psychologist,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "lOI" = (
@@ -64230,7 +64228,6 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/carpet,
 /area/command/bridge)
 "mqC" = (
@@ -64980,7 +64977,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -67305,6 +67301,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
 "ocV" = (
@@ -69483,7 +69480,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination/engineering,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "pko" = (
@@ -74780,6 +74776,16 @@
 	dir = 4
 	},
 /area/service/chapel/main)
+"rVz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/landmark/navigate_destination/gateway,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rVI" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -75817,6 +75823,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/landmark/navigate_destination/blueshield,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "syK" = (
@@ -76146,7 +76153,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/landmark/navigate_destination/gateway,
 /turf/open/floor/plasteel/dark,
 /area/command/gateway)
 "sHf" = (
@@ -78904,6 +78910,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/landmark/navigate_destination/lawyer,
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "ukJ" = (
@@ -81363,6 +81370,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
+"vLs" = (
+/obj/effect/landmark/navigate_destination/court,
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "vLD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -115666,7 +115677,7 @@ aLB
 aMN
 aOj
 aPC
-aIT
+vLs
 aRZ
 aIT
 aUG
@@ -117242,7 +117253,7 @@ wzp
 med
 tim
 oOi
-bTI
+rVz
 aYX
 bWB
 aVW

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -7365,6 +7365,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/navigate_destination/court,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "atI" = (
@@ -7571,7 +7572,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/command/nuke_storage)
 "aud" = (
@@ -8506,6 +8506,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "awg" = (
@@ -8553,6 +8554,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/navigate_destination/gateway,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "awk" = (
@@ -9981,6 +9983,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/lawyer,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAe" = (
@@ -10022,6 +10025,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/det,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAj" = (
@@ -10362,7 +10366,6 @@
 	req_access_txt = "4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/navigate_destination/det,
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "aBg" = (
@@ -14233,6 +14236,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/eva,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJW" = (
@@ -14790,7 +14794,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/landmark/navigate_destination/eva,
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
 "aLT" = (
@@ -14844,7 +14847,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/navigate_destination/teleporter,
 /turf/open/floor/plasteel,
 /area/command/teleporter)
 "aLZ" = (
@@ -51193,6 +51195,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/dorms)
+"dch" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/landmark/navigate_destination/bridge,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dci" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52081,6 +52091,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/navigate_destination/blueshield,
 /turf/open/floor/plasteel,
 /area/maintenance/department/crew_quarters/dorms)
 "exa" = (
@@ -52576,6 +52587,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/landmark/navigate_destination/psychologist,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fgh" = (
@@ -53761,6 +53773,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/landmark/navigate_destination/sec,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "gZL" = (
@@ -55474,21 +55487,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"jKk" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/landmark/navigate_destination/gateway,
-/turf/open/floor/plasteel/dark,
-/area/command/gateway)
 "jOB" = (
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
@@ -56380,7 +56378,6 @@
 	req_access_txt = "76"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination/psychologist,
 /turf/open/floor/plasteel,
 /area/medical/psychology)
 "lcU" = (
@@ -57583,7 +57580,6 @@
 	req_access_txt = "72"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination/blueshield,
 /turf/open/floor/wood,
 /area/command/blueshieldoffice)
 "mZE" = (
@@ -59533,33 +59529,6 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/department/engine)
-"pVH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Chemistry Desk";
-	req_access_txt = "5; 33"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "chemistry shutters"
-	},
-/obj/item/folder/white,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/landmark/navigate_destination/chemfactory,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "pWm" = (
 /obj/machinery/door/window/southleft{
 	dir = 4;
@@ -60612,13 +60581,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"rvE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/navigate_destination/sec,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "rvH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock{
@@ -61593,6 +61555,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"tfU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/landmark/navigate_destination/teleporter,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tfZ" = (
 /obj/structure/closet/crate/freezer,
 /obj/structure/window/reinforced{
@@ -63930,13 +63902,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"wAO" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/obj/effect/landmark/navigate_destination/bridge,
-/turf/open/floor/plasteel/dark,
-/area/command/bridge)
 "wBb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -64362,7 +64327,6 @@
 "xeB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/navigate_destination/lawyer,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "xgh" = (
@@ -64864,7 +64828,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination/court,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "xNW" = (
@@ -86734,7 +86697,7 @@ arl
 aty
 atz
 avv
-rvE
+avv
 xgz
 gZF
 ayL
@@ -94456,7 +94419,7 @@ aEC
 aDJ
 aAA
 myu
-aHU
+dch
 aIV
 aJS
 aKU
@@ -95730,7 +95693,7 @@ asR
 atU
 auR
 avX
-wAO
+axb
 ayb
 azj
 aAC
@@ -96031,7 +95994,7 @@ blp
 bmz
 bnG
 boN
-pVH
+bpW
 dHZ
 bsK
 buk
@@ -99341,7 +99304,7 @@ aGx
 aHl
 aHV
 aDZ
-aJV
+tfU
 aLd
 aLY
 aNw
@@ -100863,7 +100826,7 @@ aaa
 cBU
 aoB
 apr
-jKk
+apV
 aqR
 arY
 atb

--- a/_maps/map_files/TauStation/TauStation.dmm
+++ b/_maps/map_files/TauStation/TauStation.dmm
@@ -69380,7 +69380,6 @@
 /obj/machinery/light_switch{
 	pixel_y = -28
 	},
-/obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "xPP" = (

--- a/_maps/map_files/TauStation/TauStation.dmm
+++ b/_maps/map_files/TauStation/TauStation.dmm
@@ -15766,6 +15766,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison/cells)
+"fuL" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/landmark/navigate_destination/eva,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "fuZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -26175,7 +26185,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/landmark/navigate_destination/teleporter,
 /turf/open/floor/plasteel/dark,
 /area/command/teleporter)
 "jaJ" = (
@@ -34509,13 +34518,6 @@
 	dir = 1
 	},
 /area/cargo/office)
-"lXZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/navigate_destination/bar,
-/turf/open/floor/carpet/black,
-/area/service/bar)
 "lYc" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 4
@@ -37491,6 +37493,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/effect/landmark/navigate_destination/gateway,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "mVP" = (
@@ -38160,12 +38163,6 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/department/cargo)
-"neT" = (
-/obj/effect/landmark/navigate_destination/vault,
-/turf/open/floor/circuit/green{
-	luminosity = 2
-	},
-/area/ai_monitored/command/nuke_storage)
 "nfd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40554,10 +40551,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
-"nZT" = (
-/obj/effect/landmark/navigate_destination/eva,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/command/storage/eva)
 "nZZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -42283,7 +42276,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/landmark/navigate_destination/gateway,
 /turf/open/floor/plasteel/dark,
 /area/command/gateway)
 "oFC" = (
@@ -46243,6 +46235,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/navigate_destination/bar,
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
 "qcf" = (
@@ -48513,7 +48506,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/landmark/navigate_destination/sec,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "qTy" = (
@@ -56293,6 +56285,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/landmark/navigate_destination/teleporter,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "tEF" = (
@@ -62132,6 +62125,7 @@
 	codes_txt = "patrol;next_patrol=Jannitorial";
 	location = "Security"
 	},
+/obj/effect/landmark/navigate_destination/sec,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "vzK" = (
@@ -63319,6 +63313,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "vUs" = (
@@ -92819,7 +92814,7 @@ fza
 vZT
 kaD
 kwM
-neT
+kaa
 kYD
 lsL
 lOE
@@ -105180,9 +105175,9 @@ pmj
 pSO
 qUx
 qUx
-nZT
+qUx
 rST
-suO
+fuL
 ygo
 ygo
 vbA
@@ -119046,7 +119041,7 @@ pgi
 vki
 oJY
 oJY
-lXZ
+pvd
 oJY
 lsW
 lex


### PR DESCRIPTION


Fixes a few Nav destinations for the pathfinder system to help those who dont have access find things

All it does is move some waypoints around so people without access to some areas can find things. Like being able to find the HoP on maps and so forth without haveing HoP access. That being said, its not perfect and some areas are too deep to move the node over to, luckily these are ones that don't need to be accessed unless they have access already.