### PR TITLE
Fix mood event newlines

### DIFF
--- a/modular_splurt/code/datums/mood_events/drug_events.dm
+++ b/modular_splurt/code/datums/mood_events/drug_events.dm
@@ -3,6 +3,6 @@
 	description = span_nicegreen("I feel like I\'m finally coping!")
 
 /datum/mood_event/moth_in_chief
-	description = span_nicegreen("The mantle rests well upon your shoulders?")
+	description = span_nicegreen("The mantle rests well upon your shoulders?\n")
 	mood_change = 10
 	timeout = 5 MINUTES

--- a/modular_splurt/code/datums/mood_events/generic_negative_events.dm
+++ b/modular_splurt/code/datums/mood_events/generic_negative_events.dm
@@ -1,5 +1,5 @@
 /datum/mood_event/masked_mook_incomplete
-	description = span_warning("I feel incomplete without a gas mask...")
+	description = span_warning("I feel incomplete without a gas mask...\n")
 	mood_change = -4
 
 /datum/mood_event/creampie/cheesed
@@ -12,7 +12,7 @@
 	if(!ishuman(actual_owner))
 		return .
 	if(iscatperson(actual_owner))
-		description = span_warning("<b>CHEESE!!! WAAAAAAAAAAAAAAAAAAAAAAAAAAAA!!!</b>")
+		description = span_warning("<b>CHEESE!!! WAAAAAAAAAAAAAAAAAAAAAAAAAAAA!!!</b>\n")
 		mood_change = -5
 		timeout = 5 MINUTES
 

--- a/modular_splurt/code/datums/mood_events/generic_positive_events.dm
+++ b/modular_splurt/code/datums/mood_events/generic_positive_events.dm
@@ -1,22 +1,22 @@
 /datum/mood_event/lewd_headpat
-	description = span_nicegreen("I love headpats so much!")
+	description = span_nicegreen("I love headpats so much!\n")
 	mood_change = 3
 	timeout = 2 MINUTES
 /datum/mood_event/qareen_bliss
-	description = span_umbra("So.. horny...")
+	description = span_umbra("So.. horny...\n")
 	mood_change = 5
 
 /datum/mood_event/qareen_bliss/add_effects()
-	description = span_umbra("Must.. breed. , [pick("Nngggghh", "Can't.. think.", "It feels so good.", "Need.. fuck.")]...")
+	description = span_umbra("Must.. breed. , [pick("Nngggghh", "Can't.. think.", "It feels so good.", "Need.. fuck.")]...\n")
 
 /datum/mood_event/masked_mook
-	description = span_nicegreen("I feel more complete with gas mask on.")
+	description = span_nicegreen("I feel more complete with gas mask on.\n")
 	mood_change = 1
 
 /datum/mood_event/nudist_positive
-	description = span_nicegreen("I'm delighted to not be constricted by clothing.")
+	description = span_nicegreen("I'm delighted to not be constricted by clothing.\n")
 	mood_change = 1
 
 /datum/mood_event/dorsualiphobic_mood_positive
-	description = span_nicegreen("Nobody will know if I'm wearing a backpack or not.")
+	description = span_nicegreen("Nobody will know if I'm wearing a backpack or not.\n")
 	mood_change = 1

--- a/modular_splurt/code/datums/mood_events/needs_events.dm
+++ b/modular_splurt/code/datums/mood_events/needs_events.dm
@@ -3,14 +3,14 @@
 	var/mob/living/carbon/human/actual_owner = owner_mob()
 	if(!HAS_TRAIT(actual_owner, TRAIT_VORACIOUS))
 		return
-	description = span_nicegreen("MORE FOOD!!! MORE FOOD!!! MORE FOOD!!!")
+	description = span_nicegreen("MORE FOOD!!! MORE FOOD!!! MORE FOOD!!!\n")
 	mood_change = 8
 
 /datum/mood_event/cum_craving
-	description = "I... NEED... CUM...\n"
+	description = span_warning("I... NEED... CUM...\n")
 	mood_change = -20
 
 /datum/mood_event/cum_stuffed
-	description = span_nicegreen("It feels so good inside me!")
+	description = span_nicegreen("It feels so good inside me!\n")
 	mood_change = 8
 	timeout = 5 MINUTES

--- a/modular_splurt/code/datums/mood_events/preg_events.dm
+++ b/modular_splurt/code/datums/mood_events/preg_events.dm
@@ -1,8 +1,8 @@
 /datum/mood_event/pregnant_negative
-	description = span_boldwarning("THE BABY IS COMING OUT...")
+	description = span_boldwarning("THE BABY IS COMING OUT...\n")
 	mood_change = -7
 
 /datum/mood_event/pregnant_positive
-	description = span_nicegreen("The baby came out...phew")
+	description = span_nicegreen("The baby came out...phew\n")
 	mood_change = 3
 	timeout = 2 MINUTES


### PR DESCRIPTION
# About The Pull Request
Restores missing newline markers to modular mood events. These were lost during a replacement of HTML spans. Also adds the missing span to mood event `cum_craving`.

## Why It's Good For The Game
Fixes a code error regression.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
fix: Fixed missing newline characters for mood events
/:cl: