### PR TITLE
Prevent researching Infective Exo-Locomotion

### DIFF
--- a/modular_splurt/code/modules/research/techweb/nodes/nanites_nodes.dm
+++ b/modular_splurt/code/modules/research/techweb/nodes/nanites_nodes.dm
@@ -1,0 +1,12 @@
+// Harmful nanites node
+/datum/techweb_node/nanite_hazard/New()
+	// Define designs to remove
+	var/list/rem_designs = list(
+		"spreading_nanites"
+	)
+
+	// Remove designs from the list
+	LAZYREMOVE(design_ids, rem_designs)
+
+	// Return
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4785,6 +4785,7 @@
 #include "modular_splurt\code\modules\research\techweb\nodes\bluespace_nodes.dm"
 #include "modular_splurt\code\modules\research\techweb\nodes\mecha_nodes.dm"
 #include "modular_splurt\code\modules\research\techweb\nodes\medical_nodes.dm"
+#include "modular_splurt\code\modules\research\techweb\nodes\nanites_nodes.dm"
 #include "modular_splurt\code\modules\research\techweb\nodes\robotic_nodes.dm"
 #include "modular_splurt\code\modules\resize\smallsprite_action.dm"
 #include "modular_splurt\code\modules\ruins\objects_and_mobs\ash_walker_den.dm"


### PR DESCRIPTION
# About The Pull Request
Prevents researching the Infective Exo-Locomotion nanite type, listed in the techweb as `spreading_nanites`, due to conflicts with server rules. This is done with a modular techweb node removal edit.

Replaces https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/pull/757

## Why It's Good For The Game
Prevents users from obtaining a nanite program that is prohibited from use by server rules, without making non-modular edits.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
del: Removed techweb entry for Infective Exo-Locomotion nanites
/:cl: