### PR TITLE
Per-person single-use Dice of Fate

### DIFF
--- a/modular_splurt/code/modules/awaymissions/mission_code/academy.dm
+++ b/modular_splurt/code/modules/awaymissions/mission_code/academy.dm
@@ -6,11 +6,12 @@
 /obj/item/dice/d20/fate/one_use
 	reusable = 1 // Obsolete by the used_fingerprints list
 
-/obj/item/dice/d20/fate/diceroll(mob/user)
+/obj/item/dice/d20/fate/effect(var/mob/living/carbon/human/user,roll)
 	// This override checks if a user has rolled the dice
 	// If true; Reject them and abort
 	if (user in used_fingerprints)
-		to_chat(user, "<span class='warning'>You feel the magic of the dice reject you!</span>")
+		// Send a message implying someone else should roll
+		visible_message("<span class='notice'>[user] rolls the dice, but it doesn't respond to [user.p_them()] again.</span>")
 		return
 	// If false; Add them to the user list and continue
 	else

--- a/modular_splurt/code/modules/awaymissions/mission_code/academy.dm
+++ b/modular_splurt/code/modules/awaymissions/mission_code/academy.dm
@@ -1,0 +1,20 @@
+//Academy Items
+
+/obj/item/dice/d20/fate
+	var/list/used_fingerprints = null // Used to track who used the one_use die
+
+/obj/item/dice/d20/fate/one_use
+	reusable = 1 // Obsolete by the used_fingerprints list
+
+/obj/item/dice/d20/fate/diceroll(mob/user)
+	// This override checks if a user has rolled the dice
+	// If true; Reject them and abort
+	if (user in used_fingerprints)
+		to_chat(user, "<span class='warning'>You feel the magic of the dice reject you!</span>")
+		return
+	// If false; Add them to the user list and continue
+	else
+		LAZYADD(used_fingerprints, user)
+	
+	// Run the function normally
+	..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4494,6 +4494,7 @@
 #include "modular_splurt\code\modules\atmospherics\machinery\components\unary_devices\vent_pump.dm"
 #include "modular_splurt\code\modules\atmospherics\machinery\components\unary_devices\vent_scrubber.dm"
 #include "modular_splurt\code\modules\atmospherics\machinery\other\miner.dm"
+#include "modular_splurt\code\modules\awaymissions\mission_code\academy.dm"
 #include "modular_splurt\code\modules\cargo\supplypod.dm"
 #include "modular_splurt\code\modules\cargo\blackmarket\clothing.dm"
 #include "modular_splurt\code\modules\cargo\blackmarket\misc.dm"


### PR DESCRIPTION
# About The Pull Request
Allows the dice to be rolled once per user, instead of once ever. Completely prevents running the roll function when a user is disallowed.

## Why It's Good For The Game
Allows bringing back and sharing a rare fun item with other users, but without the ability to spam it. Also reduces confusion for why effects aren't triggering on one-use dice.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
tweak: Dice of Fate is now usable once per-person
/:cl: