### PR TITLE
Make Gear Harness adjusted by default

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -169,7 +169,7 @@
 	icon_state = "gear_harness"
 	item_state = "gear_harness"
 	can_adjust = TRUE
-	body_parts_covered = CHEST|GROIN
+	body_parts_covered = NONE
 
 /obj/item/clothing/under/misc/gear_harness/toggle_jumpsuit_adjust()
 	if(!body_parts_covered)

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -169,7 +169,7 @@
 	icon_state = "gear_harness"
 	item_state = "gear_harness"
 	can_adjust = TRUE
-	body_parts_covered = NONE
+	body_parts_covered = CHEST|GROIN
 
 /obj/item/clothing/under/misc/gear_harness/toggle_jumpsuit_adjust()
 	if(!body_parts_covered)

--- a/modular_splurt/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_splurt/code/modules/clothing/under/miscellaneous.dm
@@ -310,3 +310,4 @@
 
 /obj/item/clothing/under/misc/gear_harness
 	body_parts_covered = NONE
+

--- a/modular_splurt/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_splurt/code/modules/clothing/under/miscellaneous.dm
@@ -307,3 +307,6 @@
 	name = "yellow trencher uniform"
 	desc = "An utilitarian uniform of rugged warfare, with yellow insignias."
 	icon_state = "goner_uniform_y"
+
+/obj/item/clothing/under/misc/gear_harness
+	body_parts_covered = NONE


### PR DESCRIPTION
Needing to adjust the harness every time is annoying, counterproductive, and confusing. This does not prevent adjusting it back to covering.

# About The Pull Request

Reverts the default state of Gear Harness to not covering anything. It can still be adjusted normally.

## Why It's Good For The Game

Needing to manually adjust the gear harness every time is annoying, easy to forget, and confusing for people who don't know it can be adjusted.

## A Port?
No

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
tweak: Gear harness starts in adjusted mode
/:cl:
