### PR TITLE
Adds the One Shot quirk

### DIFF
--- a/modular_splurt/code/controllers/subsystem/processing/quirks.dm
+++ b/modular_splurt/code/controllers/subsystem/processing/quirks.dm
@@ -1,0 +1,6 @@
+// Add incompatible quirks
+/datum/controller/subsystem/processing/quirks/Initialize(timeofday)
+	. = ..()
+	
+	// Prevent DNC with One Shot
+	LAZYADD(quirk_blacklist, list(list("DNC","One Shot")))

--- a/modular_splurt/code/datums/traits/negative.dm
+++ b/modular_splurt/code/datums/traits/negative.dm
@@ -191,3 +191,12 @@
 		var/datum/physiology/P = H.physiology
 		P.hunger_mod /= 2
 		P.thirst_mod /= 2
+
+/datum/quirk/no_revive
+	name = "One Shot"
+	desc = "Your life is a precious and fleeting thing. Once it's over, it's over for good. Nothing on the station can revive you."
+	value = -4
+	mob_trait = TRAIT_NOCLONE
+	gain_text = span_danger("Your palms are sweaty, knees weak, arms are heavy.")
+	lose_text = span_notice("You find the determination to keep going.")
+	medical_record_text = "Patient cannot be revived with station-issued technologies. In the event of an emergency; Return to central command for processing."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4288,6 +4288,7 @@
 #include "modular_splurt\code\controllers\subsystem\discord.dm"
 #include "modular_splurt\code\controllers\subsystem\redbot.dm"
 #include "modular_splurt\code\controllers\subsystem\ticker.dm"
+#include "modular_splurt\code\controllers\subsystem\processing\quirks.dm"
 #include "modular_splurt\code\controllers\subsystem\processing\station.dm"
 #include "modular_splurt\code\datums\ai_laws.dm"
 #include "modular_splurt\code\datums\bark.dm"


### PR DESCRIPTION
# About The Pull Request
Adds a negative quirk that assigns TRAIT_NOCLONE to the user, which prevents all forms of revival. Quirk is made incompatible with DNC by adding a quirk_blacklist entry.

## Why It's Good For The Game
With the prevalence of defibrillation, revival surgery, cloning, and coffin revival; death can normally be considered negligible annoyance. Taking away that safety net changes how the game is perceived, and how threats are assessed.

This is also in response to users request for more negative quirks.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
add: Added a negative quirk: One Shot
/:cl: