### PR TITLE
Update LPD drink effects

### DIFF
--- a/modular_splurt/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_splurt/code/modules/mob/living/carbon/carbon.dm
@@ -22,3 +22,40 @@
 			new_rope.forceMove(src.loc)
 			return
 	. = ..()
+
+// Liquid Panty Dropper effect
+/mob/living/carbon/proc/clothing_burst(mob/living/carbon/target_user)
+	// Variable for if the action succeeded
+	var/user_disrobed = FALSE
+
+	// Get worn items
+	var/items = target_user.get_contents()
+
+	// Iterate over worn items
+	for(var/obj/item/item_worn in items)
+		// Ignore non-mob (storage)
+		if(!ismob(item_worn.loc))
+			continue
+
+		// Ignore held items
+		if(target_user.is_holding(item_worn))
+			continue
+
+		// Check for anything covering a body part
+		if(item_worn.body_parts_covered)
+			// Set the success variable
+			user_disrobed = TRUE
+			
+			// Drop the target item
+			target_user.dropItemToGround(item_worn, TRUE)
+
+			// Throw item to a random spot
+			item_worn.throw_at(pick(oview(7,get_turf(src))),10,1)
+
+	// When successfully disrobing a target
+	if(user_disrobed)
+		// Display a chat message
+		target_user.visible_message("<span class='userlove'>[target_user] suddenly bursts out of [target_user.p_their()] clothes!</span>", "<span class='userlove'>You suddenly burst out of your clothes!</span>")
+
+		// Play the ripped poster sound
+		playsound(target_user.loc, 'sound/items/poster_ripped.ogg', 50, 1)

--- a/modular_splurt/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -11,18 +11,13 @@
 	glass_desc = "You feel it's not named like that for no reason."
 	value = 6
 
+// Liquid Panty Dropper drink effect
 /datum/reagent/consumable/ethanol/panty_dropper/on_mob_life(mob/living/carbon/C)
-	var/mob/living/carbon/human/M = C
-	var/anyclothes = FALSE
-	var/items = M.get_contents()
-	for(var/obj/item/W in items)
-		if(W.body_parts_covered && ismob(W.loc))
-			anyclothes = TRUE
-			M.dropItemToGround(W, TRUE)
-			playsound(M.loc, 'sound/items/poster_ripped.ogg', 50, 1)
-	if(anyclothes)
-		M.visible_message("<span class='userlove'>[M] suddenly bursts out of [M.p_their()] clothes!</span>")
-	return ..()
+	// Praise the funny BYOND dots
+	. = ..()
+
+	// Perform drink effect
+	C.clothing_burst(C)
 
 /datum/reagent/consumable/ethanol/lean
 	name = "Lean"


### PR DESCRIPTION
# About The Pull Request
Updates Liquid Panty Dropper with the following:
- Ignores held items
- Only plays rip noise once
- Displays a different chat message for the target user
- Items are thrown, instead of dropped
- Moves functional code from alcohol reagents to a mob proc
- - This change is made so other items can use the effect
- More comments!

## Why It's Good For The Game
The main purpose of this change is facilitate other items using LPD effects.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
tweak: Liquid Panty Dropper now launches clothing
tweak: Liquid Panty Dropper no longer interferes with held items
code: LPD's clothing burst is now a mob proc
/:cl: