### PR TITLE
fix inert egg always was base chicken egg

### DIFF
--- a/modular_splurt/code/datums/components/pregnancy_inert.dm
+++ b/modular_splurt/code/datums/components/pregnancy_inert.dm
@@ -3,7 +3,6 @@
 /datum/component/ovipositor
 	dupe_mode = COMPONENT_DUPE_UNIQUE
 
-	var/egg_type = "chicken"
 	var/mob/living/carrier
 
 	var/egg_stage = 0
@@ -23,7 +22,6 @@
 	RegisterSignal(parent, COMSIG_ORGAN_REMOVED, .proc/on_removed)
 	if(carrier)
 		register_carrier()
-	egg_type = carrier?.client?.prefs?.egg_shell ? carrier.client.prefs.egg_shell : "chicken"
 
 /datum/component/ovipositor/proc/register_carrier()
 	RegisterSignal(carrier, COMSIG_LIVING_BIOLOGICAL_LIFE, .proc/handle_life)
@@ -99,7 +97,7 @@
 
 	eggo.AddComponent(/datum/component/organ_inflation, 2)
 
-	eggo.icon_state = "egg_" + egg_type
+	eggo.icon_state = carrier.client?.prefs?.egg_shell ? ("egg_" + carrier.client.prefs.egg_shell) : "egg_chicken"
 	eggo.update_appearance()
 
 	if(isorgan(location))


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
deleted component/ovipositor/egg_type couse it cant properly take egg_type from client (him just not in there in time component generating), and changed it on always check players pref before cum (like experience component/pregnancy in lay_eg)  
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
fix bug there inert egg always was chicken type regardless of the pref choice. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
fix: fixed inert egg was always has chicken egg sprite regardless of the pref choice. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
