### PR TITLE
New slut-type job titles for medical

### DIFF
--- a/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
+++ b/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
@@ -57,7 +57,11 @@
 	. = ..()
 
 /datum/job/cmo
-	alt_titles = list("Medical Director", "Medical Administrator") // Sandcode do not have alt titles for CMO at the moment.
+	alt_titles = list(
+		"Medical Director",
+		"Medical Administrator",
+		"Chief Medical Slut"
+	) // Sandcode do not have alt titles for CMO at the moment.
 
 
 // Engineering
@@ -211,7 +215,8 @@
 	var/list/extra_titles = list(
 		"Alchemist",
 		"Apothecarist",
-		"Chemical Plumber"
+		"Chemical Plumber",
+		"Chemi-Slut"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
@@ -221,7 +226,8 @@
 		"Physician",
 		"Medical Intern",
 		"Medical Resident",
-		"Medtech"
+		"Medtech",
+		"Medi-Slut"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
@@ -235,21 +241,24 @@
 		"Hypnotherapist",
 		"Sex Educator",
 		"Rental Mommy",
-		"Rental Daddy"
+		"Rental Daddy",
+		"Psycho-Slut"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
 
 /datum/job/geneticist/New()
 	var/list/extra_titles = list(
-		"Genetics Researcher"
+		"Genetics Researcher",
+		"Geneti-Slut"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
 
 /datum/job/paramedic/New()
 	var/list/extra_titles = list(
-		"Trauma Team"
+		"Trauma Team",
+		"Para-Slut"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
@@ -257,7 +266,8 @@
 /datum/job/virologist/New()
 	var/list/extra_titles = list(
 		"Microbiologist",
-		"Biochemist"
+		"Biochemist",
+		"Viro-Slut"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()

--- a/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
+++ b/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
@@ -60,7 +60,7 @@
 	alt_titles = list(
 		"Medical Director",
 		"Medical Administrator",
-		"Chief Medical Slut"
+		"Chief Heal Slut"
 	) // Sandcode do not have alt titles for CMO at the moment.
 
 
@@ -242,7 +242,7 @@
 		"Sex Educator",
 		"Rental Mommy",
 		"Rental Daddy",
-		"Psycho-Slut"
+		"Psycholo-Slut"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
@@ -250,7 +250,7 @@
 /datum/job/geneticist/New()
 	var/list/extra_titles = list(
 		"Genetics Researcher",
-		"Geneti-Slut"
+		"Gene-Slut"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()


### PR DESCRIPTION
# About The Pull Request
_Originally suggested by Average Water Enjoyer#5949, but adjusted for consistency._
Adds a job-slut title for all medical jobs

## Why It's Good For The Game
Allows the medical team to ~~ignore their jobs and~~ be even more horny.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
add: Added new job title for Chief Medical Officer: Chief Medical Slut
add: Added new job title for Medical Doctor: Medi-Slut
add: Added new job title for Paramedic: Para-Slut
add: Added new job title for Psychologist: Psycho-Slut
add: Added new job title for Chemist: Chemi-Slut
add: Added new job title for Virologist: Viro-Slut
add: Added new job title for Geneticist: Geneti-Slut
/:cl:
