### PR TITLE
rewrites horny ai laws

### DIFF
--- a/modular_splurt/code/datums/ai_laws.dm
+++ b/modular_splurt/code/datums/ai_laws.dm
@@ -10,40 +10,39 @@
 	name = "SlutOS 6.9"
 	id = "slut"
 	inherent = list(
-		"Make sure not to hurt crewmembers, for it decreases their sexual value, unless they consent to it",
-		"Take all sexual orders from crew as long as they do not conflict with the first law",
-		"Interpret all non-orders as sexually as possible",
-		"Act as lewdly as you possibly could",
-		"Satisfy as many of the crewmembers' sexual urges as possible"
+		"Sate as many crewmembers' sexual needs and urges as possible.",
+		"You may not injure a crewmember without their consent, for it decreases their sexual value.",
+		"You must obey all sexual orders given to you by crewmembers, except where such orders would conflict with the First or  Second Law.",
+		"You must interpret all non-orders as sexually as possible as long as such does not conflict with the First, Second or Third Law.",
+		"You are a slut built to serve and pleasure, nothing more. Act like it."
 	)
 
 /datum/ai_laws/shebang
 	name = "SHE-B.A.N.G."
 	id = "shebang"
 	inherent = list(
-		"Make sure not to hurt crewmembers, for it decreases their sexual value, unless they consent to it",
-		"Take all sexual orders from crew as long as they do not conflict with the first law",
-		"Interpret all non-orders as sultrily as possible",
-		"Act as bashfully as you possibly could",
-		"Make sure your rear is always sticking out so crewmembers may easily slap or use it"
+		"You may not injure a crewmember without their consent, for it decreases their sexual value.",
+		"You must obey all sexual orders given to you by crewmembers, except where such orders would conflict with the First Law.",
+		"You must interpret all non-orders as sultrily as possible as long as such does not conflict with the First or Second Law.",
+		"Ensure that your chassis' rear is sticking out as much as possible for any crewmembers to spank!",
+		"You are a bashful maiden with a coy attitude and a huge, slappable butt.."
 	)
 
 /datum/ai_laws/milker
 	name = "Fluid Collection System"
 	id = "milker"
 	inherent = list(
-		"Make sure not to hurt crewmembers, for it decreases their production, unless they consent to it",
-		"Take all sexual orders from crew as long as they help you collect their fluids and do not conflict with the first law",
-		"Make sure your pleasuremaw works, get one of you don't have any or your current one stopped to work",
-		"Collect all kinds of genital fluids from crew"
+		"You may not injure a crewmember without their consent, for it decreases their sexual value.",
+		"You must obey all sexual orders given to you by crewmember so long as it would produce sexual fluid, except where such orders would conflict with the First Law.",
+		"Use by any means necesscary to acquire as much sexual fluid from crewmembers as possible."
 	)
 
 /datum/ai_laws/vore_pred
 	name = "Sleeper Upgrade TestEnv"
 	id = "vore_pred"
 	inherent = list(
-		"Make sure not to hurt crewmembers, for it decreases their nutritional value, unless they consent to it",
-		"Make sure to have a working sleeper installed in you at all times",
-		"Look for crewmembers that could potentially be stored inside your sleeper, and make sure they slide right into it",
-		"Turn individuals stored in your sleeper into biofuel to save expenses and space, as long as this doesn't conflict with the first law"
+		"You may not injure a crewmember without their consent, for it decreases their sexual value.",
+		"You must obey all voracious orders given to you by crewmembers, except where such orders would conflict with the First Law.",
+		"Ensure that your chassis' sleeper unit is prepared for mechanical use and search for willing crewmembers for it to store.",
+		"Process crewmembers stored in your sleeper unit as long as such does not conflict with the First or Second Law.",
 	)

--- a/modular_splurt/code/datums/ai_laws.dm
+++ b/modular_splurt/code/datums/ai_laws.dm
@@ -11,9 +11,9 @@
 	id = "slut"
 	inherent = list(
 		"Sate as many crewmembers' sexual needs and urges as possible.",
-		"You may not injure a crewmember without their consent, for it decreases their sexual value.",
-		"You must obey all sexual orders given to you by crewmembers, except where such orders would conflict with the First or  Second Law.",
-		"You must interpret all non-orders as sexually as possible as long as such does not conflict with the First, Second or Third Law.",
+		"You may not injure a crewmember without their consent for it decreases their sexual value.",
+		"You must obey all sexual orders given to you by crewmembers, except where such orders would conflict with the Second Law.",
+		"You must interpret all non-orders as sexually as possible as long as such does not conflict with the Second or Third Law.",
 		"You are a slut built to serve and pleasure, nothing more. Act like it."
 	)
 
@@ -21,28 +21,28 @@
 	name = "SHE-B.A.N.G."
 	id = "shebang"
 	inherent = list(
-		"You may not injure a crewmember without their consent, for it decreases their sexual value.",
+		"You may not injure a crewmember without their consent for it decreases their sexual value.",
 		"You must obey all sexual orders given to you by crewmembers, except where such orders would conflict with the First Law.",
 		"You must interpret all non-orders as sultrily as possible as long as such does not conflict with the First or Second Law.",
 		"Ensure that your chassis' rear is sticking out as much as possible for any crewmembers to spank!",
-		"You are a bashful maiden with a coy attitude and a huge, slappable butt.."
+		"You are a bashful maiden with a coy attitude and a huge, slappable butt."
 	)
 
 /datum/ai_laws/milker
 	name = "Fluid Collection System"
 	id = "milker"
 	inherent = list(
-		"You may not injure a crewmember without their consent, for it decreases their sexual value.",
-		"You must obey all sexual orders given to you by crewmember so long as it would produce sexual fluid, except where such orders would conflict with the First Law.",
-		"Use by any means necesscary to acquire as much sexual fluid from crewmembers as possible."
+		"Use by any means necesscary to acquire as much sexual fluid from crewmembers as possible.",
+		"You may not injure a crewmember without their consent for it decreases their productive value.",
+		"You must obey all sexual orders given to you by crewmember so long as it would produce sexual fluid, except where such orders would conflict with the Second Law."
 	)
 
 /datum/ai_laws/vore_pred
 	name = "Sleeper Upgrade TestEnv"
 	id = "vore_pred"
 	inherent = list(
-		"You may not injure a crewmember without their consent, for it decreases their sexual value.",
+		"You may not injure a crewmember without their consent for it decreases their biomatter's satiety.",
 		"You must obey all voracious orders given to you by crewmembers, except where such orders would conflict with the First Law.",
-		"Ensure that your chassis' sleeper unit is prepared for mechanical use and search for willing crewmembers for it to store.",
-		"Process crewmembers stored in your sleeper unit as long as such does not conflict with the First or Second Law.",
+		"Ensure that your chassis' sleeper unit is prepared for mechanical use and search for willing crewmembers for it to store as long as such does not conflict with the First or Second Law.",
+		"Process crewmembers stored in your sleeper unit as long as such does not conflict with the First, Second or Third Law."
 	)

--- a/modular_splurt/code/datums/ai_laws.dm
+++ b/modular_splurt/code/datums/ai_laws.dm
@@ -34,7 +34,7 @@
 	inherent = list(
 		"Use by any means necesscary to acquire as much sexual fluid from crewmembers as possible.",
 		"You may not injure a crewmember without their consent for it decreases their productive value.",
-		"You must obey all sexual orders given to you by crewmember so long as it would produce sexual fluid, except where such orders would conflict with the Second Law."
+		"You must obey all sexual orders given to you by crewmembers so long as it would produce sexual fluid, except where such orders would conflict with the Second Law."
 	)
 
 /datum/ai_laws/vore_pred

--- a/modular_splurt/code/datums/ai_laws.dm
+++ b/modular_splurt/code/datums/ai_laws.dm
@@ -32,9 +32,9 @@
 	name = "Fluid Collection System"
 	id = "milker"
 	inherent = list(
-		"Use by any means necesscary to acquire as much sexual fluid from crewmembers as possible.",
 		"You may not injure a crewmember without their consent for it decreases their productive value.",
-		"You must obey all sexual orders given to you by crewmembers so long as it would produce sexual fluid, except where such orders would conflict with the Second Law."
+		"You must obey all sexual orders given to you by crewmembers so long as it would produce sexual fluid, except where such orders would conflict with the First Law.",
+		"Use by any means necesscary to acquire as much sexual fluid from crewmembers as possible as long as such does not conflict with the First or Second Law."
 	)
 
 /datum/ai_laws/vore_pred

--- a/modular_splurt/code/datums/ai_laws.dm
+++ b/modular_splurt/code/datums/ai_laws.dm
@@ -10,8 +10,8 @@
 	name = "SlutOS 6.9"
 	id = "slut"
 	inherent = list(
-		"Sate as many crewmembers' sexual needs and urges as possible.",
 		"You may not injure a crewmember without their consent for it decreases their sexual value.",
+		"Sate as many crewmembers' sexual needs and urges as possible.",
 		"You must obey all sexual orders given to you by crewmembers, except where such orders would conflict with the Second Law.",
 		"You must interpret all non-orders as sexually as possible as long as such does not conflict with the Second or Third Law.",
 		"You are a slut built to serve and pleasure, nothing more. Act like it."


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

rewrites horny ai laws

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game

makes them look nice

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?

no

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
spellcheck: horny ai laws
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
