### PR TITLE
Allow empath to detect Distant and Headpat Slut

### DIFF
--- a/modular_splurt/code/modules/mob/mob_helpers.dm
+++ b/modular_splurt/code/modules/mob/mob_helpers.dm
@@ -19,4 +19,4 @@
 		. += "<span class='warning'>You sense [t_He] might be disturbed by physical affection.</span>\n"
 	// Check for Heatpat Slut (pls touch head!)
 	if(HAS_TRAIT(src, TRAIT_HEADPAT_SLUT))
-		. += "<span class='info'>You sense [t_He] appreciates reviving physical affection more than normal.</span>\n"
+		. += "<span class='info'>You sense [t_He] appreciates receiving physical affection more than normal.</span>\n"

--- a/modular_splurt/code/modules/mob/mob_helpers.dm
+++ b/modular_splurt/code/modules/mob/mob_helpers.dm
@@ -1,0 +1,18 @@
+// Modular-friendly way of adding new quirk-based inspect text
+// Hijacks the function used for abductor examine
+/mob/common_trait_examine()
+	// Pronoun stuff
+	var/t_He = p_they(TRUE)
+	var/t_his = p_their()
+	var/t_is = p_are()
+
+	// Empathy abilities escape clause
+	if(!(HAS_TRAIT(usr, TRAIT_EMPATH) || HAS_TRAIT(usr, TRAIT_FRIENDLY) || src == usr))
+		return
+
+	// Check for Distant (no touch head!)
+	if(HAS_TRAIT(src, TRAIT_DISTANT))
+		. += "<span class='warning'>[t_He] [t_is] emitting an aura of un-pattability from [t_his] head.</span>"
+	// Check for Heatpat Slut (pls touch head!)
+	if(HAS_TRAIT(src, TRAIT_HEADPAT_SLUT))
+		. += "<span class='info'>[t_He] [t_is] emitting a weak memetic aura from [t_his] head that compels your hand to approach.</span>"

--- a/modular_splurt/code/modules/mob/mob_helpers.dm
+++ b/modular_splurt/code/modules/mob/mob_helpers.dm
@@ -1,6 +1,9 @@
 // Modular-friendly way of adding new quirk-based inspect text
 // Hijacks the function used for abductor examine
 /mob/common_trait_examine()
+	// The ever-important funny BYOND dots
+	. = ..()
+
 	// Empathy abilities escape clause
 	// Please change this when adding new quirk detection
 	if(!(HAS_TRAIT(usr, TRAIT_EMPATH) || HAS_TRAIT(usr, TRAIT_FRIENDLY) || src == usr))

--- a/modular_splurt/code/modules/mob/mob_helpers.dm
+++ b/modular_splurt/code/modules/mob/mob_helpers.dm
@@ -1,18 +1,19 @@
 // Modular-friendly way of adding new quirk-based inspect text
 // Hijacks the function used for abductor examine
 /mob/common_trait_examine()
-	// Pronoun stuff
-	var/t_He = p_they(TRUE)
-	var/t_his = p_their()
-	var/t_is = p_are()
-
 	// Empathy abilities escape clause
+	// Please change this when adding new quirk detection
 	if(!(HAS_TRAIT(usr, TRAIT_EMPATH) || HAS_TRAIT(usr, TRAIT_FRIENDLY) || src == usr))
 		return
 
+	// Pronoun stuff
+	var/t_He = p_they(FALSE)
+	//var/t_his = p_their()
+	//var/t_is = p_are()
+
 	// Check for Distant (no touch head!)
 	if(HAS_TRAIT(src, TRAIT_DISTANT))
-		. += "<span class='warning'>[t_He] [t_is] emitting an aura of un-pattability from [t_his] head.</span>"
+		. += "<span class='warning'>You sense [t_He] might be disturbed by physical affection.</span>\n"
 	// Check for Heatpat Slut (pls touch head!)
 	if(HAS_TRAIT(src, TRAIT_HEADPAT_SLUT))
-		. += "<span class='info'>[t_He] [t_is] emitting a weak memetic aura from [t_his] head that compels your hand to approach.</span>"
+		. += "<span class='info'>You sense [t_He] appreciates reviving physical affection more than normal.</span>\n"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4624,6 +4624,7 @@
 #include "modular_splurt\code\modules\mob\emote.dm"
 #include "modular_splurt\code\modules\mob\mob.dm"
 #include "modular_splurt\code\modules\mob\mob_defines.dm"
+#include "modular_splurt\code\modules\mob\mob_helpers.dm"
 #include "modular_splurt\code\modules\mob\mob_movement.dm"
 #include "modular_splurt\code\modules\mob\say_vr.dm"
 #include "modular_splurt\code\modules\mob\splurt_emotes.dm"


### PR DESCRIPTION
# About The Pull Request
Allows players with the Empath or Friendly quirk to detect when another player has the Distant or Headpat Slut quirks.

_Originally suggested by Average Water Enjoyer#5949
Modified to also allow detecting Headpat Slut_

## Why It's Good For The Game
Quoting the original request:
_"Friendly characters are more likely to use the 1 positive point they used that doesn't benefit them at all but benefit others to headpat and hug people. Funny mood boosts. This gives them a tell on who doesn't want to be headpatted."_
\- Average Water Enjoyer#5949

Not having a tell for who doesn't want to be touched causes awkward interactions, and sometimes (5% chance) triggers an attack action. Adding an additional tell for people who requested (via quirk) to be touched also made logical sense.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
tweak: Empath and Friendly crew can now detect Distant and Headpat Slut crew
/:cl:
