### PR TITLE
Modularize cursed blood effects

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -175,9 +175,6 @@ Difficulty: Medium
 	. = ..()
 	if(. && target && !targets_the_same)
 		wander = TRUE
-		if(HAS_TRAIT(target, TRAIT_CURSED_BLOOD))
-			say(pick("Hunter, you must accept your death, be freed from the night.","The night, and the dream, were long...","Beasts all over the shop... You'll be one of them, sooner or later...","The night blocks all sight..."))
-
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/proc/dash_attack()
 	INVOKE_ASYNC(src, .proc/dash, target)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -411,18 +411,6 @@
 					"You can't save him. Nothing can save him now", "It seems that Nar'Sie will triumph after all")].</span>")
 				if("emote")
 					M.visible_message("<span class='warning'>[M] [pick("whimpers quietly", "shivers as though cold", "glances around in paranoia")].</span>")
-		else if(HAS_TRAIT(M, TRAIT_CURSED_BLOOD) && prob(12))
-			M.say(pick("Somebody help me...","Unshackle me please...","Anybody... I've had enough of this dream...","The night blocks all sight...","Oh, somebody, please..."), forced = "holy water")
-			if(prob(10))
-				M.visible_message("<span class='danger'>[M] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
-				M.Unconscious(120)
-				to_chat(M, "<span class='cultlarge'>[pick("The moon is close. It will be a long hunt tonight.", "Ludwig, why have you forsaken me?", \
-				"The night is near its end...", "Fear the blood...")]</span>")
-				if(prob(25)) //Prob of a prob.. Shouldn't happen too often but hey, that's what you get.
-					M.IgniteMob()
-				else
-					M.adjustToxLoss(1, 0)
-					M.adjustFireLoss(1, 0)
 	if(data["misc"] >= 60)	// 30 units, 135 seconds
 		if(iscultist(M, FALSE, TRUE) || is_servant_of_ratvar(M, FALSE, TRUE))
 			if(iscultist(M))

--- a/modular_splurt/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/modular_splurt/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -1,0 +1,11 @@
+/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/GiveTarget(new_target)
+	var/targets_the_same = (new_target == target)
+	. = ..()
+	
+	// Escape clause from original
+	if(!(. && target && !targets_the_same))
+		return
+
+	// Unique dialog for Cursed Blood
+	if(HAS_TRAIT(target, TRAIT_CURSED_BLOOD))
+		say(pick("Hunter, you must accept your death, be freed from the night.","The night, and the dream, were long...","Beasts all over the shop... You'll be one of them, sooner or later...","The night blocks all sight..."))

--- a/modular_splurt/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -32,8 +32,43 @@
 		C.adjust_nutrition(6) //3/4ed this, felt it was a bit too much
 		C.adjust_disgust(-3) //makes the churches effects easily negated
 
-/datum/reagent/water/holywater/on_mob_life(mob/living/carbon/M)//makes holy water slightly disgusting and hungering for vampires
+/datum/reagent/water/holywater/on_mob_life(mob/living/carbon/M)
 	. = ..()
+	//makes holy water slightly disgusting and hungering for vampires
 	if(HAS_TRAIT(M,BLOODFLEDGE))
 		M.adjust_disgust(1)
 		M.adjust_nutrition(-0.1)
+
+	// Cursed blood effect moved here
+	if(HAS_TRAIT(M, TRAIT_CURSED_BLOOD))
+		// Wait for stuttering, to match old effect
+		if(!M.stuttering)
+			return
+
+		// Escape clause: 12% chance to continue
+		if(!prob(12))
+			return
+		
+		// Character speaks nonsense
+		M.say(pick("Somebody help me...","Unshackle me please...","Anybody... I've had enough of this dream...","The night blocks all sight...","Oh, somebody, please..."), forced = "holy water")
+		
+		// Escape clause: 10% chance to continue
+		if(!prob(10))
+			return
+		
+		// Character has a seisure
+		M.visible_message("<span class='danger'>[M] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
+		M.Unconscious(120)
+		to_chat(M, "<span class='cultlarge'>[pick("The moon is close. It will be a long hunt tonight.", "Ludwig, why have you forsaken me?", \
+		"The night is near its end...", "Fear the blood...")]</span>")
+		
+		// Apply damage
+		M.adjustToxLoss(1, 0)
+		M.adjustFireLoss(1, 0)
+		
+		// Escape clause: 25% chance to continue
+		if(!prob(25))
+			return
+		
+		// Spontaneous combustion
+		M.IgniteMob()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4679,6 +4679,7 @@
 #include "modular_splurt\code\modules\mob\living\simple_animal\gremlin\gremlin.dm"
 #include "modular_splurt\code\modules\mob\living\simple_animal\hostile\carrion.dm"
 #include "modular_splurt\code\modules\mob\living\simple_animal\hostile\dancer.dm"
+#include "modular_splurt\code\modules\mob\living\simple_animal\hostile\megafauna\blood_drunk_miner.dm"
 #include "modular_splurt\code\modules\mob\living\simple_animal\hostile\megafauna\king_of_goats.dm"
 #include "modular_splurt\code\modules\paperwork\pen.dm"
 #include "modular_splurt\code\modules\power\cell.dm"


### PR DESCRIPTION
# About The Pull Request
Moves TRAIT_CURSED_BLOOD effects into modular code space, and slightly re-formats the code for better readability. Makes change to holy water reagent and blood drunk miner mob.

## Why It's Good For The Game
Following modularity standards is good.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
refactor: Modularized cursed blood effects
/:cl: