### PR TITLE
Plushmium crate improvements

### DIFF
--- a/modular_splurt/code/game/objects/items/storage/boxes.dm
+++ b/modular_splurt/code/game/objects/items/storage/boxes.dm
@@ -14,3 +14,24 @@
 		new /obj/item/reagent_containers/hypospray/medipen/bellygrowth(src)
 		new /obj/item/reagent_containers/hypospray/medipen/prospacillin(src)
 		new /obj/item/reagent_containers/hypospray/medipen/lewdbomb(src)
+
+// Shipment box for Plushmium
+/obj/item/storage/box/shipment_plushmium
+	name = "plushmium backer rewards box"
+	desc = "Comes with a spray bottle quick application!"
+	icon = 'modular_sand/icons/obj/fleshlight.dmi'
+	icon_state = "box"
+
+/obj/item/storage/box/shipment_plushmium/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/str = GetComponent(/datum/component/storage)
+	str.max_items = 2
+
+/obj/item/storage/box/shipment_plushmium/PopulateContents()
+	new /obj/item/reagent_containers/spray/plushmium(src)
+	new /obj/item/paper/fluff/shipment_plushmium(src)
+
+// Plushmium box's note
+/obj/item/paper/fluff/shipment_plushmium
+	name = "plushmium backer note"
+	info = "<h2>Plushmium Instructions</h2><i>Dear esteemed customer</i>,<br><br><span>Thank for backing the Stuffing For Spessmen© crowd funding initiative. We at Donk Co. pride ourselves on making a wide variety of <i>engaging</i> toys for our loyal customers to enjoy. Now, we're bringing the toy making process directly to your home or workplace!</span> Included in this box is:<ul><li>A spray bottle of Love to Life™ solution<li>A carefully packaged plushie</ul><span>To begin enjoying your new friend, start by unpacking the included plushie. Our selection process goes through rigorous quality testing to ensure you'll always get the best toy for the job. With so many choices, you'll want to get the whole family in on the action.</span><br><br><span>Once you have everything ready, it's time to make the patented Donk Co. magic happen! Spray your new best friend with Love to Life™ solution, included in the complimentary spray bottle, and watch the stunning transformation!</span><br><br><span>But don't leave your new best friend hanging! Give them a big warm hug to celebrate the long and intimate friendship you'll be sharing.</span><br><br><hr><span><i>Donk Co. is not responsible for any injury or loss of life that may occur while using the Love to Life™ solution. Do not allow access to children or adults without supervision by a chemist.</i></span><br><br><span><i>Do not drink, splash, inject, or otherwise handle the solution. Do not come into direct physical contact with the solution, or any object the solution has been applied to, under any circumstances.</i></span>"

--- a/modular_splurt/code/modules/cargo/packs/misc.dm
+++ b/modular_splurt/code/modules/cargo/packs/misc.dm
@@ -217,10 +217,10 @@
 
 /datum/supply_pack/misc/plushmium
 	name = "Plushmium Crate"
-	desc = "Contains a small sample of an experimental chemical known as Plushmium, and a plushie to use it on."
+	desc = "Surplus shipment of Stuffing For Spessmen backer rewards. Contains a pre-packaged spray bottle of Plushmium, and toy to use it on."
 	cost = 5000 // Cost of an expensive animal
 	contains = list(
-		/obj/item/reagent_containers/glass/bottle/plushmium,
+		/obj/item/storage/box/shipment_plushmium,
 		/obj/item/choice_beacon/box/plushie
 	)
 

--- a/modular_splurt/code/modules/reagents/reagent_containers/bottle.dm
+++ b/modular_splurt/code/modules/reagents/reagent_containers/bottle.dm
@@ -8,4 +8,6 @@
 	name = "\improper Plushmium Bottle"
 	desc = "A small bottle of Plushmium. Seems almost fluffy, if not for it being a liquid."
 	icon_state = "bottle20"
-	list_reagents = list(/datum/reagent/fermi/plushmium = 30)
+	list_reagents = list(/datum/reagent/fermi/plushmium = 5)
+	possible_transfer_amounts = list(5)
+	volume = 5

--- a/modular_splurt/code/modules/reagents/reagent_containers/spray.dm
+++ b/modular_splurt/code/modules/reagents/reagent_containers/spray.dm
@@ -1,2 +1,25 @@
 /obj/item/reagent_containers/spray/chemsprayer/sleeper
 	list_reagents = list(/datum/reagent/toxin/sodium_thiopental = 100, /datum/reagent/consumable/condensedcapsaicin = 100, /datum/reagent/toxin/chloralhydrate = 100)
+
+/obj/item/reagent_containers/spray/plushmium
+	name = "\improper Love to Life spray bottle"
+	desc = "A toy spray bottle marked with the Donk Co. Stuffing For Spessmen branding. Must be applied directly to a plush, and only contains enough for one."
+	icon_state = "cleaner_drying"
+	// Single use item!
+	volume = 5
+	spray_range = 1
+	can_fill_from_container = FALSE
+	amount_per_transfer_from_this = 5
+	possible_transfer_amounts = list(5)
+	list_reagents = list(/datum/reagent/fermi/plushmium = 5)
+
+// Custom interaction to prevent wasting the item
+/obj/item/reagent_containers/spray/plushmium/afterattack(atom/target, mob/user)
+	// Check for plush toy
+	if(!istype(target, /obj/item/toy/plush))
+		// Alert user and return
+		to_chat(user, "<span class='warning'>You don't want to waste the solution on a non-plushie.</span>")
+		return
+
+	// Return normally
+	. = ..()


### PR DESCRIPTION
# About The Pull Request
This PR incorporates user feedback for https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/pull/676.

- Reduces the amount from 30 to 5
- - Allows converting only one plushie per shipment
- Replaces the bottle with a single-use a spray bottle variant
- Prevents using the spray bottle on non-plushies
- Adds a boxed set for the items
- Adds an explanatory lore note to the box set
- Updates shipment information

## Why It's Good For The Game
The original was intended to convert one plushie per shipment, but was mistakenly set too high. In addition, users could become confused at the item's intended usage, and accidentally waste it.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
add: Added the Love to Life spray bottle
tweak: Updated Plushmium Crate contents
/:cl: