### PR TITLE
Remove redundant use of quirk DNC

### DIFF
--- a/code/__SPLURTCODE/DEFINES/zeros/traits.dm
+++ b/code/__SPLURTCODE/DEFINES/zeros/traits.dm
@@ -3,7 +3,6 @@
 #define TRAIT_CURSED_BLOOD "cursed_blood" //Yo dawg I heard you like bloodborne references so I put a
 #define TRAIT_HEADPAT_SLUT "headpat_slut"
 #define TRAIT_DISTANT "headpat_hater"
-#define TRAIT_NO_CLONE "no_clone"
 #define TRAIT_IN_HEAT "in_heat"
 #define TRAIT_HEAT_DETECT "heat_detect"
 #define TRAIT_ILLITERATE "illiterate"

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -502,10 +502,6 @@
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 
 /obj/machinery/computer/cloning/proc/can_scan(datum/dna/dna, mob/living/mob_occupant, experimental = FALSE, datum/bank_account/account)
-	if(HAS_TRAIT(mob_occupant, TRAIT_NO_CLONE))
-		scantemp = "Subject has an active DNC record on file. Unable to clone."
-		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-		return
 	if(!istype(dna))
 		scantemp = "Unable to locate valid genetic data."
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)

--- a/modular_splurt/code/datums/traits/negative.dm
+++ b/modular_splurt/code/datums/traits/negative.dm
@@ -66,13 +66,6 @@
 		speech_args[SPEECH_MESSAGE] = message
 
 //Own stuff
-/datum/quirk/no_clone
-	name = "DNC"
-	desc = "You have filed a Do Not Clone order, stating that you do not wish to be cloned. You can still be revived by other means."
-	value = -2
-	mob_trait = TRAIT_NO_CLONE
-	medical_record_text = "Patient has a DNC (Do Not Clone) order and will be rejected by cloning mechanisms as a result."
-
 /datum/quirk/no_guns
 	name = "Fat-Fingered"
 	desc = "Due to the shape of your hands, width of your fingers or just not having fingers at all, you're unable to fire guns without accommodation."


### PR DESCRIPTION
## About The Pull Request
Removes the quirk DNC from the code, as it was made redundant by an upstream merge, containing an important exploit fix.

The upstream PR can be found here: https://github.com/Sandstorm-Station/Sandstorm-Station-13/pull/293.

## Why It's Good For The Game
Removes obsolete redundant code.

## A Port?
No.

## Changelog
:cl:
code: Removed redundant definition of DNC quirk
/:cl: