### PR TITLE
Bandaid fix for Nightshift switching

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -41,24 +41,15 @@ SUBSYSTEM_DEF(nightshift)
 	if(nightshift_active != night_time)
 		update_nightshift(night_time, announcing)
 
-/datum/controller/subsystem/nightshift/proc/update_nightshift(active, announce = TRUE, max_level_override)
-	set waitfor = FALSE
+/datum/controller/subsystem/nightshift/proc/update_nightshift(active, announce = TRUE)
 	nightshift_active = active
 	if(announce)
 		if (active)
 			announce("Good evening, crew. To reduce power consumption and stimulate the circadian rhythms of some species, all of the lights aboard the station have been dimmed for the night.")
 		else
 			announce("Good morning, crew. As it is now day time, all of the lights aboard the station have been restored to their former brightness.")
-	var/max_level
-	var/configured_level = CONFIG_GET(number/night_shift_public_areas_only)
-	if(isnull(max_level_override))
-		max_level = active? configured_level : INFINITY		//by default, deactivating shuts off nightshifts everywhere.
-	else
-		max_level = max_level_override
 	for(var/A in GLOB.apcs_list)
 		var/obj/machinery/power/apc/APC = A
-		if(APC.area?.type in GLOB.the_station_areas)
-			var/their_level = APC.area.nightshift_public_area
-			if(!max_level || (their_level <= max_level))		//if max level is 0, it means public area-only config is disabled so hit everything. if their level is 0, it means they have nightshift forced.
-				APC.set_nightshift(active)
-				CHECK_TICK
+		if(APC.area && (APC.area.type in GLOB.the_station_areas))
+			APC.set_nightshift(active)
+			CHECK_TICK


### PR DESCRIPTION
Might need a test-merge to see if it breaks something else... Just to be sure.
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
While won't accurately (at least it looked like so on my machine) switch in correct time, nightshift still should "just work" now, instead of suddenly deciding to update mode of the lighting only while alert level changes.
Speaking of, also *supposedly* makes an announcement of nightshift turning off due emergency "less annoying".
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
Hey, nothing wrong with moody lighting from time to time.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
~~Stolen~~ Borrowed from nu-skyrat code (well, the one before the subsystem rework).
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl: Anonymous
fix: Band-aid fixes nightshift not switching on and off at required times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
