### PR TITLE
Deltastation Engineering QOL

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -15532,10 +15532,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"bot" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/engineering/atmospherics_engine)
 "boE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -21459,11 +21455,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"bLH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "bMa" = (
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
@@ -41740,10 +41731,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cVb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/engineering/atmospherics_engine)
 "cVl" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/fire/firefighter,
@@ -45075,11 +45062,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"dbF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/maintenance/port/fore)
 "dbM" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -72082,10 +72064,6 @@
 /obj/machinery/chem_dispenser/apothecary,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"eLR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "eLT" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -73179,10 +73157,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
-"fgB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "fgC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -73729,6 +73703,16 @@
 	},
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
+"fqr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "fqv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
@@ -74283,13 +74267,6 @@
 	},
 /turf/closed/wall,
 /area/commons/vacant_room/commissary)
-"fBq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmospherics_engine)
 "fBw" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -79330,6 +79307,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/t_scanner,
 /obj/effect/turf_decal/bot,
+/obj/item/clothing/glasses/meson/engine/tray,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "hnO" = (
@@ -84776,6 +84754,18 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/aft)
+"iUd" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "iUq" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
@@ -89673,7 +89663,7 @@
 /obj/effect/turf_decal/bot,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/item/construction/rld/mini,
+/obj/item/weldingtool/experimental,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "kzj" = (
@@ -90032,6 +90022,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
+"kDN" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "kDW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -93227,9 +93221,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/lawoffice)
 "lNF" = (
-/obj/item/clothing/gloves/color/black,
 /obj/structure/table/reinforced,
-/obj/item/clothing/glasses/meson/engine/tray,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -96421,10 +96413,6 @@
 /area/service/library)
 "mRB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Gravity Generator Chamber";
-	req_access_txt = "10"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -96436,6 +96424,10 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "2-4"
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Gravity Generator Chamber";
+	req_access_txt = "10"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
@@ -97018,6 +97010,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"nbs" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/maintenance/disposal/incinerator)
 "nbC" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -98543,12 +98544,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
-"nBT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmospherics_engine)
 "nBU" = (
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -98796,18 +98791,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"nGu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/fore)
 "nGB" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -98824,6 +98807,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
+"nGF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "nGL" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -99701,22 +99689,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
-"nVV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engineering/atmos)
 "nWn" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -100169,6 +100141,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/carpet,
 /area/service/bar/atrium)
+"ofw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "ofz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -101756,6 +101735,18 @@
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /turf/open/floor/engine,
 /area/science/mixing)
+"oIH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "oJu" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -102067,18 +102058,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"oNg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/fore)
 "oNF" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -103710,17 +103689,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"psH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/maintenance/port/fore)
 "psM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -105051,6 +105019,22 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
+"pNf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
 "pNm" = (
 /obj/machinery/door/morgue{
 	name = "Curator's Study";
@@ -105487,16 +105471,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
-"pTS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/maintenance/port/fore)
 "pUe" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
@@ -107608,14 +107582,14 @@
 /turf/open/space,
 /area/solars/starboard/aft)
 "qHr" = (
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding,
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
+/obj/item/weldingtool/largetank,
+/obj/item/clothing/head/welding,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "qHA" = (
@@ -110129,6 +110103,10 @@
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
+"rDF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "rDO" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -111190,6 +111168,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
+"rUJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
+"rVb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "rVo" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythreeXtwentythree,
@@ -113747,15 +113740,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/office)
-"sNx" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/maintenance/disposal/incinerator)
 "sOh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -114056,6 +114040,10 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solars/starboard/fore)
+"sTU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "sUa" = (
 /obj/machinery/camera/motion{
 	c_tag = "E.V.A. Storage";
@@ -124951,6 +124939,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
+"wJo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "wJE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -127187,6 +127180,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/vacant_room/commissary)
+"xAc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "xAm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -152812,16 +152811,16 @@ wiE
 vXY
 vXY
 vXY
-cVb
+rDF
 vXY
 vXY
 vXY
 wiE
-nBT
+xAc
 aFr
 ueE
 aJQ
-sNx
+nbs
 qaO
 eqS
 txj
@@ -153075,7 +153074,7 @@ vdS
 vdS
 opj
 xnI
-fgB
+rVb
 aIy
 aJR
 aLm
@@ -153594,7 +153593,7 @@ inc
 iPU
 rzU
 lUA
-nVV
+pNf
 fcn
 lfN
 oUP
@@ -154108,7 +154107,7 @@ mEe
 qsc
 uNf
 lUA
-nVV
+pNf
 fcn
 lfN
 oUP
@@ -154622,7 +154621,7 @@ hGj
 pCB
 rAp
 lUA
-nVV
+pNf
 pDr
 lfN
 oUP
@@ -155903,7 +155902,7 @@ wGF
 hey
 vjf
 eNX
-bot
+kDN
 hGj
 hGj
 lUA
@@ -157436,7 +157435,7 @@ tpa
 tpa
 stO
 stO
-fBq
+ofw
 tpa
 lQc
 qyD
@@ -158205,17 +158204,17 @@ vcS
 tiz
 tRl
 waq
-pTS
+fqr
 waq
-dbF
+nGF
 ayS
-oNg
-eLR
-bLH
-bLH
-psH
-eLR
-eLR
+oIH
+sTU
+wJo
+wJo
+rUJ
+sTU
+sTU
 kND
 aKg
 alf
@@ -159758,7 +159757,7 @@ uWg
 knQ
 mLS
 peV
-nGu
+iUd
 aKi
 qOV
 qDq

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4614,6 +4614,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
+"apK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "aqh" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /obj/structure/window/reinforced{
@@ -5475,12 +5487,18 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "asE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -5496,6 +5514,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "asG" = (
@@ -5505,25 +5526,22 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asH" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/fore)
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "asI" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asJ" = (
@@ -7089,6 +7107,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "axI" = (
@@ -7715,13 +7736,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aBZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/engineering/atmospherics_engine)
 "aCl" = (
 /obj/structure/table/wood,
@@ -9006,6 +9024,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aIH" = (
@@ -9013,6 +9032,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9255,9 +9277,6 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "aJw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/circuit/green,
 /area/engineering/atmospherics_engine)
 "aJx" = (
@@ -9540,11 +9559,9 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aJS" = (
@@ -9597,6 +9614,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aKj" = (
@@ -9612,7 +9632,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aKl" = (
@@ -9896,8 +9918,10 @@
 /area/maintenance/disposal/incinerator)
 "aLm" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aLB" = (
@@ -12647,16 +12671,15 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
 "aYb" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/black,
-/obj/item/wrench,
-/obj/item/clothing/glasses/meson/engine,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
 	pixel_x = -22;
 	pixel_y = 26
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel,
 /area/engineering/storage)
 "aYd" = (
@@ -18004,6 +18027,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"bxK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "bxP" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -67718,6 +67751,9 @@
 	dir = 1;
 	state = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/circuit/green,
 /area/engineering/atmospherics_engine)
 "dZw" = (
@@ -71057,9 +71093,6 @@
 /area/commons/fitness/pool)
 "eqS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -71070,6 +71103,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "erk" = (
@@ -71158,6 +71192,9 @@
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
@@ -71733,7 +71770,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -71761,9 +71797,6 @@
 "eGk" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -72196,8 +72229,8 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "eOd" = (
@@ -72270,12 +72303,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Fore";
 	name = "engineering camera"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -72389,7 +72425,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/library/abandoned)
 "eSp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -73359,11 +73394,11 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
@@ -74372,7 +74407,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74556,11 +74591,11 @@
 /area/science/circuit)
 "fGw" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
@@ -74732,6 +74767,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"fIy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "fIz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -74881,19 +74921,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/kitchen)
-"fKW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmospherics_engine)
 "fKY" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigars{
@@ -75536,11 +75563,9 @@
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
-/obj/item/stock_parts/cell/high,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/rcl/pre_loaded,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -75551,6 +75576,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/stock_parts/cell/hyper,
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "fWX" = (
@@ -75923,9 +75949,6 @@
 /area/cargo/office)
 "gda" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
@@ -76031,7 +76054,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -76299,9 +76321,6 @@
 /area/engineering/atmos)
 "gjS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -76349,8 +76368,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/sorting/mail{
+	name = "Engineering Junction";
+	sortType = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "gkq" = (
@@ -76471,6 +76493,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
+"gmv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "gnd" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
@@ -76561,6 +76588,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "goe" = (
@@ -76585,7 +76613,6 @@
 	pixel_y = 3
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/glasses/meson{
 	pixel_y = 1
@@ -77139,11 +77166,10 @@
 	},
 /area/engineering/atmos)
 "gCU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/engineering/atmospherics_engine)
 "gDb" = (
 /obj/structure/chair/comfy/brown,
@@ -77635,22 +77661,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
-"gLj" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmospherics_engine)
 "gLq" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
@@ -78186,10 +78196,13 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/theater/abandoned)
 "gUE" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "gUH" = (
@@ -78688,9 +78701,6 @@
 /area/cargo/office)
 "hbY" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -78752,13 +78762,10 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "hdg" = (
@@ -78829,6 +78836,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/engineering/atmos)
+"hff" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "hfm" = (
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -78904,9 +78915,12 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "hgp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "hgF" = (
 /turf/open/floor/plasteel{
 	dir = 8;
@@ -80390,6 +80404,12 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/solars/port/fore)
+"hFK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "hFQ" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
@@ -81106,6 +81126,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "hNL" = (
@@ -81574,6 +81597,9 @@
 "hVY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "hWc" = (
@@ -81630,11 +81656,12 @@
 "hWV" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
-/obj/item/wrench/power,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/wrench/power,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "hXf" = (
@@ -81943,6 +81970,9 @@
 /area/service/library/abandoned)
 "ida" = (
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "idf" = (
@@ -82115,9 +82145,6 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -82384,6 +82411,13 @@
 	heat_capacity = 1e+006
 	},
 /area/command/heads_quarters/ce)
+"ilQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "imf" = (
 /obj/structure/table/wood,
 /obj/machinery/status_display/evac{
@@ -82797,13 +82831,11 @@
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
 "iqL" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/structure/cable/white,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/break_room)
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "iqQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -83306,6 +83338,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "ixj" = (
@@ -85704,10 +85739,6 @@
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
 "jlD" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 4;
@@ -85715,6 +85746,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/engineering/storage)
 "jml" = (
@@ -87256,7 +87288,6 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "jKZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -87266,6 +87297,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
@@ -87903,6 +87937,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "jTa" = (
@@ -88481,7 +88516,6 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solars/port/fore)
 "keB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -88862,6 +88896,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "kkO" = (
@@ -89615,7 +89650,6 @@
 "kyv" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/rods/fifty,
-/obj/item/wrench,
 /obj/item/storage/box/lights/mixed,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -89649,18 +89683,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/stack/sheet/metal{
-	amount = 30
-	},
-/obj/item/stack/sheet/glass{
-	amount = 30
-	},
-/obj/item/crowbar/red,
-/obj/item/wrench,
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/construction/rld/mini,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "kzj" = (
@@ -89947,7 +89976,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/item/crowbar,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/effect/turf_decal/bot,
@@ -90263,9 +90291,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -90378,7 +90403,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
@@ -90408,6 +90432,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
@@ -90684,9 +90711,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
@@ -91235,6 +91259,9 @@
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "lcr" = (
@@ -91326,9 +91353,6 @@
 /turf/closed/wall,
 /area/service/bar)
 "leE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -91489,6 +91513,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
@@ -92049,18 +92076,25 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/main)
 "lss" = (
-/obj/structure/cable/white{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/white,
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Tools Storage";
+	req_access_txt = "32"
+	},
+/turf/open/floor/plasteel,
 /area/engineering/break_room)
 "lti" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped,
@@ -92105,6 +92139,9 @@
 	name = "engineering camera"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "luF" = (
@@ -92556,22 +92593,6 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engineering/break_room)
-"lCx" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/ce,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/command/heads_quarters/ce)
 "lCB" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -92738,9 +92759,6 @@
 /area/command/teleporter)
 "lEK" = (
 /obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -92864,12 +92882,6 @@
 /obj/machinery/light,
 /obj/structure/cable/white{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -93055,9 +93067,6 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/glasses/meson/engine,
 /obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
@@ -93091,12 +93100,6 @@
 /area/service/abandoned_gambling_den)
 "lLv" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/blue{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/folder/yellow,
-/obj/item/lighter,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -93262,6 +93265,7 @@
 /obj/item/clothing/head/cone,
 /obj/item/clothing/head/cone,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "lNU" = (
@@ -93413,6 +93417,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "lQx" = (
@@ -93524,6 +93529,9 @@
 "lTp" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/bot,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "lTx" = (
@@ -93996,10 +94004,6 @@
 /area/engineering/atmos)
 "mcs" = (
 /obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/gps/engineering{
-	gpstag = "CE0"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -94091,16 +94095,12 @@
 /turf/open/floor/plasteel,
 /area/service/bar/atrium)
 "mdG" = (
-/obj/structure/rack,
 /obj/machinery/button/door{
 	id = "engpa";
 	name = "Engineering Chamber Shutters Control";
 	pixel_y = 26;
 	req_access_txt = "11"
 	},
-/obj/item/storage/belt/utility,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -94219,9 +94219,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -94231,6 +94228,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
@@ -95160,7 +95160,6 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Supermatter Engine - Port";
 	dir = 4;
@@ -95208,7 +95207,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -96183,6 +96181,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "mMH" = (
@@ -96984,11 +96985,11 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "mZU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmospherics_engine)
@@ -97472,17 +97473,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
-"njN" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/machinery/power/emitter/anchored{
-	dir = 1;
-	state = 2
-	},
-/turf/open/floor/circuit/green,
-/area/engineering/atmospherics_engine)
 "njZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -97764,7 +97754,6 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "npu" = (
-/obj/machinery/light,
 /obj/machinery/computer/station_alert{
 	dir = 1
 	},
@@ -97778,6 +97767,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "npH" = (
@@ -97916,12 +97906,12 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "nrL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/circuit/green,
 /area/engineering/atmospherics_engine)
@@ -98021,10 +98011,9 @@
 /area/commons/fitness/recreation)
 "nsY" = (
 /obj/structure/rack,
-/obj/item/crowbar,
-/obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/stack/cable_coil/white,
 /obj/effect/turf_decal/bot,
+/obj/item/tank/internals/emergency_oxygen/double,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "nte" = (
@@ -98078,6 +98067,17 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/command/heads_quarters/captain/private)
+"ntP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "num" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -99032,7 +99032,6 @@
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "nKC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -99409,9 +99408,6 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -99528,6 +99524,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "nSH" = (
@@ -99614,6 +99613,22 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
+/area/engineering/atmos)
+"nTw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "nUc" = (
 /obj/structure/sign/directions/command{
@@ -99849,6 +99864,9 @@
 /area/engineering/main)
 "nYu" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "nYy" = (
@@ -99907,7 +99925,6 @@
 /area/command/bridge)
 "nZq" = (
 /obj/structure/rack,
-/obj/item/crowbar,
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -100460,10 +100477,11 @@
 /area/engineering/atmos)
 "okJ" = (
 /obj/structure/rack,
-/obj/item/crowbar,
-/obj/item/wirecutters,
-/obj/item/stack/cable_coil/white,
 /obj/effect/turf_decal/bot,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/airlock_painter/decal,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "okO" = (
@@ -100569,25 +100587,17 @@
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
 "ont" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Power Tools Storage";
-	req_access_txt = "19"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engineering/break_room)
 "onx" = (
 /obj/machinery/status_display/evac{
@@ -100735,7 +100745,6 @@
 /turf/open/floor/plating/airless,
 /area/engineering/main)
 "opj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -100744,8 +100753,8 @@
 /area/engineering/atmospherics_engine)
 "opu" = (
 /obj/structure/sign/warning/electricshock,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmospherics_engine)
@@ -101216,9 +101225,6 @@
 "oyS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -101316,7 +101322,6 @@
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
 "oAn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -101592,9 +101597,6 @@
 /area/service/library)
 "oGD" = (
 /obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -101700,9 +101702,6 @@
 	},
 /obj/machinery/light_switch{
 	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -103645,12 +103644,12 @@
 /turf/open/floor/plasteel/dark,
 /area/service/library)
 "prb" = (
-/obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plasteel,
 /area/engineering/storage)
 "prr" = (
@@ -104777,7 +104776,6 @@
 /area/engineering/break_room)
 "pKe" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
@@ -105061,6 +105059,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "pNr" = (
@@ -105256,7 +105257,6 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/book/manual/wiki/engineering_singulo_tesla,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -105349,6 +105349,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "pRH" = (
@@ -105571,6 +105574,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "pWA" = (
@@ -105636,6 +105642,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "pXG" = (
@@ -105652,6 +105661,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
@@ -105796,6 +105808,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
@@ -106312,7 +106327,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -106982,6 +106996,10 @@
 /obj/effect/spawner/lootdrop/techstorage/RnD_secure,
 /turf/open/floor/plasteel,
 /area/engineering/storage/tech)
+"quU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qva" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /obj/effect/turf_decal/delivery,
@@ -107480,7 +107498,6 @@
 /area/cargo/sorting)
 "qFJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
@@ -107956,7 +107973,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engineering/storage)
@@ -108592,9 +108608,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
 "reD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
 /area/engineering/atmospherics_engine)
 "reJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -108648,6 +108665,9 @@
 "rfM" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "rfT" = (
@@ -109113,7 +109133,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -109690,13 +109709,12 @@
 	name = "Reflector Access";
 	req_one_access_txt = "24;10"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
@@ -110330,28 +110348,18 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "rHS" = (
-/obj/structure/rack,
 /obj/machinery/button/door{
 	id = "engpa";
 	name = "Engineering Chamber Shutters Control";
 	pixel_y = -26;
 	req_access_txt = "11"
 	},
-/obj/item/clothing/gloves/color/black,
-/obj/item/wrench,
-/obj/item/clothing/glasses/meson/engine,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -110900,6 +110908,9 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "rRk" = (
@@ -111197,9 +111208,6 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -111591,9 +111599,6 @@
 "saL" = (
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -112107,9 +112112,6 @@
 	pixel_x = -28;
 	pixel_y = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -112381,9 +112383,6 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
@@ -112643,6 +112642,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
 "sul" = (
@@ -112666,13 +112666,9 @@
 /turf/open/floor/plasteel,
 /area/service/kitchen)
 "suD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -113135,14 +113131,9 @@
 /area/engineering/break_room)
 "sEp" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/rglass{
-	amount = 30;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/stack/cable_coil/white,
 /obj/effect/turf_decal/bot,
+/obj/item/construction/rcd/loaded/upgraded,
+/obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "sEF" = (
@@ -113357,6 +113348,9 @@
 	},
 /obj/machinery/light/small,
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "sIm" = (
@@ -113377,7 +113371,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -113996,11 +113989,15 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "sSp" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
+/obj/structure/table/reinforced,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/rglass{
+	amount = 30;
+	pixel_x = 2;
+	pixel_y = -2
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/item/stack/cable_coil/white,
+/turf/open/floor/plasteel,
 /area/engineering/break_room)
 "sSv" = (
 /obj/structure/cable/white{
@@ -114402,7 +114399,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/abandoned_gambling_den/secondary)
 "sYu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -114413,6 +114409,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmospherics_engine)
 "sYG" = (
@@ -114554,16 +114551,13 @@
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
 "sZO" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/dark/corner,
 /area/engineering/main)
 "sZW" = (
@@ -115446,9 +115440,9 @@
 /turf/open/floor/plasteel,
 /area/commons/toilet/restrooms)
 "tpa" = (
-/obj/item/weldingtool/largetank,
-/turf/open/floor/plating,
-/area/engineering/main)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "tpd" = (
 /obj/structure/cable/white{
 	icon_state = "1-4"
@@ -115465,8 +115459,8 @@
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/break_room)
 "tpq" = (
@@ -116929,12 +116923,15 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/library)
 "tPO" = (
-/obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/weldingtool/hugetank,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
 /turf/open/floor/plasteel,
 /area/engineering/storage)
 "tQa" = (
@@ -117022,9 +117019,11 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "tRl" = (
-/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
 /turf/open/floor/plating,
-/area/engineering/main)
+/area/maintenance/port/fore)
 "tRE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -117298,6 +117297,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/supermatter)
+"tVG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "tVI" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -117483,6 +117486,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
 "tYG" = (
@@ -117618,13 +117622,10 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	name = "Engineering Junction";
-	sortType = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "uaV" = (
@@ -118725,9 +118726,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -119419,9 +119417,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
+"uJy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "uJG" = (
-/obj/structure/rack,
-/obj/item/storage/secure/briefcase,
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
@@ -120543,9 +120551,6 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
@@ -120699,26 +120704,11 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/hop)
-"vib" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmospherics_engine)
 "vif" = (
 /obj/structure/sign/warning/radiation,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmospherics_engine)
 "vii" = (
@@ -120749,9 +120739,6 @@
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
 "vjf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -120916,9 +120903,6 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "vmV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1
@@ -120926,6 +120910,9 @@
 /obj/machinery/power/emitter/anchored{
 	dir = 1;
 	state = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/circuit/green,
 /area/engineering/atmospherics_engine)
@@ -121607,9 +121594,6 @@
 /turf/open/floor/plating,
 /area/commons/toilet/auxiliary)
 "vAl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -121659,16 +121643,6 @@
 /area/service/chapel/office)
 "vBq" = (
 /obj/structure/table/reinforced,
-/obj/item/cartridge/engineering{
-	pixel_x = 6
-	},
-/obj/item/cartridge/engineering{
-	pixel_x = -6
-	},
-/obj/item/cartridge/engineering{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/pill/patch/silver_sulf,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -121679,6 +121653,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/clipboard,
+/obj/item/folder/blue{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/folder/yellow,
+/obj/item/toy/figure/ce,
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
 "vBC" = (
@@ -122029,9 +122010,6 @@
 /area/service/library/abandoned)
 "vJs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -122195,6 +122173,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/office)
+"vMZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "vNj" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -122413,6 +122395,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
@@ -122694,6 +122679,7 @@
 /area/command/gateway)
 "vXY" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
 "vYd" = (
@@ -122857,21 +122843,9 @@
 /turf/open/floor/plasteel,
 /area/commons/vacant_room/commissary)
 "waq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmospherics_engine)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "war" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -123290,6 +123264,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/engineering/atmospherics_engine)
 "wiI" = (
@@ -124178,9 +124153,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -124624,12 +124596,6 @@
 /turf/open/floor/plasteel,
 /area/command/gateway)
 "wDU" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/cartridge/atmos,
-/obj/item/cartridge/atmos,
-/obj/item/cartridge/atmos,
-/obj/item/stamp/ce,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -124640,6 +124606,15 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/rack,
+/obj/item/cartridge/atmos{
+	pixel_x = -3
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = 6
+	},
+/obj/item/storage/secure/briefcase,
+/obj/item/reagent_containers/pill/patch/silver_sulf,
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "wDV" = (
@@ -126407,9 +126382,6 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
@@ -126552,8 +126524,8 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
@@ -126595,8 +126567,10 @@
 /area/commons/fitness/recreation)
 "xoB" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 3
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -126606,6 +126580,22 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/denied{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/stamp{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/stamp/ce{
+	pixel_x = 8;
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
@@ -127274,6 +127264,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/abandoned_gambling_den)
+"xBF" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/maintenance/disposal/incinerator)
 "xBP" = (
 /obj/machinery/computer/security/mining,
 /obj/effect/turf_decal/tile/purple{
@@ -127660,7 +127659,6 @@
 /area/cargo/storage)
 "xKr" = (
 /obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -127671,6 +127669,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/lighter,
+/obj/item/flashlight/lamp,
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
 "xKu" = (
@@ -128230,9 +128230,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/abandoned_gambling_den)
 "xUl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -128453,25 +128450,17 @@
 /turf/open/floor/wood,
 /area/command/blueshieldoffice)
 "xYk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Power Tools Storage";
-	req_access_txt = "19"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable/white{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engineering/break_room)
 "xYm" = (
 /obj/structure/cable{
@@ -129331,9 +129320,6 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -152347,7 +152333,7 @@ rqi
 vLg
 twN
 sSp
-iqL
+whB
 lss
 mMB
 pRP
@@ -152356,7 +152342,7 @@ mcs
 tGF
 xKr
 lLv
-lCx
+lLv
 vBq
 ikP
 vXq
@@ -152819,24 +152805,24 @@ ajr
 aad
 ajr
 aad
-hGj
+asH
 vXY
 vXY
 wiE
 vXY
 vXY
 vXY
-hGj
+hff
 vXY
 vXY
 vXY
 wiE
-hGj
+hFK
 aFr
 ueE
 aJQ
-aLk
-xDu
+xBF
+qaO
 eqS
 txj
 mUX
@@ -152886,7 +152872,7 @@ kVk
 rXT
 hIu
 hIu
-tRl
+hIu
 spg
 kVk
 reO
@@ -153076,24 +153062,24 @@ aad
 aad
 aad
 aad
-hGj
+aBZ
 lKL
 goO
 opj
-reD
+vdS
 eSp
 eSp
 mwV
 oAn
-reD
-reD
+vdS
+vdS
 opj
 xnI
-aFr
+vMZ
 aIy
 aJR
 aLm
-hgp
+lUA
 mfO
 gCE
 lfN
@@ -153333,9 +153319,9 @@ hGj
 hGj
 hGj
 hGj
-hGj
+gCU
 fCU
-aBZ
+sVs
 jmX
 sVs
 mJF
@@ -153399,7 +153385,7 @@ nsY
 pzB
 icy
 hJl
-tpa
+hIu
 ylT
 fTv
 pzB
@@ -153608,7 +153594,7 @@ inc
 iPU
 rzU
 lUA
-xrk
+nTw
 fcn
 lfN
 oUP
@@ -154122,7 +154108,7 @@ mEe
 qsc
 uNf
 lUA
-xrk
+nTw
 fcn
 lfN
 oUP
@@ -154630,13 +154616,13 @@ pcN
 pcY
 kCt
 juu
-waq
+lLZ
 rVN
 hGj
 pCB
 rAp
 lUA
-xrk
+nTw
 pDr
 lfN
 oUP
@@ -154875,7 +154861,7 @@ kSw
 rHB
 rHB
 rHB
-iWb
+hgp
 mZU
 nhM
 ihF
@@ -154887,7 +154873,7 @@ xDH
 fhW
 qUW
 rYG
-gLj
+vjf
 hdc
 uaV
 mYC
@@ -155658,9 +155644,9 @@ gEH
 pcY
 kCt
 tVA
-waq
+lLZ
 oIb
-hGj
+aBZ
 nBZ
 ulp
 lUA
@@ -155904,7 +155890,7 @@ sIq
 sIq
 sIq
 sLy
-fKW
+rHQ
 qFt
 uJU
 kCt
@@ -155915,9 +155901,9 @@ kCt
 jSQ
 wGF
 hey
-vib
+vjf
 eNX
-hGj
+tVG
 hGj
 hGj
 lUA
@@ -156421,7 +156407,7 @@ vmV
 suD
 sIp
 nKC
-gCU
+sVs
 gfX
 uuq
 mxo
@@ -156674,7 +156660,7 @@ sIq
 sIq
 sIq
 lBY
-njN
+vmV
 wxx
 ktw
 vKd
@@ -156931,7 +156917,7 @@ hGj
 hGj
 hGj
 hGj
-hGj
+iqL
 pNn
 gSJ
 tEZ
@@ -157188,7 +157174,7 @@ aad
 aaa
 aad
 aaa
-hGj
+iqL
 lcb
 gnV
 kkI
@@ -157445,13 +157431,13 @@ aad
 aad
 aad
 aad
-hGj
-hGj
-hGj
+reD
+tpa
+tpa
 stO
 stO
-hGj
-hGj
+ilQ
+tpa
 lQc
 qyD
 hGj
@@ -157707,7 +157693,7 @@ aad
 aaa
 jso
 jso
-hGj
+aBZ
 mIr
 hVY
 kij
@@ -157964,7 +157950,7 @@ alf
 alf
 aqV
 aqV
-hGj
+aBZ
 inc
 pXG
 mEe
@@ -158217,19 +158203,19 @@ rNg
 qXd
 vcS
 tiz
-alg
-alg
-avm
-alg
-arB
+tRl
+waq
+bxK
+waq
+fIy
 ayS
-avm
-alg
-arB
-arB
-aug
-alg
-alg
+apK
+quU
+gmv
+gmv
+ntP
+quU
+quU
 kND
 aKg
 alf
@@ -158474,7 +158460,7 @@ pZh
 mzL
 mOS
 tiz
-alg
+asY
 aub
 avn
 alg
@@ -159759,7 +159745,7 @@ hVA
 pwF
 wng
 quN
-asH
+asP
 alf
 avr
 awp
@@ -159772,7 +159758,7 @@ uWg
 knQ
 mLS
 peV
-aIH
+uJy
 aKi
 qOV
 qDq

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4614,18 +4614,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
-"apK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/fore)
 "aqh" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /obj/structure/window/reinforced{
@@ -15544,6 +15532,10 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"bot" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "boE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -18027,16 +18019,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"bxK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/maintenance/port/fore)
 "bxP" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -21477,6 +21459,11 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
+"bLH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "bMa" = (
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
@@ -41753,6 +41740,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cVb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "cVl" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/fire/firefighter,
@@ -45084,6 +45075,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dbF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "dbM" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -72086,6 +72082,10 @@
 /obj/machinery/chem_dispenser/apothecary,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"eLR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "eLT" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -73179,6 +73179,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
+"fgB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "fgC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -74279,6 +74283,13 @@
 	},
 /turf/closed/wall,
 /area/commons/vacant_room/commissary)
+"fBq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "fBw" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -74767,11 +74778,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"fIy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/maintenance/port/fore)
 "fIz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -76493,11 +76499,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
-"gmv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "gnd" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
@@ -78836,10 +78837,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/engineering/atmos)
-"hff" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/engineering/atmospherics_engine)
 "hfm" = (
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -80404,12 +80401,6 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/solars/port/fore)
-"hFK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmospherics_engine)
 "hFQ" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
@@ -82411,13 +82402,6 @@
 	heat_capacity = 1e+006
 	},
 /area/command/heads_quarters/ce)
-"ilQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmospherics_engine)
 "imf" = (
 /obj/structure/table/wood,
 /obj/machinery/status_display/evac{
@@ -96439,7 +96423,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "Gravity Generator Chamber";
-	req_access_txt = "19; 61"
+	req_access_txt = "10"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -98067,17 +98051,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/command/heads_quarters/captain/private)
-"ntP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/maintenance/port/fore)
 "num" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -98570,6 +98543,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
+"nBT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "nBU" = (
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -98817,6 +98796,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"nGu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "nGB" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -99614,22 +99605,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"nTw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engineering/atmos)
 "nUc" = (
 /obj/structure/sign/directions/command{
 	dir = 1
@@ -99726,6 +99701,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
+"nVV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
 "nWn" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -102076,6 +102067,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"oNg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "oNF" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -103707,6 +103710,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"psH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "psM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -105473,6 +105487,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
+"pTS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/port/fore)
 "pUe" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
@@ -106443,7 +106467,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
-	req_access_txt = "19;23"
+	req_access_txt = "10"
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -106996,10 +107020,6 @@
 /obj/effect/spawner/lootdrop/techstorage/RnD_secure,
 /turf/open/floor/plasteel,
 /area/engineering/storage/tech)
-"quU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "qva" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /obj/effect/turf_decal/delivery,
@@ -113727,6 +113747,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/office)
+"sNx" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/maintenance/disposal/incinerator)
 "sOh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -117297,10 +117326,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/supermatter)
-"tVG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/engineering/atmospherics_engine)
 "tVI" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -119417,18 +119442,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
-"uJy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/fore)
 "uJG" = (
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -122173,10 +122186,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/office)
-"vMZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "vNj" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -127264,15 +127273,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/abandoned_gambling_den)
-"xBF" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/maintenance/disposal/incinerator)
 "xBP" = (
 /obj/machinery/computer/security/mining,
 /obj/effect/turf_decal/tile/purple{
@@ -152812,16 +152812,16 @@ wiE
 vXY
 vXY
 vXY
-hff
+cVb
 vXY
 vXY
 vXY
 wiE
-hFK
+nBT
 aFr
 ueE
 aJQ
-xBF
+sNx
 qaO
 eqS
 txj
@@ -153075,7 +153075,7 @@ vdS
 vdS
 opj
 xnI
-vMZ
+fgB
 aIy
 aJR
 aLm
@@ -153594,7 +153594,7 @@ inc
 iPU
 rzU
 lUA
-nTw
+nVV
 fcn
 lfN
 oUP
@@ -154108,7 +154108,7 @@ mEe
 qsc
 uNf
 lUA
-nTw
+nVV
 fcn
 lfN
 oUP
@@ -154622,7 +154622,7 @@ hGj
 pCB
 rAp
 lUA
-nTw
+nVV
 pDr
 lfN
 oUP
@@ -155903,7 +155903,7 @@ wGF
 hey
 vjf
 eNX
-tVG
+bot
 hGj
 hGj
 lUA
@@ -157436,7 +157436,7 @@ tpa
 tpa
 stO
 stO
-ilQ
+fBq
 tpa
 lQc
 qyD
@@ -158205,17 +158205,17 @@ vcS
 tiz
 tRl
 waq
-bxK
+pTS
 waq
-fIy
+dbF
 ayS
-apK
-quU
-gmv
-gmv
-ntP
-quU
-quU
+oNg
+eLR
+bLH
+bLH
+psH
+eLR
+eLR
 kND
 aKg
 alf
@@ -159758,7 +159758,7 @@ uWg
 knQ
 mLS
 peV
-uJy
+nGu
 aKi
 qOV
 qDq


### PR DESCRIPTION
# About The Pull Request
• Fixes dark spots in engineering due to lack of lighting.
• Removes junk-clutter in engineering and the CE's office.
• Second disposals bin for engineering, near the lathes. Mail sorting now goes to this bin.
• Autolathe in engineering, saves the manual task of removing the plasteel table and putting an autolathe there every shift.
• Power tool storage now has engineering access. It gets hacked into **every** round. That's it's only purpose. May as well skip the chore. It also has the welding tool too.
• Supermatter engine room has the scrubbers and supply piping moved out of the way to allow more modification to the default engine. Previously, a quarter to a third of the floorspace was taken up by air and scrubber pipes. Now it's kinda like a tenth at most.
• Gravity Generator access is now set to engine access, akin to Boxstation.

## Why It's Good For The Game
Removes minor sources of frustration from Delta that collectively gets annoying. Delta is full of junk, yeah it's a charm, but... do engineers need black gloves? Do they need five wrenches? Is there a solid gameplay reason for having engineers on Delta hack the door for power tools?

This is all harmless stuff that makes things a little more fun.

## A Port?
Nope!

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
qol: Some love given to Deltastation engineering to make it less annoying to play. Clutter cleaned up, piping underneath the SM cleaned up, and extra disposal bins!
fix: Dark spots in Deltastation engineering fixed.
/:cl:
