### PR TITLE
Adds the surplus condom box

### DIFF
--- a/modular_splurt/code/game/objects/items/storage/boxes.dm
+++ b/modular_splurt/code/game/objects/items/storage/boxes.dm
@@ -51,3 +51,28 @@
 /obj/item/paper/fluff/shipment_plushmium
 	name = "plushmium backer note"
 	info = "<h2>Plushmium Instructions</h2><i>Dear esteemed customer</i>,<br><br><span>Thank for backing the Stuffing For Spessmen© crowd funding initiative. We at Donk Co. pride ourselves on making a wide variety of <i>engaging</i> toys for our loyal customers to enjoy. Now, we're bringing the toy making process directly to your home or workplace!</span> Included in this box is:<ul><li>A spray bottle of Love to Life™ solution<li>A carefully packaged plushie</ul><span>To begin enjoying your new friend, start by unpacking the included plushie. Our selection process goes through rigorous quality testing to ensure you'll always get the best toy for the job. With so many choices, you'll want to get the whole family in on the action.</span><br><br><span>Once you have everything ready, it's time to make the patented Donk Co. magic happen! Spray your new best friend with Love to Life™ solution, included in the complimentary spray bottle, and watch the stunning transformation!</span><br><br><span>But don't leave your new best friend hanging! Give them a big warm hug to celebrate the long and intimate friendship you'll be sharing.</span><br><br><hr><span><i>Donk Co. is not responsible for any injury or loss of life that may occur while using the Love to Life™ solution. Do not allow access to children or adults without supervision by a chemist.</i></span><br><br><span><i>Do not drink, splash, inject, or otherwise handle the solution. Do not come into direct physical contact with the solution, or any object the solution has been applied to, under any circumstances.</i></span>"
+
+// Kinkmate listing for condom box
+/obj/item/storage/box/bulk_condoms
+	name = "surplus condom box"
+	desc = "A large collection of condoms, suitable for the safest of sluts!"
+	icon = 'modular_sand/icons/obj/fleshlight.dmi'
+	icon_state = "box"
+	custom_price = PRICE_ALMOST_EXPENSIVE // Half the price of buying individually
+
+/obj/item/storage/box/bulk_condoms/ComponentInitialize()
+	. = ..()
+
+	// Define storage component
+	var/datum/component/storage/str = GetComponent(/datum/component/storage)
+
+	// Set max items to 10
+	str.max_items = 10
+
+	// Restrict contents to only condoms
+	str.can_hold = typecacheof(list(/obj/item/genital_equipment/condom))
+
+/obj/item/storage/box/bulk_condoms/PopulateContents()
+	// Add maximum amount
+	for(var/i in 1 to 10)
+		new /obj/item/genital_equipment/condom(src)

--- a/modular_splurt/code/modules/client/loadout/backpack.dm
+++ b/modular_splurt/code/modules/client/loadout/backpack.dm
@@ -5,6 +5,11 @@
 	path = /obj/item/genital_equipment/condom
 	cost = 1
 
+/datum/gear/backpack/condom_box
+	name = "Box of Condoms"
+	path = /obj/item/storage/box/bulk_condoms
+	cost = 2
+
 /datum/gear/backpack/sounding
 	name = "Sounding rod"
 	path = /obj/item/genital_equipment/sounding

--- a/modular_splurt/code/modules/vending/kinkmate.dm
+++ b/modular_splurt/code/modules/vending/kinkmate.dm
@@ -24,6 +24,7 @@
 		/obj/item/clothing/neck/syntech/collar = 4,
 		/obj/item/storage/fancy/jellybean_pack = 5,
 		/obj/item/storage/box/aphrodisiac_pump = 5,
+		/obj/item/storage/box/bulk_condoms = 10,
 		/obj/item/strapon_strap = 5,
 		/obj/item/restraints/bondage_rope = 5,
 		/obj/item/clothing/under/domina = 5,


### PR DESCRIPTION
# About The Pull Request
Adds a box of ten condoms to the kinkmate vendor. The item is priced at half the cost of buying them individually. Also added to the loadout screen, under the backpack tab.

_Created to address Suggestion 112 by Discord user Remi_Scuntlet#5535_

## Why It's Good For The Game
Increases opportunities for the crew to practice safe and responsible interpersonal relations. Users expressed a desire for additional stock of this item.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
add: Added a surplus condom box to Kinkmates
/:cl: