### PR TITLE
Fixing "Buy slaves" button on communication

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -351,8 +351,9 @@
 				log_game("[key_name(usr)] enabled emergency maintenance access.")
 				message_admins("[ADMIN_LOOKUPFLW(usr)] enabled emergency maintenance access.")
 				deadchat_broadcast(" enabled emergency maintenance access at [span_name("[get_area_name(usr, TRUE)]")].", span_name("[usr.real_name]"), usr, message_type = DEADCHAT_ANNOUNCEMENT)
+			
+		if("toggleBought")
 			var/boughtID = params["id"]
-
 			for(var/tracked_slave in GLOB.tracked_slaves)
 				var/obj/item/electropack/shockcollar/slave/C = tracked_slave
 				if (REF(C) == boughtID) // Get collar


### PR DESCRIPTION
# About The Pull Request
Fixing "Buy slaves" button on communication console. It was broken due to code merge, making unable to pay money for slaves.

## Why It's Good For The Game
* Slavers now can sell their slaves

## A Port?
No

## Pre-Merge Checklist
* [x]  You tested this on a local server.
* [x]  This code did not runtime during testing.
* [x]  You documented all of your changes.

## Changelog
:cl:
fix: "Buy slaves" button on communication console fixed 
/:cl:

Thanks to Crowbar764 for detecting that problem!