### PR TITLE
Bugfix: Stops telekinetic users from teleporting to poles.

### DIFF
--- a/modular_splurt/code/game/objects/structures/pole.dm
+++ b/modular_splurt/code/game/objects/structures/pole.dm
@@ -16,6 +16,11 @@
 	. = ..()
 	if(.)
 		return
+
+	// Don't teleport telekinetic users to the pole.
+	if (get_dist(src,user) > 1)
+		return
+
 	if(obj_flags & IN_USE)
 		to_chat(user, "It's already in use - wait a bit.")
 		return


### PR DESCRIPTION
# About The Pull Request

Adds a simple range check.

Resolves: https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/issues/512

## Why It's Good For The Game

Teleporting is baaad.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl: Casper
fix: fixes telekinetic users from teleporting to stripper poles
/:cl: