### PR TITLE
Nerf Bane Syndrome quirk

### DIFF
--- a/modular_splurt/code/datums/traits/negative.dm
+++ b/modular_splurt/code/datums/traits/negative.dm
@@ -126,31 +126,7 @@
 	if(mood)
 		mood.mood_modifier -= 0.5
 
-/datum/quirk/masked_mook
-	name = "Bane Syndrome"
-	desc = "For some reason you don't feel... right without wearing some kind of gas mask."
-	gain_text = "<span class='danger'>You start feeling unwell without any gas mask on.</span>"
-	lose_text = "<span class='notice'>You no longer have a need to wear some gas mask.</span>"
-	value = -2
-	mood_quirk = TRUE
-	medical_record_text = "Patient feels more secure when wearing a gas mask."
-	processing_quirk = TRUE
-	var/mood_category = "masked_mook"
-
-/datum/quirk/masked_mook/on_process()
-	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/clothing/mask/gas/gasmask = H.get_item_by_slot(ITEM_SLOT_MASK)
-	if(istype(gasmask))
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook)
-	else
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook_incomplete)
-
-/datum/quirk/masked_mook/on_spawn()
-	. = ..()
-	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/clothing/mask/gas/gasmask = new(get_turf(quirk_holder))
-	H.equip_to_slot(gasmask, ITEM_SLOT_MASK)
-	H.regenerate_icons()
+// masked_mook moved to neutral
 
 //well-trained moved to neutral
 

--- a/modular_splurt/code/datums/traits/neutral.dm
+++ b/modular_splurt/code/datums/traits/neutral.dm
@@ -531,6 +531,32 @@
 	W.Remove(H)
 	. = ..()
 
+/datum/quirk/masked_mook
+	name = "Bane Syndrome"
+	desc = "For some reason you don't feel... right without wearing some kind of gas mask."
+	gain_text = "<span class='danger'>You start feeling unwell without any gas mask on.</span>"
+	lose_text = "<span class='notice'>You no longer have a need to wear some gas mask.</span>"
+	value = 0
+	mood_quirk = TRUE
+	medical_record_text = "Patient feels more secure when wearing a gas mask."
+	processing_quirk = TRUE
+	var/mood_category = "masked_mook"
+
+/datum/quirk/masked_mook/on_process()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/clothing/mask/gas/gasmask = H.get_item_by_slot(ITEM_SLOT_MASK)
+	if(istype(gasmask))
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook)
+	else
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook_incomplete)
+
+/datum/quirk/masked_mook/on_spawn()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/clothing/mask/gas/cosmetic/gasmask = new(get_turf(quirk_holder)) // Uses a custom gas mask
+	H.equip_to_slot(gasmask, ITEM_SLOT_MASK)
+	H.regenerate_icons()
+
 /// quirk actions ///
 
 //vampire bite

--- a/modular_splurt/code/modules/clothing/masks/gasmask.dm
+++ b/modular_splurt/code/modules/clothing/masks/gasmask.dm
@@ -32,3 +32,11 @@
 	name = "stripped trencher gas mask"
 	desc = "A stripped version of No Man's Land-type mask equipment. While you can connect it to air supply, it doesn't block gas flow."
 	armor = 0
+
+// Cosmetic gas mask for Bane Syndrome (masked_mook)
+/obj/item/clothing/mask/gas/cosmetic
+	name = "aesthetic gas mask"
+	desc = "A face-covering mask that resembles a traditional gas mask, but without the breathing functionality."
+	clothing_flags = NONE
+	gas_transfer_coefficient = 0
+	permeability_coefficient = 0


### PR DESCRIPTION
# About The Pull Request
Under the precedent that mood quirks should be neutral, this commit makes the following changes;
- Adds a new cosmetic-only gas mask variant
- Bane Syndrome is now neutral, worth 0 points
- Quirk grants the new non-functional gas mask instead of a regular one

## Why It's Good For The Game
Wearing a mask is mechanically beneficial. Some jobs - like shaft miner - even require it. Granting both quirk points and a mood bonus for something advantageous, simple, and often required allows for easy power-gaming.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
tweak: Converted Bane Syndrome quirk to neutral
tweak: Bane Syndrome starts with a non-functional mask
/:cl:
