### PR TITLE
Buffs Succubus/Incubus trait

### DIFF
--- a/modular_splurt/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -13,18 +13,18 @@
 //incubus and succubus additions below
 /datum/reagent/consumable/semen/on_mob_life(mob/living/carbon/M)
 	. = ..()
-	if(HAS_TRAIT(M,TRAIT_SUCCUBUS))
-		M.adjust_nutrition(1)
+	if(HAS_TRAIT(M,TRAIT_SUCCUBUS)||HAS_TRAIT(M,TRAIT_INCUBUS))
+		M.adjust_nutrition(2.5)
 
 /datum/reagent/consumable/ethanol/cum_in_a_hot_tub/semen/on_mob_life(mob/living/carbon/M)
 	. = ..()
-	if(HAS_TRAIT(M,TRAIT_SUCCUBUS))
+	if(HAS_TRAIT(M,TRAIT_SUCCUBUS)||HAS_TRAIT(M,TRAIT_INCUBUS))
 		M.adjust_nutrition(0.5)
 
 /datum/reagent/consumable/milk/on_mob_life(mob/living/carbon/M)
 	. = ..()
-	if(HAS_TRAIT(M,TRAIT_INCUBUS))
-		M.adjust_nutrition(1.5)
+	if(HAS_TRAIT(M,TRAIT_INCUBUS)||HAS_TRAIT(M,TRAIT_SUCCUBUS))
+		M.adjust_nutrition(4)
 
 /datum/reagent/blood/on_mob_life(mob/living/carbon/C)
 	. = ..()


### PR DESCRIPTION
# About The Pull Request
Makes it so the succubus/incubus traits can subsist off of both milk AND semen. Also buffs the amount of nutrition either chemical gives.

## Why It's Good For The Game
Makes using the traits more user friendly; nine out of ten doctors say that starving to death is no-good

## A Port?
Absolutely not

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
qol: Allows Mayhem to play a demon character without starving to death
/:cl: