### PR TITLE
Reduces a source of confusion with positronic brains

### DIFF
--- a/modular_splurt/code/modules/research/designs/mechfabricator_designs.dm
+++ b/modular_splurt/code/modules/research/designs/mechfabricator_designs.dm
@@ -191,7 +191,7 @@
 	category = list("IPC Organs")
 
 /datum/design/ipc_brain
-	name = "IPC Positronic Brain"
+	name = "IPC Brain (inert)"
 	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. It has an IPC serial number engraved on the top. It is usually slotted into the head of synthetic crewmembers."
 	id = "ipc_brain"
 	build_type = MECHFAB

--- a/modular_splurt/code/modules/research/designs/mechfabricator_designs.dm
+++ b/modular_splurt/code/modules/research/designs/mechfabricator_designs.dm
@@ -181,7 +181,7 @@
 	category = list("IPC Organs")
 
 /datum/design/ipc_tongue
-	name = "IPC Positronic Voicebox"
+	name = "IPC Voicebox"
 	desc = "A voice synthesizer used by IPCs to smoothly interface with organic lifeforms."
 	id = "ipc_tongue"
 	build_type = MECHFAB


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
This PR is just a name change for the printable IPC brain. I have observed several cases of inexperienced roboticists not knowing what is and is not a usable positronic brain, so I have removed the word "positronic" from the one that does not go to borgs. This should hopefully reduce confusion and mistakes. I was going to remove it completely, but you can print non-functional brains from the limb grower, and it would be inconsistent to remove them here.

Also got the voice box. Did you know that IPC stands for Integrated Positronic Chassis? "IPC Positronic" is redundant anyway.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
Reduces a source of OOC confusion.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
![image](https://user-images.githubusercontent.com/67441715/205735100-6b350f21-73f2-4f80-b841-5b2bc553fd09.png)
![image](https://user-images.githubusercontent.com/67441715/205735160-95f46228-47db-470b-bfe4-9b6df56e8470.png)

## A Port?
Nope.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
qol: removed the word "positronic" to reduce the number of items called this in the exosuit fab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
