### PR TITLE
Minor auto-cryo improvements

### DIFF
--- a/config/splurt/autocryo.txt
+++ b/config/splurt/autocryo.txt
@@ -1,5 +1,5 @@
 ## Uncomment to enable automatic SSD cryo
 # AUTOCRYO_ENABLED
 
-## Time in seconds before sending SSD users to cryo
 AUTOCRYO_TIME_TRIGGER 24000
+## Time in ticks before sending SSD users to cryo

--- a/config/splurt/autocryo.txt
+++ b/config/splurt/autocryo.txt
@@ -1,5 +1,5 @@
 ## Uncomment to enable automatic SSD cryo
 # AUTOCRYO_ENABLED
 
-AUTOCRYO_TIME_TRIGGER 24000
 ## Time in ticks before sending SSD users to cryo
+AUTOCRYO_TIME_TRIGGER 24000

--- a/modular_splurt/code/controllers/subsystem/afk.dm
+++ b/modular_splurt/code/controllers/subsystem/afk.dm
@@ -15,7 +15,7 @@ SUBSYSTEM_DEF(auto_cryo)
 
 /datum/controller/subsystem/auto_cryo/fire()
 	// Check for any targets
-	if(!GLOB.ssd_mob_list.len)
+	if(!LAZYLEN(GLOB.ssd_mob_list))
 		// No SSD mobs exist
 		return
 

--- a/modular_splurt/code/modules/mob/living/logout.dm
+++ b/modular_splurt/code/modules/mob/living/logout.dm
@@ -3,19 +3,33 @@
 
 	// Check for BORIS AI borgs
 	if(src in GLOB.available_ai_shells)
+		// Log event and return
+		log_game("[src] ignored auto-cryo by being: An AI shell.")
 		return
 
 	// Check for the AI
 	if(isAI(src))
+		// Log event and return
+		log_game("[src] ignored auto-cryo by being: The AI.")
+		return
+
+	// Check if dead
+	if(stat == DEAD)
+		// Log event and return
+		log_game("[src] ignored auto-cryo by being: Dead.")
 		return
 
 	// Check for VR mob
 	if(src.GetComponent(/datum/component/virtual_reality))
+		// Log event and return
+		log_game("[src] ignored auto-cryo by being: A VR avatar.")
 		return
 
 	// Check if mob is in a VR pod
 	// This is not an ideal solution
 	if(istype(src.loc, /obj/machinery/vr_sleeper))
+		// Log event and return
+		log_game("[src] ignored auto-cryo by being: In a VR sleeper.")
 		return
 
 	// Add to SSD list


### PR DESCRIPTION
# About The Pull Request
This PR does the following
- Adds logging for when a mob isn't added to the auto-cryo list
- Adds an exclusion condition for dead mobs
- Changes list length checking method to `LAZYLEN`
- Fixes a typographical mistake in configuration text ("seconds" to "ticks")

## Why It's Good For The Game
Adds more logging for admins, and prevents cases potential cases of unwanted automatic body disposal services.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
tweak: Auto-cryo now ignores dead bodies
admin: Auto-cryo now logs all cases of mobs being ignored
/:cl: