### PR TITLE
Adds breasts to 'Set Gender' verb

### DIFF
--- a/modular_splurt/code/modules/mob/living/silicon/pai/pai.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/pai/pai.dm
@@ -22,7 +22,4 @@
 			has_balls = FALSE
 			has_vagina = FALSE
 		if("Toggle Breasts")
-			if(!has_breasts)
-				has_breasts = TRUE
-			else
-				has_breasts = FALSE
+			has_breasts = !has_breasts

--- a/modular_splurt/code/modules/mob/living/silicon/pai/pai.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/pai/pai.dm
@@ -3,7 +3,7 @@
 	set desc = "Allows you to set your gender."
 	set category = "IC"
 
-	var/choice = tgui_alert(usr, "Select Gender.", "Gender", list("Both", "Male", "Female", "None"))
+	var/choice = tgui_alert(usr, "Select Gender.", "Gender", list("Both", "Male", "Female", "None","Toggle Breasts"))
 	switch(choice)
 		if("Both")
 			has_penis = TRUE
@@ -21,3 +21,8 @@
 			has_penis = FALSE
 			has_balls = FALSE
 			has_vagina = FALSE
+		if("Toggle Breasts")
+			if(!has_breasts)
+				has_breasts = TRUE
+			else
+				has_breasts = FALSE

--- a/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
@@ -28,10 +28,8 @@
 			has_balls = FALSE
 			has_vagina = FALSE
 		if("Toggle Breasts")
-			if(!has_breasts)
-				has_breasts = TRUE
-			else
-				has_breasts = FALSE
+			has_breasts = !has_breasts
+
 // Slaver medical borg
 /mob/living/silicon/robot/modules/syndicate/slaver/medical
 	faction = list(ROLE_SLAVER)

--- a/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
@@ -9,7 +9,7 @@
 		to_chat(usr, "<span class='warning'>You cannot toggle your gender while unconcious!</span>")
 		return
 
-	var/choice = tgui_alert(usr, "Select Gender.", "Gender", list("Both", "Male", "Female", "None"))
+	var/choice = tgui_alert(usr, "Select Gender.", "Gender", list("Both", "Male", "Female", "None","Toggle Breasts"))
 	switch(choice)
 		if("Both")
 			has_penis = TRUE
@@ -27,7 +27,11 @@
 			has_penis = FALSE
 			has_balls = FALSE
 			has_vagina = FALSE
-
+		if("Toggle Breasts")
+			if(!has_breasts)
+				has_breasts = TRUE
+			else
+				has_breasts = FALSE
 // Slaver medical borg
 /mob/living/silicon/robot/modules/syndicate/slaver/medical
 	faction = list(ROLE_SLAVER)

--- a/modular_splurt/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/modular_splurt/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -22,7 +22,4 @@
 			has_balls = FALSE
 			has_vagina = FALSE
 		if("Toggle Breasts")
-			if(!has_breasts)
-				has_breasts = TRUE
-			else
-				has_breasts = FALSE
+			has_breasts = !has_breasts

--- a/modular_splurt/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/modular_splurt/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -3,7 +3,7 @@
 	set desc = "Allows you to set your gender."
 	set category = "IC"
 
-	var/choice = tgui_alert(usr, "Select Gender.", "Gender", list("Both", "Male", "Female", "None"))
+	var/choice = tgui_alert(usr, "Select Gender.", "Gender", list("Both", "Male", "Female", "None","Toggle Breasts"))
 	switch(choice)
 		if("Both")
 			has_penis = TRUE
@@ -21,3 +21,8 @@
 			has_penis = FALSE
 			has_balls = FALSE
 			has_vagina = FALSE
+		if("Toggle Breasts")
+			if(!has_breasts)
+				has_breasts = TRUE
+			else
+				has_breasts = FALSE


### PR DESCRIPTION
# About The Pull Request
Makes it so the 'Set Gender' verb has a 'toggle breasts' option which, well, toggles breasts. 

## Why It's Good For The Game
Let borgs, pai's (And simplemobs I guess), have mommy milkers

## A Port?

No

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
code: changed some code
/:cl:
