### PR TITLE
chemistry access added to Med-U DELUXE cartridge

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -171,7 +171,7 @@
 /obj/item/cartridge/cmo
 	name = "\improper Med-U DELUXE cartridge"
 	icon_state = "cart-cmo"
-	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_REAGENT_SCANNER | CART_MEDICAL
+	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_REAGENT_SCANNER | CART_MEDICAL | CART_CHEMISTRY
 	bot_access_flags = MED_BOT
 
 /obj/item/cartridge/rd

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -171,7 +171,7 @@
 /obj/item/cartridge/cmo
 	name = "\improper Med-U DELUXE cartridge"
 	icon_state = "cart-cmo"
-	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_REAGENT_SCANNER | CART_MEDICAL | CART_CHEMISTRY
+	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_REAGENT_SCANNER | CART_MEDICAL
 	bot_access_flags = MED_BOT
 
 /obj/item/cartridge/rd

--- a/modular_splurt/code/game/objects/items/devices/PDA/radio.dm
+++ b/modular_splurt/code/game/objects/items/devices/PDA/radio.dm
@@ -1,0 +1,4 @@
+/obj/item/cartridge/cmo/Initialize(mapload)
+	//adds chemistry access
+	access |= CART_CHEMISTRY
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4381,6 +4381,7 @@
 #include "modular_splurt\code\game\objects\items\circuitboards\computer_circuitboards.dm"
 #include "modular_splurt\code\game\objects\items\circuitboards\machine_circuitboards.dm"
 #include "modular_splurt\code\game\objects\items\circuitboards\miner_circuitboards.dm"
+#include "modular_splurt\code\game\objects\items\devices\PDA\radio.dm"
 #include "modular_splurt\code\game\objects\items\devices\radio\electropack.dm"
 #include "modular_splurt\code\game\objects\items\devices\radio\headset.dm"
 #include "modular_splurt\code\game\objects\items\implants\implant_aphropumps.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Self explanatory, added chemwhiz chemical lookup function to med-u deluxe.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
CMO can be a better chemist, removes the need to switch between the ChemWhiz cartridges and the Med-U DELUXE
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
no.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
add: Added CART_CHEMISTRY access to cart-cmo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
