### PR TITLE
traits grammar episode two

### DIFF
--- a/modular_splurt/code/datums/traits/good.dm
+++ b/modular_splurt/code/datums/traits/good.dm
@@ -140,6 +140,6 @@
 
 /datum/quirk/flutter
 	name = "Flutter"
-	desc = "You are able to move in Preassurized Low Gravity enviroments. Don't ask me how."
+	desc = "You are able to move about freely in pressurized low-gravity environments be it through the use of wings, magic, or some other physiological nonsense."
 	value = 1
 	mob_trait = TRAIT_FLUTTER

--- a/modular_splurt/code/datums/traits/neutral.dm
+++ b/modular_splurt/code/datums/traits/neutral.dm
@@ -37,7 +37,7 @@
 
 /datum/quirk/headpat_hater
 	name = "Distant"
-	desc = "You don't seem to show much care for being touched. Whether it's because you're reserved or due to self control, others touching your head won't make you wag your tail should you possess one, and the action may even attract your ire.."
+	desc = "You don't seem to show much care for being touched. Whether it's because you're reserved or due to self control, others touching your head won't make you wag your tail should you possess one, and the action may even attract your ire."
 	mob_trait = TRAIT_DISTANT
 	value = 0
 	gain_text = "<span class='notice'>Others' touches begin to make your blood boil...</span>"
@@ -164,7 +164,7 @@
 
 /datum/quirk/overweight
 	name = "Overweight"
-	desc = "You're particularly fond of food, and join the round being overweight."
+	desc = "You're particularly fond of food, and join the shift being overweight."
 	value = 0
 	gain_text = "<span class='notice'>You feel a bit chubby!</span>"
 	//no lose_text cause why would there be?
@@ -257,7 +257,7 @@
 		return
 	if(!user.has_quirk(/datum/quirk/dominant_aura))
 		return
-	examine_list += span_lewd("You can sense submissiveness irradiating from [quirk_holder.p_them()]")
+	examine_list += span_lewd("You sense a strong aura of submission from [quirk_holder.p_them()]")
 
 /datum/quirk/well_trained/on_process()
 	. = ..()
@@ -309,7 +309,7 @@
 		"Thoughts of being commanded flood you with lust...",
 		"You really want to be called a good [good_x]...",
 		"Someone's presence is making you all flustered...",
-		"You start getting excited and sweat..."
+		"You start getting sweaty and excited..."
 	)
 
 	to_chat(quirk_holder, span_lewd(pick(notices)))
@@ -516,7 +516,7 @@
 
 /datum/quirk/werewolf //adds the werewolf quirk
 	name = "Werewolf"
-	desc = "you are capable of turning into an anthropomorphic wolf (this is still being tested, please send any bugs to nukechicken on discord)"
+	desc = "A beastly affliction allows you to shapeshift into a more wolfish appearance at will! This will incrrease your size (In general and below!) and cause you to behave as though you were a mammal. (This is still being tested. Please send any bugs to nukechicken on discord)"
 	value = 0
 
 /datum/quirk/werewolf/add()
@@ -616,7 +616,7 @@
 
 /datum/action/werewolf
 	name = "Transform"
-	desc = "Transform into a wolf."
+	desc = "Transform into your wolf form."
 	icon_icon = 'modular_splurt/icons/mob/actions/misc_actions.dmi'
 	button_icon_state = "Transform"
 	var/transformed = FALSE
@@ -630,7 +630,7 @@
 	var/obj/item/organ/genital/vagina/V = H.getorganslot(ORGAN_SLOT_VAGINA)
 	H.shake_animation(2)
 	if(!transformed) // transform them
-		H.visible_message(span_danger("The pale touch of moonlight transforms [H] into an anthropomorphic wolf!"))
+		H.visible_message(span_danger("[H] shivers, their flesh bursting with a sudden growth of thick fur and their features twisting to something beastly, full transforming into a werewolf!"))
 		H.set_species(/datum/species/mammal, 1)
 		H.dna.species.mutant_bodyparts["mam_tail"] = "Wolf"
 		H.dna.species.mutant_bodyparts["legs"] = "Digitigrade"
@@ -660,7 +660,7 @@
 			V.color = "#[H.dna.features["mcolor"]]"
 			V.update()
 	else // untransform them
-		H.visible_message(span_danger("[H]'s features slowly recede from their wolfish appearance"))
+		H.visible_message(span_danger("[H] shrinks, their wolfish features quickly receding."))
 		H.set_species(old_features["species"], TRUE)
 		H.set_bark(old_features["bark"])
 		H.dna.features["mam_ears"] = old_features["mam_ears"]

--- a/modular_splurt/code/datums/traits/neutral.dm
+++ b/modular_splurt/code/datums/traits/neutral.dm
@@ -630,7 +630,7 @@
 	var/obj/item/organ/genital/vagina/V = H.getorganslot(ORGAN_SLOT_VAGINA)
 	H.shake_animation(2)
 	if(!transformed) // transform them
-		H.visible_message(span_danger("[H] shivers, their flesh bursting with a sudden growth of thick fur and their features twisting to something beastly, full transforming into a werewolf!"))
+		H.visible_message(span_danger("[H] shivers, their flesh bursting with a sudden growth of thick fur and their features contorting to that of a beast's, fully transforming them into a werewolf!"))
 		H.set_species(/datum/species/mammal, 1)
 		H.dna.species.mutant_bodyparts["mam_tail"] = "Wolf"
 		H.dna.species.mutant_bodyparts["legs"] = "Digitigrade"

--- a/modular_splurt/code/datums/traits/neutral.dm
+++ b/modular_splurt/code/datums/traits/neutral.dm
@@ -516,7 +516,7 @@
 
 /datum/quirk/werewolf //adds the werewolf quirk
 	name = "Werewolf"
-	desc = "A beastly affliction allows you to shapeshift into a more wolfish appearance at will! This will incrrease your size (In general and below!) and cause you to behave as though you were a mammal. (This is still being tested. Please send any bugs to nukechicken on discord)"
+	desc = "A beastly affliction allows you to shapeshift into a more wolfish appearance at will. This will increase your size (In general and below!) and cause you to behave as though you were an anthropomorphic canine. (This is still being tested. Please send any bugs to nukechicken on discord)"
 	value = 0
 
 /datum/quirk/werewolf/add()


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

does a second over of the traits files' grammar

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game

look at a dictionary please

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?

no

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
spellcheck: traits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
