### PR TITLE
Revert non-modular TETRIS edits

### DIFF
--- a/modular_sand/code/game/machinery/computer/arcade/tetris.dm
+++ b/modular_sand/code/game/machinery/computer/arcade/tetris.dm
@@ -18,9 +18,6 @@
 			var/temp_score = text2num(href_list["tetrisScore"])
 			say("YOUR SCORE: [temp_score]!")
 			var/reward = round(temp_score/REWARD_DIVISOR)
-			message_admins("[ADMIN_LOOKUPFLW(usr)] used [src] with score [temp_score] and total_rewards [reward]!!!")
-			if(reward > 5)
-				reward = 4
 			prizevend(usr, reward)
 	return
 


### PR DESCRIPTION
# About The Pull Request
This commit reverts non-modular edits to the TETRIS arcade machine to maintain parity with upstream edits.

Upstream PR can be found here: https://github.com/Sandstorm-Station/Sandstorm-Station-13/pull/300

## Why It's Good For The Game
Changes made in this repository have been rendered obsolete by upstream changes. Reverting these changes will allow for cleaner merging.

## A Port?
No.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
code: Reverted non-modular SPLURT edits to TETRIS
/:cl:
