### PR TITLE
Changes loincloth crafting and kinkmate loincloth

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -163,7 +163,8 @@ GLOBAL_LIST_INIT(leather_recipes, list ( \
 	new/datum/stack_recipe("leather shoes", /obj/item/clothing/shoes/laceup, 2), \
 	new/datum/stack_recipe("leather overcoat", /obj/item/clothing/suit/jacket/leather/overcoat, 10), \
 	new/datum/stack_recipe("gear harness", /obj/item/clothing/under/misc/gear_harness, 6), \
-	new/datum/stack_recipe("loincloth", /obj/item/clothing/under/costume/loincloth, 2), \
+	new/datum/stack_recipe("loincloth", /obj/item/clothing/under/costume/loincloth/sensor, 2), \
+	new/datum/stack_recipe("sensorless loincloth", /obj/item/clothing/under/costume/loincloth, 2), \
 ))
 
 /obj/item/stack/sheet/leather/get_main_recipes()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -384,7 +384,8 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("grey jumpsuit", /obj/item/clothing/under/color/grey, 3), \
 	new/datum/stack_recipe("black shoes", /obj/item/clothing/shoes/sneakers/black, 2), \
 	new/datum/stack_recipe("cloth footwraps", /obj/item/clothing/shoes/footwraps, 2), \
-	new/datum/stack_recipe("loincloth", /obj/item/clothing/under/costume/loincloth/cloth, 2), \
+	new/datum/stack_recipe("loincloth", /obj/item/clothing/under/costume/loincloth/cloth/sensor, 2), \
+	new/datum/stack_recipe("sensorless loincloth", /obj/item/clothing/under/costume/loincloth/cloth, 2), \
 	new/datum/stack_recipe("tunic", /obj/item/clothing/under/tunic, 3), \
 	null, \
 	new/datum/stack_recipe("backpack", /obj/item/storage/backpack, 4), \

--- a/modular_sand/code/modules/vending/kinkmate.dm
+++ b/modular_sand/code/modules/vending/kinkmate.dm
@@ -1,5 +1,5 @@
 /obj/machinery/vending/kink/Initialize(mapload)
-	products += list(/obj/item/clothing/under/costume/loincloth = 4,
+	products += list(/obj/item/clothing/under/costume/loincloth/sensor = 4,
 					/obj/item/fleshlight = 4,
 					/obj/item/storage/box/portallight = 4)
 	. = ..()


### PR DESCRIPTION
# About The Pull Request
Changes the leather and cloth crafting recipes to have both a loincloth with and without sensors. Also changes the loincloth in the kinkmate to have sensors.

## Why It's Good For The Game
Makes you not need to look for an autodrobe or have a loincloth in your loadout if you want to go a bit more tribal while retaining your suit sensors.

## A Port?

No

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
qol: Makes loincloths with and without sensors craftable, makes the loincloth from the kinkmate have sensors.
/:cl:
