### PR TITLE
A poor attempt to de-duplicate "Set Gender" verb code

### DIFF
--- a/modular_splurt/code/modules/mob/living/living.dm
+++ b/modular_splurt/code/modules/mob/living/living.dm
@@ -1,6 +1,33 @@
 /mob/living
 	var/datum/action/sizecode_smallsprite/small_sprite
 
+/// Gender Change
+// Intended only for silicons/robots (incl. pAI) and simple_animal code so far. This proc was made to somewhat ease up duplicated verb code.
+// There's probably better way to do this but I am terrible at it --Nopeman
+/mob/living/proc/change_gender()
+	if(stat != CONSCIOUS)
+		to_chat(usr, "<span class='warning'>You cannot toggle your gender while unconcious!</span>")
+		return
+
+	var/choice = tgui_alert(usr, "Select Gender.", "Gender", list("Both", "Male", "Female", "None", "Toggle Breasts"))
+	switch(choice)
+		if("Both")
+			has_penis = TRUE
+			has_balls = TRUE
+			has_vagina = TRUE
+		if("Male")
+			has_penis = TRUE
+			has_balls = TRUE
+			has_vagina = FALSE
+		if("Female")
+			has_penis = FALSE
+			has_balls = FALSE
+			has_vagina = TRUE
+		if("None")
+			has_penis = FALSE
+			has_balls = FALSE
+			has_vagina = FALSE
+
 /// Toggle admin frozen
 /mob/living/proc/toggle_admin_freeze(client/admin)
 	admin_frozen = !admin_frozen

--- a/modular_splurt/code/modules/mob/living/living.dm
+++ b/modular_splurt/code/modules/mob/living/living.dm
@@ -27,6 +27,8 @@
 			has_penis = FALSE
 			has_balls = FALSE
 			has_vagina = FALSE
+		if("Toggle Breasts") // Idea/Initial code by @LunarFleet (github)
+			has_breasts = !has_breasts // Simplified line by @Zirok-BYOND (github)
 
 /// Toggle admin frozen
 /mob/living/proc/toggle_admin_freeze(client/admin)

--- a/modular_splurt/code/modules/mob/living/silicon/pai/pai.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/pai/pai.dm
@@ -2,22 +2,4 @@
 	set name = "Set Gender"
 	set desc = "Allows you to set your gender."
 	set category = "IC"
-
-	var/choice = tgui_alert(usr, "Select Gender.", "Gender", list("Both", "Male", "Female", "None"))
-	switch(choice)
-		if("Both")
-			has_penis = TRUE
-			has_balls = TRUE
-			has_vagina = TRUE
-		if("Male")
-			has_penis = TRUE
-			has_balls = TRUE
-			has_vagina = FALSE
-		if("Female")
-			has_penis = FALSE
-			has_balls = FALSE
-			has_vagina = TRUE
-		if("None")
-			has_penis = FALSE
-			has_balls = FALSE
-			has_vagina = FALSE
+	change_gender()

--- a/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
@@ -1,32 +1,11 @@
 //Main code edits
 /// Allows "cyborg" players to change gender at will - Modularised here
+// FUNCTION MOVED TO living.dm AS PROC
 /mob/living/silicon/robot/verb/toggle_gender()
 	set name = "Set Gender"
 	set desc = "Allows you to set your gender."
 	set category = "Robot Commands"
-
-	if(stat != CONSCIOUS)
-		to_chat(usr, "<span class='warning'>You cannot toggle your gender while unconcious!</span>")
-		return
-
-	var/choice = tgui_alert(usr, "Select Gender.", "Gender", list("Both", "Male", "Female", "None"))
-	switch(choice)
-		if("Both")
-			has_penis = TRUE
-			has_balls = TRUE
-			has_vagina = TRUE
-		if("Male")
-			has_penis = TRUE
-			has_balls = TRUE
-			has_vagina = FALSE
-		if("Female")
-			has_penis = FALSE
-			has_balls = FALSE
-			has_vagina = TRUE
-		if("None")
-			has_penis = FALSE
-			has_balls = FALSE
-			has_vagina = FALSE
+	change_gender()
 
 // Slaver medical borg
 /mob/living/silicon/robot/modules/syndicate/slaver/medical

--- a/modular_splurt/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/modular_splurt/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -2,22 +2,4 @@
 	set name = "Set Gender"
 	set desc = "Allows you to set your gender."
 	set category = "IC"
-
-	var/choice = tgui_alert(usr, "Select Gender.", "Gender", list("Both", "Male", "Female", "None"))
-	switch(choice)
-		if("Both")
-			has_penis = TRUE
-			has_balls = TRUE
-			has_vagina = TRUE
-		if("Male")
-			has_penis = TRUE
-			has_balls = TRUE
-			has_vagina = FALSE
-		if("Female")
-			has_penis = FALSE
-			has_balls = FALSE
-			has_vagina = TRUE
-		if("None")
-			has_penis = FALSE
-			has_balls = FALSE
-			has_vagina = FALSE
+	change_gender()


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Verb to set gender for simple mobs and silicon+pAI is now call a shared proc instead of having major code copy-pasted to each related path. This is not very good attempt at "sharing" verb, but I cannot do it any better personally.
Note: Includes #568 changes (by @LunarFleet) along with @Zirok-BYOND edit suggestions.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
Better code readability? idk
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Not a port but (again) incorporates changes of #568 into proc edition.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl: Anonymous
code: Rewrites "Set Gender" for simple mobs and silicon as an upward proc for "mob/living", while makes previous verbs to call for the proc instead. While it'll help with verbs now sharing the same function (and thus easier to edit), I am not sure if it will help with duplicate code.
add: "Set Gender" menu (for silicon/simple mobs) now allow you to toggle breasts on and off (@LunarFleet).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
