### PR TITLE
Add two new Peacekeeper titles

### DIFF
--- a/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
+++ b/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
@@ -315,14 +315,6 @@
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
 
-/datum/job/peacekeeper/New()
-	var/list/extra_titles = list(
-		"Hired Muscle",
-		"Bodyguard"
-	)
-	LAZYADD(alt_titles, extra_titles)
-	. = ..()
-
 
 // Cargo
 /datum/job/cargo_tech/New()

--- a/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
+++ b/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
@@ -315,6 +315,14 @@
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
 
+/datum/job/peacekeeper/New()
+	var/list/extra_titles = list(
+		"Hired Muscle",
+		"Bodyguard"
+	)
+	LAZYADD(alt_titles, extra_titles)
+	. = ..()
+
 
 // Cargo
 /datum/job/cargo_tech/New()

--- a/modular_splurt/code/modules/jobs/job_types/peacekeeper.dm
+++ b/modular_splurt/code/modules/jobs/job_types/peacekeeper.dm
@@ -12,7 +12,16 @@
 	exp_requirements = 100
 	exp_type = EXP_TYPE_CREW
 	considered_combat_role = FALSE
-	alt_titles = list("Slutcurity Trainee", "Security Trainee", "Security Assistant", "Security Cadet", "Security Trainee", "Rookie")
+	alt_titles = list(
+		"Slutcurity Trainee",
+		"Security Trainee",
+		"Security Assistant",
+		"Security Cadet",
+		"Security Trainee",
+		"Rookie",
+		"Hired Muscle",
+		"Bodyguard"
+		)
 	custom_spawn_text = "<font color='black' size='2'><b> Your job is to help Security and react to minor crimes. Conflict de-escalation through WORDS is your top priority. Only use your taser as a last resort.</b></font><font color='red' size='4'><b>You are NOT a Security Officer.</b></font>"
 
 	outfit = /datum/outfit/job/peacekeeper


### PR DESCRIPTION
# About The Pull Request
Adds the titles "Hired Muscle" and "Bodyguard" to Peacekeeper.

_Originally requested as a job by LISKO FLEXIT ALLE#0085
Requested as job titles by ReturnToZender#3590_

## Why It's Good For The Game
Adds a new title-based roleplay opportunity.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
add: Added new job titles for Peacekeeper: Bodyguard, Hired Muscle
/:cl: