### PR TITLE
Allow service borgs to cook

### DIFF
--- a/Build.bat
+++ b/Build.bat
@@ -1,4 +1,4 @@
 @echo off
 call "%~dp0\tools\build\build.bat" %*
-pause
+rem pause
 rem pausing is just annoying, don't

--- a/Build.bat
+++ b/Build.bat
@@ -1,4 +1,4 @@
 @echo off
 call "%~dp0\tools\build\build.bat" %*
-rem pause
+pause
 rem pausing is just annoying, don't

--- a/modular_splurt/code/game/objects/items/robot/robot_items.dm
+++ b/modular_splurt/code/game/objects/items/robot/robot_items.dm
@@ -79,3 +79,15 @@
 	source = /datum/robot_energy_storage/wrapping_paper
 
 /// End Cargo Borg Items ///
+
+
+/obj/item/gripper/service
+	name = "service gripper"
+	desc = "A simple grasping tool for interacting with food and condiments."
+	can_hold = list(
+		/obj/item/reagent_containers/glass,
+		/obj/item/reagent_containers/food,
+		/obj/item/kitchen,
+		/obj/item/storage/bag/tray
+		)
+

--- a/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
@@ -42,13 +42,14 @@
 	laws.associate(src)
 	update_icons()
 
-/datum/component/personal_crafting/borg
-	icon = 'icons/mob/screen_midnight.dmi'
-	screen_loc = "CENTER+5:5,SOUTH+1:5"
-
 /mob/living/silicon/robot/Initialize(mapload)
 	.=..()
 	AddComponent(/datum/component/personal_crafting)
-	//var/datum/component/personal_crafting/C = locate() in datum_components
-	//C.icon = 'icons/mob/screen_midnight.dmi'
-	//C.screen_loc = "CENTER+5:5,SOUTH+1:5"
+
+
+mob/living/silicon/robot/pick_module()
+	.=..()
+	var/datum/hud/R = src.hud_used
+	var/atom/movable/screen/craft/C = locate() in R.static_inventory
+	C.icon = 'icons/mob/screen_midnight.dmi'
+	C.screen_loc = "CENTER+5:5,SOUTH+1:5"

--- a/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
@@ -41,3 +41,14 @@
 	laws = new /datum/ai_laws/slaver_override
 	laws.associate(src)
 	update_icons()
+
+/datum/component/personal_crafting/borg
+	icon = 'icons/mob/screen_midnight.dmi'
+	screen_loc = "CENTER+5:5,SOUTH+1:5"
+
+/mob/living/silicon/robot/Initialize(mapload)
+	.=..()
+	AddComponent(/datum/component/personal_crafting)
+	//var/datum/component/personal_crafting/C = locate() in datum_components
+	//C.icon = 'icons/mob/screen_midnight.dmi'
+	//C.screen_loc = "CENTER+5:5,SOUTH+1:5"

--- a/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/robot/robot.dm
@@ -47,9 +47,9 @@
 	AddComponent(/datum/component/personal_crafting)
 
 
-mob/living/silicon/robot/pick_module()
+/mob/living/silicon/robot/pick_module()
 	.=..()
-	var/datum/hud/R = src.hud_used
+	var/datum/hud/R = hud_used
 	var/atom/movable/screen/craft/C = locate() in R.static_inventory
 	C.icon = 'icons/mob/screen_midnight.dmi'
 	C.screen_loc = "CENTER+5:5,SOUTH+1:5"

--- a/modular_splurt/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -265,7 +265,13 @@
 	var/list/extra = list(
 		/obj/item/dogborg/jaws/small,
 		/obj/item/analyzer/nose,
-		/obj/item/soap/tongue/scrubpup
+		/obj/item/soap/tongue/scrubpup,
+		/obj/item/gripper/service,
+		/obj/item/kitchen/rollingpin,
+		/obj/item/kitchen/unrollingpin,
+		/obj/item/kitchen/knife/butcher,
+		/obj/item/kitchen/efink,
+		/obj/item/kitchen/knife
 	)
 	LAZYADD(basic_modules, extra)
 	. = ..()


### PR DESCRIPTION
# About The Pull Request

This allows service cyborgs to cook, and it also allows other types of borgs to use the crafting menu. 

## Why It's Good For The Game

Service borgs are near utterly unused, as all they really do is... clean floors and pour drinks; now, they can cook too, which will hopefully make them a bit more enticing. Furthermore, giving engineering borgs the crafting menu allows them to make previously inaccessible structures/furniture!

## A Port?

No

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
tweak: Allowed borgs to craft
tweak: Changes service borgs' items
/:cl: