### PR TITLE
Revert non-modular removal of cryptominers

### DIFF
--- a/modular_sand/code/modules/research/designs/machine_designs.dm
+++ b/modular_sand/code/modules/research/designs/machine_designs.dm
@@ -33,21 +33,21 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 //Cryptocurrency Miners
-// /datum/design/board/cryptominer
-//	name = "Machine Design (Cryptocurrency Miner)"
-//	desc = "The circuit board for a Cryptocurrency Miner."
-//	id = "cryptominer"
-//	build_path = /obj/item/circuitboard/machine/cryptominer
-//	category = list("Misc. Machinery")
-//	departmental_flags = DEPARTMENTAL_FLAG_CARGO
+/datum/design/board/cryptominer
+	name = "Machine Design (Cryptocurrency Miner)"
+	desc = "The circuit board for a Cryptocurrency Miner."
+	id = "cryptominer"
+	build_path = /obj/item/circuitboard/machine/cryptominer
+	category = list("Misc. Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
-// /datum/design/board/cryptominer/syndie
-//	name = "Machine Design (Syndicate Cryptocurrency Miner)"
-//	desc = "The circuit board for a Syndicate Cryptocurrency Miner."
-//	id = "cryptominersyndie"
-//	build_path = /obj/item/circuitboard/machine/cryptominer/syndie
-//	category = list("Misc. Machinery")
-//	departmental_flags = DEPARTMENTAL_FLAG_CARGO
+/datum/design/board/cryptominer/syndie
+	name = "Machine Design (Syndicate Cryptocurrency Miner)"
+	desc = "The circuit board for a Syndicate Cryptocurrency Miner."
+	id = "cryptominersyndie"
+	build_path = /obj/item/circuitboard/machine/cryptominer/syndie
+	category = list("Misc. Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
 //BS miner
 /datum/design/board/bluespace_miner

--- a/modular_sand/code/modules/research/techweb/nodes/bluespace_nodes.dm
+++ b/modular_sand/code/modules/research/techweb/nodes/bluespace_nodes.dm
@@ -1,18 +1,18 @@
-// /datum/techweb_node/cryptominer
-//	id = "cryptominer"
-//	display_name = "Cryptocurrency Mining"
-//	description = "Harness the power of cryptocurrency to make credits for Cargo-- slowly."
-//	prereq_ids = list("bluespace_mining")
-//	design_ids = list("cryptominer")
-//	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+/datum/techweb_node/cryptominer
+	id = "cryptominer"
+	display_name = "Cryptocurrency Mining"
+	description = "Harness the power of cryptocurrency to make credits for Cargo-- slowly."
+	prereq_ids = list("bluespace_mining")
+	design_ids = list("cryptominer")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
-// /datum/techweb_node/cryptominersyndie
-//	id = "cryptominersyndie"
-//	display_name = "Illegal Cryptocurrency Mining"
-//	description = "Harness the power of bluespace to make credits for Cargo-- slowly."
-//	prereq_ids = list("cryptominer","syndicate_basic")
-//	design_ids = list("cryptominersyndie")
-//	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+/datum/techweb_node/cryptominersyndie
+	id = "cryptominersyndie"
+	display_name = "Illegal Cryptocurrency Mining"
+	description = "Harness the power of bluespace to make credits for Cargo-- slowly."
+	prereq_ids = list("cryptominer","syndicate_basic")
+	design_ids = list("cryptominersyndie")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/computermath
 	id = "computermath"


### PR DESCRIPTION
# About The Pull Request
Uncomments the techweb node and machine design for crypto miners. This is in response to Suggestion #3951 by Discord user legume#4970.

## Why It's Good For The Game
Prevents cargo from needing to gamble for crypto miner boards later into the round, and reduces the annoyance of farming random crates. Cryptominers were balanced around being easily obtainable, but difficult to run.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
tweak: Restored techweb node and circuit printing for Cryptominers
/:cl: