### PR TITLE
Minor Hexa-chem overdose improvements

### DIFF
--- a/modular_splurt/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -1,3 +1,5 @@
+#define QUIRK_ESTROUS_ACTIVE /datum/quirk/estrous_active
+
 // Hexacrocin
 /datum/reagent/drug/aphrodisiacplus/overdose_start(mob/living/M)
 	. = ..()
@@ -19,9 +21,9 @@
 		return
 
 	// Check for pre-existing heat trait
-	if(!HAS_TRAIT(M, TRAIT_ESTROUS_ACTIVE))
+	if(!M.has_quirk(QUIRK_ESTROUS_ACTIVE))
 		// Add quirk
-		M.add_quirk(/datum/quirk/estrous_active, APHRO_TRAIT)
+		M.add_quirk(QUIRK_ESTROUS_ACTIVE, APHRO_TRAIT)
 
 		// Chat message is handled by the quirk
 
@@ -46,9 +48,11 @@
 		return
 
 	// Check for pre-existing heat trait
-	if(HAS_TRAIT(M, TRAIT_ESTROUS_ACTIVE))
+	if(M.has_quirk(QUIRK_ESTROUS_ACTIVE))
 		// Remove quirk
-		M.remove_quirk(/datum/quirk/estrous_active)
+		M.remove_quirk(QUIRK_ESTROUS_ACTIVE)
+
+		// Chat message is handled by the quirk
 
 		// Log interaction
 		M.log_message("lost the In Estrous quirk due to [src] overdose.", LOG_EMOTE)
@@ -120,3 +124,5 @@
 		var/temp = holder ? holder.chem_temp : T20C
 		T.atmos_spawn_air("copium=[volume];TEMP=[temp]")
 	return
+
+#undef QUIRK_ESTROUS_ACTIVE

--- a/modular_splurt/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -1,18 +1,57 @@
+// Hexacrocin
 /datum/reagent/drug/aphrodisiacplus/overdose_start(mob/living/M)
+	. = ..()
+
+	// Check for mob with client
+	if(!(istype(M) && M.client))
+		return
+
+	// Check pref for arousable
+	if(!M.client?.prefs.arousable)
+		// Log interaction and return
+		M.log_message("overdosed on [src], but ignored it due to arousal preference.", LOG_EMOTE)
+		return
+
+	// Check pref for aphro
+	if(M.client?.prefs.cit_toggles & NO_APHRO)
+		// Log interaction and return
+		M.log_message("overdosed on [src], but ignored it due to aphrodisiac preference.", LOG_EMOTE)
+		return
+
 	// Check for pre-existing heat trait
 	if(!HAS_TRAIT(M, TRAIT_ESTROUS_ACTIVE))
-		// Check client preferences
-		if(M && M.client?.prefs.arousable && !(M.client?.prefs.cit_toggles & NO_APHRO))
-			// Add quirk
-			M.add_quirk(/datum/quirk/estrous_active, APHRO_TRAIT)
+		// Add quirk
+		M.add_quirk(/datum/quirk/estrous_active, APHRO_TRAIT)
 
-			// Chat message is handled by the quirk
+		// Chat message is handled by the quirk
 
-			// Log interaction
-			M.log_message("Given the In Estrous quirk by hexacrocin overdose.", LOG_EMOTE)
+		// Log interaction
+		M.log_message("was given the In Estrous quirk by [src] overdose.", LOG_EMOTE)
 
 	// Return normally
 	. = ..()
+
+// Hexacamphor
+/datum/reagent/drug/anaphrodisiacplus/overdose_start(mob/living/M)
+	. = ..()
+
+	// Check for mob with client
+	if(!(istype(M) && M.client))
+		return
+
+	// Check pref for arousable
+	if(!M.client?.prefs.arousable)
+		// Log interaction and return
+		M.log_message("overdosed on [src], but ignored it due to arousal preference.", LOG_EMOTE)
+		return
+
+	// Check for pre-existing heat trait
+	if(HAS_TRAIT(M, TRAIT_ESTROUS_ACTIVE))
+		// Remove quirk
+		M.remove_quirk(/datum/quirk/estrous_active)
+
+		// Log interaction
+		M.log_message("lost the In Estrous quirk due to [src] overdose.", LOG_EMOTE)
 
 //Own stuff
 /datum/reagent/drug/maint/tar


### PR DESCRIPTION
# About The Pull Request
This PR does the following:
- Adds In Estrous quirk removal effect to Hexacamphor
- Adds preference-related failure event logging to Hexacrocin and Hexacamphor
- Checks for quirk instead of trait

## Why It's Good For The Game
This will accomplish the following:
- Allow removing the otherwise permanent quirk assignment caused by Hexacrocin
- Allow admins to check logs for potentially unwanted usage of Hexa-chems

While non-consensual use of these chemicals is an admin issue, having an in-character method of counteracting negative effects is helpful for when admins are unavailable, or for users who would prefer to resolve cases in-character.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
tweak: Hexacamphor overdose will remove the In Estrous quirk
/:cl: