### PR TITLE
Update Fluid Infuser button

### DIFF
--- a/modular_splurt/code/game/objects/items/implants/implant_gfluid.dm
+++ b/modular_splurt/code/game/objects/items/implants/implant_gfluid.dm
@@ -95,7 +95,7 @@
 	to_chat(genital_owner, span_notice("You feel the fluids inside your [genital_input.name] bubble and swirl..."))
 
 	// Send admin notice
-	message_admins("[ADMIN_LOOKUPFLW(genital_owner)] changed the fluid of their [genital_owner.p_their()] [genital_input.name] to [reagent_selection].")
+	message_admins("[ADMIN_LOOKUPFLW(genital_owner)] changed the fluid of [genital_owner.p_their()] [genital_input.name] to [reagent_selection].")
 
 // Unlock with an emag
 /obj/item/implant/genital_fluid/emag_act()

--- a/modular_splurt/code/game/objects/items/implants/implant_gfluid.dm
+++ b/modular_splurt/code/game/objects/items/implants/implant_gfluid.dm
@@ -4,6 +4,10 @@
 	icon_state = "genital_fluid"
 	var/use_blacklist = TRUE
 
+	// Custom action for extra customization
+	actions_types = list(/datum/action/item_action/genital_fluid_infuse)
+
+// Implant flavor text
 /obj/item/implant/genital_fluid/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
 				<b>Name:</b> Nanotrasen Genital Fluid Inducer Implant<BR>
@@ -12,69 +16,119 @@
 				<b>Implant Details:</b><BR>
 				<b>Function:</b> Allows the user to induce their genitals into producing a specific reagent.<BR>
 				<b>Special Features:</b> Will prevent harmful liquids from being accepted as a genital fluid replace.<BR>
-				<b>Integrity:</b> Implant will last so long as the implant is inside the host and they posess genitals capable of fluid production."}
+				<b>Integrity:</b> Implant will last so long as the implant is inside the host and they possess genitals capable of fluid production."}
 	return dat
 
+// Only allow use on "human" targets
 /obj/item/implant/genital_fluid/can_be_implanted_in(mob/living/target)
 	if(!ishuman(target))
 		return FALSE
 	. = ..()
 
+// Runs on toggling the implant
 /obj/item/implant/genital_fluid/activate()
 	. = ..()
-	var/list/obj/item/organ/genital/penidlist
-	var/list/datum/reagent/fluidlist = list()
-	var/mob/living/carbon/human/owner = imp_in
 
-	//List their genitals if they have any at all
-	for(var/obj/item/organ/genital/dicc in owner.internal_organs)
-		if(istype(dicc) && (dicc.genital_flags & GENITAL_FUID_PRODUCTION))
-			LAZYADD(penidlist, dicc)
+	// Set list of possible genitals
+	var/list/obj/item/organ/genital/genitals_list
+	
+	// Set list of possible fluids
+	var/list/datum/reagent/fluid_list = list()
+	
+	// Set owner
+	var/mob/living/carbon/human/genital_owner = imp_in
 
-	//List their current reagents if they're valid
-	for(var/datum/reagent/pee in owner.reagents.reagent_list)
-		if((find_reagent_object_from_type(pee.type)) && ((pee.type in allowed_gfluid_paths()) || !use_blacklist))
-			LAZYADD(fluidlist, find_reagent_object_from_type(pee.type))
+	// List their genitals if they have any at all
+	for(var/obj/item/organ/genital/genital_checked in genital_owner.internal_organs)
+		if(istype(genital_checked) && (genital_checked.genital_flags & GENITAL_FUID_PRODUCTION))
+			// Add genitals to the list
+			LAZYADD(genitals_list, genital_checked)
 
-	//List any reagents they may be holding in their hands
-	if(owner.available_rosie_palms(TRUE, /obj/item/reagent_containers))
-		for(var/obj/item/reagent_containers/container in owner.held_items)
+	// List their current reagents if they're valid
+	for(var/datum/reagent/genital_reagent in genital_owner.reagents.reagent_list)
+		if((find_reagent_object_from_type(genital_reagent.type)) && ((genital_reagent.type in allowed_gfluid_paths()) || !use_blacklist))
+			// Add valid reagents to the list
+			LAZYADD(fluid_list, find_reagent_object_from_type(genital_reagent.type))
+
+	// List any reagents they may be holding in their hands
+	if(genital_owner.available_rosie_palms(TRUE, /obj/item/reagent_containers))
+		for(var/obj/item/reagent_containers/container in genital_owner.held_items)
 			if(container.is_open_container() || istype(container, /obj/item/reagent_containers/food/snacks))
-				for(var/datum/reagent/pee in container.reagents.reagent_list)
-					if((find_reagent_object_from_type(pee.type)) && ((pee.type in allowed_gfluid_paths()) || !use_blacklist))
-						LAZYADD(fluidlist, find_reagent_object_from_type(pee.type))
+				for(var/datum/reagent/genital_reagent in container.reagents.reagent_list)
+					if((find_reagent_object_from_type(genital_reagent.type)) && ((genital_reagent.type in allowed_gfluid_paths()) || !use_blacklist))
+						// Add valid reagents to the list
+						LAZYADD(fluid_list, find_reagent_object_from_type(genital_reagent.type))
 
-	//Return if genitals list is void/null
-	if(!penidlist)
-		SEND_SOUND(owner, 'sound/machines/terminal_error.ogg')
-		to_chat(owner, span_notice("ERROR: No compatible genitals detected."))
+	// Return if genitals list is void/null
+	if(!genitals_list)
+		// Play an error sound
+		SEND_SOUND(genital_owner, 'sound/machines/terminal_error.ogg')
+		
+		// Alert the user in chat
+		to_chat(genital_owner, span_notice("ERROR: No compatible genitals detected."))
+
+		// Escape
 		return
 
-	var/obj/item/organ/genital/cocc = tgui_input_list(owner, "Pick a genital", "Genital Fluid Infuser", penidlist)
-	if(!cocc)
+	// Prompt user for which genital to use
+	var/obj/item/organ/genital/genital_input = tgui_input_list(genital_owner, "Pick a genital", "Genital Fluid Infuser", genitals_list)
+	if(!genital_input)
+		// No selection was made
 		return
 
-	fluidlist = list(find_reagent_object_from_type(cocc.get_default_fluid())) + fluidlist
+	// Update list of possible fluids
+	fluid_list = list(find_reagent_object_from_type(genital_input.get_default_fluid())) + fluid_list
 
-	var/datum/reagent/selection = tgui_input_list(owner, "Choose your new reagent", "Genital Fluid Infuser", fluidlist)
-	if(!selection)
+	// Prompt user to select a new fluid
+	var/datum/reagent/reagent_selection = tgui_input_list(genital_owner, "Choose your new reagent", "Genital Fluid Infuser", fluid_list)
+	if(!reagent_selection)
+		// No selection was made
 		return
 
-	cocc.fluid_id = selection.type
-	SEND_SOUND(owner, 'sound/effects/bubbles.ogg')
-	to_chat(owner, span_notice("You feel the fluids inside your [cocc.name] bubble and swirl..."))
-	message_admins("[ADMIN_LOOKUPFLW(owner)] changed the fluid of their [owner.p_their()] [cocc.name] to [selection].")
+	// Set new fluid
+	genital_input.fluid_id = reagent_selection.type
+	
+	// Play the reagent processing sound effect
+	SEND_SOUND(genital_owner, 'sound/effects/bubbles.ogg')
+	
+	// Display flavor text
+	to_chat(genital_owner, span_notice("You feel the fluids inside your [genital_input.name] bubble and swirl..."))
 
+	// Send admin notice
+	message_admins("[ADMIN_LOOKUPFLW(genital_owner)] changed the fluid of their [genital_owner.p_their()] [genital_input.name] to [reagent_selection].")
+
+// Unlock with an emag
 /obj/item/implant/genital_fluid/emag_act()
 	. = ..()
 	name = "hacked genital fluid implant"
 	use_blacklist = FALSE
 	obj_flags |= EMAGGED
 
+/*
+ * Action datum
+*/
+
+// Action for updating genital fluids
+/datum/action/item_action/genital_fluid_infuse
+	name = "Infuse Genital Fluids"
+	desc = "Activate an integrated reagent receptor device to modify your genital contents."
+	icon_icon = 'modular_splurt/icons/obj/implants.dmi'
+	button_icon_state = "genital_fluid"
+	background_icon_state = "bg_tech"
+
+	// Restrict non-synthesizable reagents?
+	var/use_blacklist = TRUE
+
+/*
+ * Implant items
+*/
+
+// Implanter item
 /obj/item/implanter/genital_fluid
 	name = "implanter (genital fluid)"
 	imp_type = /obj/item/implant/genital_fluid
 
+// Implanter item, emagged
 /obj/item/implanter/genital_fluid/hacked
 	name = "implanter (genital fluid (hacked))"
 
@@ -84,11 +138,13 @@
 		var/obj/item/implant/genital_fluid/I = imp
 		I.emag_act()
 
+// Implant case item
 /obj/item/implantcase/genital_fluid
 	name = "implant case - 'Genital Fluid'"
 	desc = "A glass case containing a Genital Fluid Infuser implant."
 	imp_type = /obj/item/implant/genital_fluid
 
+// Implant case item, emagged
 /obj/item/implantcase/genital_fluid/hacked
 	name = "implant case - 'Genital Fluid (Hacked)'"
 


### PR DESCRIPTION
# About The Pull Request
Updates the fluid infuser implant to use an action datum button instead of the standard implant button. Also fixes a typo, adds more comments, and updates variable name readability.

![infuse_action_datum](https://user-images.githubusercontent.com/5933805/211203508-6f8712d2-0fec-49f6-bc61-3c766f8e4f6d.png)

## Why It's Good For The Game
Action datums look nicer, and provide more information to the end user.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
tweak: Fluid Infuser implant uses an improved activation button
/:cl: