### PR TITLE
Add roleplay brain trauma toys

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -31,6 +31,11 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		/obj/item/toy/toy_xeno = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/windupToolbox = ARCADE_WEIGHT_TRICK,
 
+		// SPLURT EDIT
+		/obj/item/handmirror/split_personality = ARCADE_WEIGHT_TRICK,
+		/obj/item/toy/figure/assistant/imaginary_friend = ARCADE_WEIGHT_TRICK,
+		// END SPLURT EDIT
+
 		/mob/living/simple_animal/bot/secbot/grievous/toy = ARCADE_WEIGHT_RARE,
 		/obj/item/clothing/mask/facehugger/toy = ARCADE_WEIGHT_RARE,
 		/obj/item/gun/ballistic/automatic/toy/pistol/unrestricted = ARCADE_WEIGHT_TRICK,

--- a/modular_splurt/code/game/objects/items/miscellaneous.dm
+++ b/modular_splurt/code/game/objects/items/miscellaneous.dm
@@ -190,12 +190,12 @@
 	name = "security holo badge"
 	desc = "A more futuristic hard-light badge"
 	icon_state = "security_badge_holo"
-	
+
 /obj/item/clothing/accessory/badge/deputy
 	name = "security deputy badge"
 	desc = "A shiny silver badge for deputies on the Security force"
 	icon_state = "security_badge_deputy"
-	
+
 /datum/design/sec_badge
 	name = "Security Badge"
 	desc = "A shiny badge to show the bearer is part of the Security force."
@@ -215,3 +215,41 @@
 	build_path = /obj/item/clothing/accessory/badge/deputy
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/obj/item/handmirror/split_personality
+	name = "dissociative mirror"
+	desc = "An enchanted hand mirror. You may not recognize who stares back."
+	var/item_used
+
+/obj/item/handmirror/split_personality/attack_self(mob/user)
+	// Check if already used
+	if(item_used)
+		// Warn user, then return
+		to_chat(user, span_warning("[src] is no longer functional."))
+		return
+
+	// Check if human user exists
+	if(!ishuman(user))
+		// Warn user, then return
+		to_chat(user, span_warning("You see nothing in [src]."))
+		return
+
+	// Define human user
+	var/mob/living/carbon/human/mirror_user = user
+
+	// Add brain trauma
+	mirror_user.gain_trauma(/datum/brain_trauma/severe/split_personality, TRAUMA_RESILIENCE_SURGERY)
+
+	// Set item used variable
+	// This prevents future use
+	item_used = TRUE
+
+	// Alert in local chat
+	mirror_user.visible_message(span_warning("The [src] shatters in [mirror_user]'s hands!"), span_warning("The mirror shatters in your hands!"))
+
+	// Play mirror break sound
+	playsound(src, 'sound/effects/Glassbr3.ogg', 50, 1)
+
+	// Set flavor text
+	name = "broken hand mirror"
+	desc = "You won\'t get much use out of it."

--- a/modular_splurt/code/game/objects/items/toys.dm
+++ b/modular_splurt/code/game/objects/items/toys.dm
@@ -3,3 +3,39 @@
 	icon = 'modular_splurt/icons/obj/toy.dmi'
 	icon_state = "savannahivanovtoy"
 	desc = "Mini-Mecha action figure! Collect them all! 13/12."
+
+/obj/item/toy/figure/assistant/imaginary_friend
+	name = "imaginary friend action figure"
+	desc = "A toy that resembles a special friend."
+	toysay = "I'll always be your best friend!"
+	var/item_used
+
+/obj/item/toy/figure/assistant/imaginary_friend/attack_self(mob/user as mob)
+	// Check if already used
+	if(item_used)
+		// Warn user, then return
+		to_chat(user, span_warning("[src] does nothing. It must be broken."))
+		return
+
+	// Check if human user exists
+	if(!ishuman(user))
+		// Warn user, then return
+		to_chat(user, span_warning("You refrain from handling [src]."))
+		return
+
+	// Define human user
+	var/mob/living/carbon/human/mirror_user = user
+
+	// Add brain trauma
+	mirror_user.gain_trauma(/datum/brain_trauma/special/imaginary_friend, TRAUMA_RESILIENCE_SURGERY)
+
+	// Set item used variable
+	// This prevents future use
+	item_used = TRUE
+
+	// Alert in local chat
+	mirror_user.visible_message(span_warning("[mirror_user] plays with [src]."), span_warning("You start to remember [src], as if they were a real person!"))
+
+	// Set flavor text
+	name = "generic action figure"
+	desc = "It\'s just a normal toy."


### PR DESCRIPTION
# About The Pull Request
Adds two new toy items that grant role-play-oriented brain traumas. Both can be earned as prizes from the arcade machine, and are single-use. Item flavor text is updated after use to indicate their status.

Items and associated traumas are:
- Imaginary Friend Action Figure: Imaginary Friend
- Dissociative Mirror: Split Personality

_Created in response to Suggestion #3844 by Discord user Hen 101#6765._

## Why It's Good For The Game
Adds a more reliable method for obtaining brain traumas that create new unique social opportunities. Items should be uncommon enough to prevent spam usage.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
add: Added the Imaginary Friend Action Figure
add: Added the Dissociative Mirror
/:cl: