### PR TITLE
Remove obsolete Heat quirks

### DIFF
--- a/code/__SPLURTCODE/DEFINES/zeros/traits.dm
+++ b/code/__SPLURTCODE/DEFINES/zeros/traits.dm
@@ -3,8 +3,6 @@
 #define TRAIT_CURSED_BLOOD "cursed_blood" //Yo dawg I heard you like bloodborne references so I put a
 #define TRAIT_HEADPAT_SLUT "headpat_slut"
 #define TRAIT_DISTANT "headpat_hater"
-#define TRAIT_IN_HEAT "in_heat"
-#define TRAIT_HEAT_DETECT "heat_detect"
 #define TRAIT_ILLITERATE "illiterate"
 #define TRAIT_HIDE_BACKPACK "hide_backpack"
 

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -153,10 +153,6 @@
 			if(MOOD_LEVEL_HAPPY4 to INFINITY)
 				. += "[t_He] look[p_s()] ecstatic."
 
-	if(HAS_TRAIT(src, TRAIT_IN_HEAT) && (HAS_TRAIT(user, TRAIT_HEAT_DETECT) || src == user))
-		. += ""
-		. += "<span class='love'>[t_He] [t_is] currently in [gender == MALE ? "rut" : "heat"].</span>"
-
 	if(LAZYLEN(.) > 1)
 		.[1] += "<hr>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -460,10 +460,6 @@
 	if (length(msg))
 		. += "<span class='warning'>[msg.Join("")]</span>"
 
-	if(HAS_TRAIT(src, TRAIT_IN_HEAT) && (HAS_TRAIT(user, TRAIT_HEAT_DETECT) || src == user))
-		. += ""
-		. += "<span class='love'>[t_He] [t_is] currently in [gender == MALE ? "rut" : "heat"].</span>"
-
 	var/trait_exam = common_trait_examine()
 	if (!isnull(trait_exam))
 		. += trait_exam

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -64,10 +64,6 @@
 	brutemod = 0.9
 	species_language_holder = /datum/language_holder/lizard/ash
 
-
-#define HEAT_CYCLE_LENGTH 32
-#define HEAT_CYCLE_OFFSET 11
-
 /datum/species/lizard/ashwalker/on_species_gain(mob/living/carbon/human/C, datum/species/old_species)
 	if((C.dna.features["spines"] != "None" ) && (C.dna.features["tail_lizard"] == "None")) //tbh, it's kinda ugly for them not to have a tail yet have floating spines
 		C.dna.features["tail_lizard"] = "Smooth"
@@ -80,12 +76,6 @@
 		C.dna.features["mam_snouts"] = "Sharp"
 	C.dna.features["mcolor2"] = C.dna.features["mcolor"] //for no funne rainbows
 	C.dna.features["mcolor3"] = C.dna.features["mcolor"]
-	ADD_TRAIT(C, TRAIT_HEAT_DETECT, SPECIES_TRAIT)
-	var/temp = text2num(GLOB.round_id)
-	var/tempish = ((temp + (HEAT_CYCLE_OFFSET + 2)) % HEAT_CYCLE_LENGTH)
-	if(tempish <= 2 && tempish >= 0)
-		to_chat(C, "<span class='userlove'>It's this time again.. Your loins lay restless as they await a potential mate.</span>")
-		ADD_TRAIT(C, TRAIT_IN_HEAT, SPECIES_TRAIT)
 
 	if(C.gender == MALE)
 		C.dna.features["has_cock"] = TRUE
@@ -103,6 +93,3 @@
 	C.give_genitals(1)
 	C.update_body()
 	return ..()
-
-#undef HEAT_CYCLE_LENGTH
-#undef HEAT_CYCLE_OFFSET

--- a/modular_splurt/code/datums/traits/neutral.dm
+++ b/modular_splurt/code/datums/traits/neutral.dm
@@ -61,14 +61,6 @@
 	. = ..()
 	quirk_holder.RemoveElement(/datum/element/wuv/headpat)
 
-/datum/quirk/in_heat
-	name = "In Heat"
-	desc = "Your system burns with the desire to be bred. Satisfying your lust will make you happy, but ignoring it may cause you to become sad and needy."
-	value = 0
-	mob_trait = TRAIT_IN_HEAT
-	gain_text = span_notice("You body burns with the desire to be bred.")
-	lose_text = span_notice("You feel more in control of your body and thoughts.")
-
 /datum/quirk/Hypnotic_gaze
 	name = "Hypnotic Gaze"
 	desc = "Be it through mysterious patterns, flickering colors, or some genetic oddity, prolonged eye contact with you will place the viewer into a highly-suggestible hypnotic trance."
@@ -83,14 +75,6 @@
 	var/datum/action/innate/Hypnotize/spell = new
 	spell.Grant(Hypno_eyes)
 	spell.owner = Hypno_eyes
-
-/datum/quirk/heat
-	name = "Estrus Detection"
-	desc = "You have a animalistic sense of detecting if someone is in heat."
-	value = 0
-	mob_trait = TRAIT_HEAT_DETECT
-	gain_text = span_notice("You feel your senses adjust, allowing a animalistic sense of others' fertility.")
-	lose_text = span_notice("You feel your sense of others' fertility fade.")
 
 /datum/quirk/overweight
 	name = "Overweight"

--- a/modular_splurt/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -1,3 +1,19 @@
+/datum/reagent/drug/aphrodisiacplus/overdose_start(mob/living/M)
+	// Check for pre-existing heat trait
+	if(!HAS_TRAIT(M, TRAIT_ESTROUS_ACTIVE))
+		// Check client preferences
+		if(M && M.client?.prefs.arousable && !(M.client?.prefs.cit_toggles & NO_APHRO))
+			// Add quirk
+			M.add_quirk(/datum/quirk/estrous_active, APHRO_TRAIT)
+
+			// Chat message is handled by the quirk
+
+			// Log interaction
+			M.log_message("Given the In Estrous quirk by hexacrocin overdose.", LOG_EMOTE)
+
+	// Return normally
+	. = ..()
+
 //Own stuff
 /datum/reagent/drug/maint/tar
 	name = "Maintenance Tar"

--- a/modular_splurt/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -1,12 +1,3 @@
-//Main code edits
-/datum/reagent/drug/aphrodisiacplus/overdose_process(mob/living/M)
-	if(M && M.client?.prefs.arousable && !(M.client?.prefs.cit_toggles & NO_APHRO))
-		if(!HAS_TRAIT(M, TRAIT_IN_HEAT))
-			to_chat(M, span_userlove("Your need for sex is overpowering!"))
-			M.log_message("Made In Heat by hexacrocin.", LOG_EMOTE)
-			ADD_TRAIT(M, TRAIT_IN_HEAT, APHRO_TRAIT)
-	. = ..()
-
 //Own stuff
 /datum/reagent/drug/maint/tar
 	name = "Maintenance Tar"


### PR DESCRIPTION
# About The Pull Request
Removes quirks In Heat and Estrus Detection, which were merged upstream in https://github.com/Sandstorm-Station/Sandstorm-Station-13/pull/298.

These features were originally ported to this codebase in PR https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/pull/20 by GitHub user @NullFag, who would prefer to be credited for doing so.

## Why It's Good For The Game
Removes content that was made obsolete by an upstream merge.

## A Port?
No.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
code: Removed obsolete entries for In Heat and Estrus Detection
/:cl: