### PR TITLE
Removes duplicated mining points card from Minerborg.

### DIFF
--- a/modular_sand/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_sand/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -88,10 +88,11 @@
 	basic_modules += /obj/item/reagent_containers/borghypo/borgshaker/sodashaker
 	basic_modules += /obj/item/reagent_containers/borghypo/borgshaker/miscshaker
 	. = ..()
-
+/*
 /obj/item/robot_module/miner/Initialize(mapload)
 	basic_modules += /obj/item/card/id/miningborg
-	. = ..()
+	. = ..() 
+*/ //Sandstorm, the main citacode already gives a mining points card to the minerborg, borgs don't need another one.
 
 /datum/robot_energy_storage/plasma
 	name = "Plasma Buffer Container"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Basically this is a simple PR removal of the duplicated mining points card.

## Why It's Good For The Game

Annoyingly unnecesary to have two mining points cards.

## A Port?

It was in the sandstorm's modular codes.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
del: Removed duplicated mining points card.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
