### PR TITLE
Guarantee Cryptographic Sequencer from black market

### DIFF
--- a/modular_splurt/code/modules/cargo/blackmarket/blackmarket_items/gadgets.dm
+++ b/modular_splurt/code/modules/cargo/blackmarket/blackmarket_items/gadgets.dm
@@ -1,0 +1,2 @@
+/datum/blackmarket_item/syndi/gadget/emag
+	availability_prob = 100 // Fan favorite item

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4498,6 +4498,7 @@
 #include "modular_splurt\code\modules\cargo\blackmarket\clothing.dm"
 #include "modular_splurt\code\modules\cargo\blackmarket\misc.dm"
 #include "modular_splurt\code\modules\cargo\blackmarket\weapons.dm"
+#include "modular_splurt\code\modules\cargo\blackmarket\blackmarket_items\gadgets.dm"
 #include "modular_splurt\code\modules\cargo\bounties\assistant.dm"
 #include "modular_splurt\code\modules\cargo\bounties\lewd.dm"
 #include "modular_splurt\code\modules\cargo\exports\gear.dm"


### PR DESCRIPTION
# About The Pull Request
Changes the odds of the black market having a Cryptographic Sequencer (emag) from 45% to 100%.

_Originally suggested by Prophet#6580 on Discord_

## Why It's Good For The Game
Players will have a more reliable way to get a fun game-altering item.

_"No emag in the black market = no cool shuttle"
\- Prophet_

## A Port?
No.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

:cl:
tweak: Increased black market emag probability from 45% to 100%
/:cl: