### PR TITLE
Add more assorted job alt titles

### DIFF
--- a/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
+++ b/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
@@ -199,14 +199,17 @@
 		"Toxins Researcher",
 		"Research Intern",
 		"Junior Scientist",
-		"Rack Researcher"
+		"Rack Researcher",
+		"Nanite Programmer",
+		"Tetromino Researcher"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
 
 /datum/job/roboticist/New()
 	var/list/extra_titles = list(
-		"Ripperdoc"
+		"Ripperdoc",
+		"MOD Mechanic"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
@@ -325,7 +328,8 @@
 		"Mail Man",
 		"Mail Woman",
 		"Mailroom Technician",
-		"Logistics Technician"
+		"Logistics Technician",
+		"Cryptocurrency Technician"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
@@ -338,6 +342,19 @@
 		"Ashwalker Sex Slave",
 		"Ashwalker Breeder",
 		"Slayer"
+	)
+	LAZYADD(alt_titles, extra_titles)
+	. = ..()
+
+// Prisoner
+/datum/job/prisoner/New()
+	var/list/extra_titles = list(
+		"Low Security Prisoner",
+		"Medium Security Prisoner",
+		"Maximum Security Prisoner",
+		"Supermax Prisoner",
+		"Protective Custody Prisoner",
+		"Prison Slut"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()


### PR DESCRIPTION
# About The Pull Request
This commit adds more alternate titles for jobs.

Scientist:
- Nanite Programmer
- Tetromino Researcher

Prisoner:
- Low Security Prisoner
- Medium Security Prisoner
- Maximum Security Prisoner
- Supermax Prisoner
- Protective Custody Prisoner
- Prison Slut

Roboticist:
- MOD Mechanic

Cargo
- Cryptocurrency Technician

_Addresses Suggestion #4142 by Gmgaraz#4289 - Prisoner job titles
Addresses Suggestion #4139 by Tony Meowprano#2038 - Nanites job title_


## Why It's Good For The Game
Adds more ways to describe a character's job on the station.

## A Port?
No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
add: Added new scientist job titles: Nanite Programmer, Tetromino Researcher
add: Added new roboticist job titles: MOD Mechanic
add: Added new prisoner job titles: Low Security Prisoner, Medium Security Prisoner, Maximum Security Prisoner, Supermax Prisoner, Prison Slut
add: Added new cargo job titles: Cryptocurrency Technician
/:cl: