### PR TITLE
Add Invisiber Footwraps to Kinkmate vendor

### DIFF
--- a/modular_splurt/code/modules/vending/kinkmate.dm
+++ b/modular_splurt/code/modules/vending/kinkmate.dm
@@ -27,7 +27,8 @@
 		/obj/item/strapon_strap = 5,
 		/obj/item/restraints/bondage_rope = 5,
 		/obj/item/clothing/under/domina = 5,
-		/obj/item/clothing/under/performer = 3
+		/obj/item/clothing/under/performer = 3,
+		/obj/item/clothing/shoes/invisiboots = 10 // Added here to go with the Gear Harness
 	)
 	var/list/extra_contraband = list(
 		//Lewd-Clothes


### PR DESCRIPTION
# About The Pull Request
Invisible shoes are currently only obtainable by loadout. Forgetting to select them, or losing them during the round, would them unobtainable before this change. They're added to Kinkmate to match the Gear Harness placement, as the two items serve a similar purpose.

_This should've been in the original PR, but I forgot._

## Why It's Good For The Game
Makes a cosmetic item available without needing to respawn. Helpful when dying to a freak science accident and losing your shoes.

## A Port?
No.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
tweak: Invisifiber Footwraps can be purchased from the Kinkmate vendor
/:cl: