### PR TITLE
Add variant Subtle verb with typing indicator

### DIFF
--- a/modular_splurt/code/modules/keybindings/keybind/communication.dm
+++ b/modular_splurt/code/modules/keybindings/keybind/communication.dm
@@ -1,0 +1,13 @@
+/datum/keybinding/client/communication/subtle
+	hotkey_keys = list("Ctrl5")
+
+/datum/keybinding/client/communication/subtle_indicator
+	hotkey_keys = list("5")
+	name = "Subtle_Indicator"
+	full_name = "Subtle Emote (with indicator)"
+	clientside = "subtle-indicator"
+
+/datum/keybinding/client/communication/subtle_indicator/down(client/user)
+	var/mob/living/mob_keybound = user.mob
+	mob_keybound.subtle_indicator()
+	return TRUE

--- a/modular_splurt/code/modules/mob/say_vr.dm
+++ b/modular_splurt/code/modules/mob/say_vr.dm
@@ -55,7 +55,7 @@
 
 /mob/living/verb/subtle_indicator()
 	// Set data
-	set name = "subtle_indicator"
+	set name = "Subtle (Indicator)"
 	set category = "IC"
 
 	// Check if say is disabled

--- a/modular_splurt/code/modules/mob/say_vr.dm
+++ b/modular_splurt/code/modules/mob/say_vr.dm
@@ -48,3 +48,30 @@
 		return
 	message = trim(html_encode(message), MAX_MESSAGE_LEN)
 	emote("narrate", message=message)
+
+/datum/emote/living/subtle/subtle_indicator
+	key = "subtle-indicator"
+	key_third_person = "subtle-indicator"
+
+/mob/living/verb/subtle_indicator()
+	// Set data
+	set name = "subtle_indicator"
+	set category = "IC"
+
+	// Check if say is disabled
+	if(GLOB.say_disabled)
+		// Warn user and return
+		to_chat(usr, span_danger("Speech is currently admin-disabled."))
+		return
+
+	// Display typing indicator
+	display_typing_indicator()
+
+	// Prompt user for text input
+	var/input_message = input(usr, "What would you like to subtly emote, with a typing indicator?", "Input subtle emote") as message|null
+
+	// Remove typing indicator
+	clear_typing_indicator()
+
+	// Run subtle emote with input
+	usr.emote("subtle", message = input_message)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4643,6 +4643,7 @@
 #include "modular_splurt\code\modules\jobs\job_types\security_officer.dm"
 #include "modular_splurt\code\modules\jobs\job_types\service.dm"
 #include "modular_splurt\code\modules\jobs\job_types\station_engineer.dm"
+#include "modular_splurt\code\modules\keybindings\keybind\communication.dm"
 #include "modular_splurt\code\modules\keybindings\keybind\human.dm"
 #include "modular_splurt\code\modules\keybindings\keybind\movement.dm"
 #include "modular_splurt\code\modules\language\xenocommon.dm"


### PR DESCRIPTION
# About The Pull Request
This commit adds a variant of the subtle verb that uses a typing indicator, and replaces the original key binding with it. Does not attempt to fix unrelated cyborg overlay issues.

Replaces https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/pull/489.

## Why It's Good For The Game
Replaces an existing test-merged PR with better code.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
add: Added variant of Subtle verb with typing indicator
tweak: Default binding for Subtle is now Control-5
/:cl: