### PR TITLE
Adds a Plushmium Crate

### DIFF
--- a/modular_splurt/code/modules/cargo/packs/misc.dm
+++ b/modular_splurt/code/modules/cargo/packs/misc.dm
@@ -215,6 +215,15 @@
 	cost = 100000
 	contains = list(/obj/item/reagent_containers/food/drinks/diminicillin)
 
+/datum/supply_pack/misc/plushmium
+	name = "Plushmium Crate"
+	desc = "Contains a small sample of an experimental chemical known as Plushmium, and a plushie to use it on."
+	cost = 5000 // Cost of an expensive animal
+	contains = list(
+		/obj/item/reagent_containers/glass/bottle/plushmium,
+		/obj/item/choice_beacon/box/plushie
+	)
+
 /datum/supply_pack/misc/microbricks
 	name = "Microbricks Crate"
 	desc = "Extremely bored? Recreate a downscale city and get upset when it all comes crumbling down!"

--- a/modular_splurt/code/modules/reagents/reagent_containers/bottle.dm
+++ b/modular_splurt/code/modules/reagents/reagent_containers/bottle.dm
@@ -3,3 +3,9 @@
 	desc = "A small bottle of Mute Toxin. It stops the user from speaking."
 	icon_state = "bottle20"
 	list_reagents = list(/datum/reagent/toxin/mutetoxin = 30)
+
+/obj/item/reagent_containers/glass/bottle/plushmium
+	name = "\improper Plushmium Bottle"
+	desc = "A small bottle of Plushmium. Seems almost fluffy, if not for it being a liquid."
+	icon_state = "bottle20"
+	list_reagents = list(/datum/reagent/fermi/plushmium = 30)


### PR DESCRIPTION
# About The Pull Request
Adds the new Plushmium Crate to cargo, which contains a bottle of Plushmium and a plushie choice box. Also adds an item for the Plushmium Bottle, so it can be in the crate.

_Originally requested by Toast#8706 on Discord, in Suggestion #3839._

## Why It's Good For The Game
Facilitates some users _specific interests_ without reliance on a chemist player's cooperation.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
add: Added a Plushmium Crate to cargo
/:cl: