### PR TITLE
Bugfix: Infinite metal.

### DIFF
--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -15,9 +15,12 @@
 		var/obj/structure/chair/C = new /obj/structure/chair(loc)
 		W.play_tool_sound(src)
 		C.setDir(dir)
-		part.forceMove(loc)
-		part.master = null
-		part = null
+
+		if (part)
+			part.forceMove(loc)
+			part.master = null
+			part = null
+
 		qdel(src)
 
 /obj/structure/chair/e_chair/proc/shock()
@@ -44,3 +47,10 @@
 			to_chat(buckled_mob, "<span class='userdanger'>You feel a deep shock course through your body!</span>")
 			addtimer(CALLBACK(buckled_mob, /mob/living.proc/electrocute_act, 85, src, 1), 1)
 	visible_message("<span class='danger'>The electric chair went off!</span>", "<span class='italics'>You hear a deep sharp shock!</span>")
+
+/obj/structure/chair/e_chair/Destroy()
+	if(part)
+		qdel(part)
+		part = null
+
+	return ..()

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -50,7 +50,6 @@
 
 /obj/structure/chair/e_chair/Destroy()
 	if(part)
-		qdel(part)
-		part = null
+		QDEL_NULL(part)
 
 	return ..()

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -27,8 +27,10 @@
 	return TRUE
 
 /obj/item/assembly/shock_kit/attack_self(mob/user)
-	part1.attack_self(user)
-	part2.attack_self(user)
+	if (part1)
+		part1.attack_self(user)
+	if (part2)
+		part2.attack_self(user)
 	add_fingerprint(user)
 	return
 


### PR DESCRIPTION
# About The Pull Request

- Fixes self-attack shock component runtime.
- Fixes map-spawn electric chair infinite metal exploit.
        Map-spawned e-chairs are created without a shock component, thus runtime during deconstruction.

Resolves: https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/issues/671

## Why It's Good For The Game

Less runtimes.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl: Casper
fix: infinite metal exploit
/:cl: