### PR TITLE
Reduce condom prices

### DIFF
--- a/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/condom.dm
+++ b/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/condom.dm
@@ -9,6 +9,7 @@
 	icon_state 			= "b_condom_wrapped"
 	var/unwrapped		= 0
 	w_class 			= WEIGHT_CLASS_TINY
+	custom_price		= PRICE_CHEAP_AS_FREE // 10 credits
 
 /obj/item/genital_equipment/condom/Initialize()
 	create_reagents(300, DRAWABLE|NO_REACT)

--- a/modular_splurt/code/game/objects/items/storage/boxes.dm
+++ b/modular_splurt/code/game/objects/items/storage/boxes.dm
@@ -58,7 +58,7 @@
 	desc = "A large collection of condoms, suitable for the safest of sluts!"
 	icon = 'modular_sand/icons/obj/fleshlight.dmi'
 	icon_state = "box"
-	custom_price = PRICE_ALMOST_EXPENSIVE // Half the price of buying individually
+	custom_price = PRICE_BELOW_NORMAL // 20% discount from buying individually
 
 /obj/item/storage/box/bulk_condoms/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
# About The Pull Request
This PR will do the following:
- Set a price for the condom item: 10 credits (PRICE_CHEAP_AS_FREE)
- Reduce the set price for the surplus condom box: 80 credits (PRICE_BELOW_NORMAL)

_Addresses Suggestion #3984 by Discord user Remi_Scuntlet#5535._

## Why It's Good For The Game
Makes a roleplay-oriented item more affordable for crew with low paying jobs, including Assistants. Primarily meant to address user feedback.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
balance: Reduced the price of individual condoms from 40 to 10 credits
balance: Reduced the price of bulk condoms from 200 to 80 credits
/:cl: