### PR TITLE
Check client prefs before triggering LPD drink

### DIFF
--- a/modular_splurt/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -16,6 +16,18 @@
 	// Praise the funny BYOND dots
 	. = ..()
 
+	// Check for client
+	if(C.client)
+		// Check target pref for ERP
+		if(C.client?.prefs.erppref == "No")
+			// Return without triggering
+			return
+
+		// Check target pref for aphrodisiacs
+		if(C.client?.prefs.cit_toggles & NO_APHRO)
+			// Return without triggering
+			return
+
 	// Perform drink effect
 	C.clothing_burst(C)
 


### PR DESCRIPTION
# About The Pull Request
Updates Liquid Panty Dropper's drink effect to check the client's preferences for ERP and aphrodisiacs before triggering. Setting either to disabled will return with no effect.

## Why It's Good For The Game
Mitigates the effects non-consensual drink spiking and chem flooding. While this does not account for more nuanced preferences, it can eliminate some unwanted cases.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
tweak: Liquid Panty Dropper now checks client prefs
/:cl: