### PR TITLE
Refactor trait defines

### DIFF
--- a/code/__SPLURTCODE/DEFINES/quirks.dm
+++ b/code/__SPLURTCODE/DEFINES/quirks.dm
@@ -1,3 +1,9 @@
 //Dominant/Well-trained quirks
 #define DOMINANT_DETECT_RANGE 5
 #define DOMINANT_SNAP_COOLDOWN 10 SECONDS
+
+// Quirk mood types
+#define QMOOD_NUDIST		"mood_nudist"
+#define QMOOD_MASKED_MOOK	"mood_masked_mook"
+#define QMOOD_HIDE_BAG		"mood_storage_concealment"
+#define QMOOD_WELL_TRAINED	"mood_dom_trained"

--- a/code/__SPLURTCODE/DEFINES/species.dm
+++ b/code/__SPLURTCODE/DEFINES/species.dm
@@ -1,2 +1,4 @@
-#define SPECIES_SPECBOT		"spectre_bot"
-#define SPECIES_SHADEKIN	"shadekin"
+#define SPECIES_SPECBOT			"spectre_bot"
+#define SPECIES_SHADEKIN		"shadekin"
+#define SPECIES_ASHWALKER_WEST	"ashlizard_west"
+#define SPECIES_ASHWALKER_EAST	"ashlizard_east"

--- a/code/__SPLURTCODE/DEFINES/traits.dm
+++ b/code/__SPLURTCODE/DEFINES/traits.dm
@@ -1,29 +1,32 @@
-#define SLAVER_TRAIT "slaver"
-#define PREGNANCY_TRAIT "pregnancy"
+// General traits
+#define TRAIT_PREGNANT			"pregnant"
+#define TRAIT_FLOORED			"floored"
+#define IGNORE_FAKE_Z_AXIS		"ignore_fake_z_axis"
+#define TRAIT_TONGUELESS_SPEECH "tongueless_speech"
 
-#define TRAIT_HYPNOTIC_GAZE "Hypnotic Gaze"
-#define TRAIT_PREGNANT "pregnant"
+// Trait types
+#define SLAVER_TRAIT			"slaver"
+#define PREGNANCY_TRAIT			"pregnancy"
 
-#define TRAIT_FLOORED "floored"
-#define IGNORE_FAKE_Z_AXIS "ignore_fake_z_axis"
-
-#define TRAIT_GFLUID_DETECT "genital_fluid_detect"
-
-#define TRAIT_ASHRESISTANCE		"TRAIT_ASHRESISTANCE"
-
-#define TRAIT_TONGUELESS_SPEECH "tongueless-speech" //for dephelm stuff
-
-// Hyperstation traits
-#define TRAIT_PHARMA            "hepatic_pharmacokinesis"
+// Quirk traits
+#define TRAIT_HYPNOTIC_GAZE		"hypnotic_gaze"
+#define TRAIT_GFLUID_DETECT		"genital_fluid_detect"
+#define TRAIT_ASHRESISTANCE		"ash_resistance"
+#define TRAIT_PHARMA			"hepatic_pharmacokinesis"
 #define TRAIT_CHOKE_SLUT		"choke_slut"
-
-#define TRAIT_BLOODFLEDGE		"BloodFledge"
-
-#define TRAIT_INCUBUS			"Incubus"
-#define TRAIT_SUCCUBUS			"Succubus"
-
-#define TRAIT_ARACHNID			"Arachnid"
+#define TRAIT_BLOODFLEDGE		"bloodfledge"
+#define TRAIT_INCUBUS			"incubus"
+#define TRAIT_SUCCUBUS			"succubus"
+#define TRAIT_ARACHNID			"arachnid"
 #define TRAIT_FLUTTER			"flutter"
-#define TRAIT_NUDIST			"Nudist"
+#define TRAIT_NUDIST			"nudist"
 #define TRAIT_CLOTH_EATER		"cloth_eater"
-#define TRAIT_WEREWOLF			"Werewolf"
+#define TRAIT_WEREWOLF			"werewolf"
+#define TRAIT_PRIMITIVE			"primitive"
+#define TRAIT_STEEL_ASS			"steel_ass"
+#define TRAIT_CURSED_BLOOD		"cursed_blood"
+#define TRAIT_HEADPAT_SLUT		"headpat_slut"
+#define TRAIT_DISTANT			"headpat_hater"
+#define TRAIT_ILLITERATE		"illiterate"
+#define TRAIT_HIDE_BACKPACK		"hide_backpack"
+#define TRAIT_DUMB4CUM			"dumb4cum"

--- a/code/__SPLURTCODE/DEFINES/zeros/species.dm
+++ b/code/__SPLURTCODE/DEFINES/zeros/species.dm
@@ -1,2 +1,0 @@
-#define SPECIES_ASHWALKER_WEST "ashlizard_west"
-#define SPECIES_ASHWALKER_EAST "ashlizard_east"

--- a/code/__SPLURTCODE/DEFINES/zeros/traits.dm
+++ b/code/__SPLURTCODE/DEFINES/zeros/traits.dm
@@ -1,9 +1,0 @@
-#define TRAIT_PRIMITIVE "primitive"
-#define TRAIT_STEEL_ASS "steel_ass"
-#define TRAIT_CURSED_BLOOD "cursed_blood" //Yo dawg I heard you like bloodborne references so I put a
-#define TRAIT_HEADPAT_SLUT "headpat_slut"
-#define TRAIT_DISTANT "headpat_hater"
-#define TRAIT_ILLITERATE "illiterate"
-#define TRAIT_HIDE_BACKPACK "hide_backpack"
-
-#define TRAIT_DUMB4CUM "dumb4cum"

--- a/modular_splurt/code/datums/traits/neutral.dm
+++ b/modular_splurt/code/datums/traits/neutral.dm
@@ -152,7 +152,6 @@
 	gain_text = span_notice("You feel like being someone's pet...")
 	lose_text = span_notice("You no longer feel like being a pet...")
 	processing_quirk = TRUE
-	var/mood_category = "dom_trained"
 	var/notice_delay = 0
 	var/mob/living/carbon/human/last_dom
 
@@ -202,10 +201,10 @@
 
 	//Handle the mood
 	var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
-	if(istype(mood.mood_events[mood_category], /datum/mood_event/dominant/good_boy))
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/dominant/good_boy)
+	if(istype(mood.mood_events[QMOOD_WELL_TRAINED], /datum/mood_event/dominant/good_boy))
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QMOOD_WELL_TRAINED, /datum/mood_event/dominant/good_boy)
 	else
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/dominant/need)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QMOOD_WELL_TRAINED, /datum/mood_event/dominant/need)
 
 	//Don't do anything if a previous dom was found
 	if(last_dom)
@@ -279,7 +278,6 @@
 	// The shame is unbearable
 	mood_quirk = FALSE
 	processing_quirk = FALSE
-	var/mood_category = "backpack_implant_mood"
 
 /datum/quirk/storage_concealment/on_spawn()
 	. = ..()
@@ -295,10 +293,10 @@
 	// Check the quirk holder for the trait
 	if(HAS_TRAIT(quirk_holder, TRAIT_HIDE_BACKPACK))
 		// When found: Mood bonus
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/dorsualiphobic_mood_positive)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QMOOD_HIDE_BAG, /datum/mood_event/dorsualiphobic_mood_positive)
 	else
 		// When not found: Mood penalty
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/dorsualiphobic_mood_negative)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QMOOD_HIDE_BAG, /datum/mood_event/dorsualiphobic_mood_negative)
 
 //succubus and incubus below
 /datum/quirk/incubus
@@ -635,15 +633,14 @@
 	value = 0
 	mood_quirk = TRUE
 	processing_quirk = TRUE
-	var/mood_category = "nudist_mood"
 
 /datum/quirk/nudist/on_process()
 	var/mob/living/carbon/human/H = quirk_holder
 	// Checking torso exposure appears to be a robust method.
 	if( ( H.is_chest_exposed() && H.is_groin_exposed() ) )
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/nudist_positive)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QUIRK_MOOD_NUDIST, /datum/mood_event/nudist_positive)
 	else
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/nudist_negative)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QUIRK_MOOD_NUDIST, /datum/mood_event/nudist_negative)
 
 /datum/quirk/nudist/on_spawn()
 	. = ..()
@@ -662,15 +659,14 @@
 	mood_quirk = TRUE
 	medical_record_text = "Patient feels more secure when wearing a gas mask."
 	processing_quirk = TRUE
-	var/mood_category = "masked_mook"
 
 /datum/quirk/masked_mook/on_process()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/mask/gas/gasmask = H.get_item_by_slot(ITEM_SLOT_MASK)
 	if(istype(gasmask))
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QMOOD_MASKED_MOOK, /datum/mood_event/masked_mook)
 	else
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook_incomplete)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QMOOD_MASKED_MOOK, /datum/mood_event/masked_mook_incomplete)
 
 /datum/quirk/masked_mook/on_spawn()
 	. = ..()

--- a/modular_splurt/code/datums/traits/neutral.dm
+++ b/modular_splurt/code/datums/traits/neutral.dm
@@ -638,9 +638,9 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	// Checking torso exposure appears to be a robust method.
 	if( ( H.is_chest_exposed() && H.is_groin_exposed() ) )
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QUIRK_MOOD_NUDIST, /datum/mood_event/nudist_positive)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QMOOD_NUDIST, /datum/mood_event/nudist_positive)
 	else
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QUIRK_MOOD_NUDIST, /datum/mood_event/nudist_negative)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, QMOOD_NUDIST, /datum/mood_event/nudist_negative)
 
 /datum/quirk/nudist/on_spawn()
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -281,8 +281,6 @@
 #include "code\__SPLURTCODE\DEFINES\traits.dm"
 #include "code\__SPLURTCODE\DEFINES\arousal\genitals.dm"
 #include "code\__SPLURTCODE\DEFINES\dcs\signals.dm"
-#include "code\__SPLURTCODE\DEFINES\zeros\species.dm"
-#include "code\__SPLURTCODE\DEFINES\zeros\traits.dm"
 #include "code\_globalvars\admin.dm"
 #include "code\_globalvars\bitfields.dm"
 #include "code\_globalvars\configuration.dm"


### PR DESCRIPTION
# About The Pull Request
Moves all trait definitions into a single file, fixes inconsistent capitalization, and sorts them into even lists by type. Does the same for species defines. Also removes mood category variables, and replaces them with defines.

## Why It's Good For The Game
Reduces potential confusion and inconsistency when adding new traits, and may help to reduce merge conflicts from pull requests that add new traits. Mood categories were better set as defines, as they will never change.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
refactor: Refactored trait defines
/:cl: