### PR TITLE
Removes access lock from protolathes and other machines

### DIFF
--- a/config/splurt/general.txt
+++ b/config/splurt/general.txt
@@ -18,3 +18,7 @@ WEIGHTED_STATION_TRAITS
 # SM delamination
 # Comment to make the SM not explode
 SM_DELAMINATION
+
+# Protolathe access
+# Comment to make protolathes and mechfabs use their access locks
+PROTOLOCK_ALL_ACCESS

--- a/modular_splurt/code/controllers/configuration/entries/splurt_general.dm
+++ b/modular_splurt/code/controllers/configuration/entries/splurt_general.dm
@@ -9,3 +9,5 @@
 	config_entry_value = DEFAULT_SAVE_SLOTS
 
 /datum/config_entry/flag/sm_delamination
+
+/datum/config_entry/flag/protolock_all_access

--- a/modular_splurt/code/modules/mob/mob.dm
+++ b/modular_splurt/code/modules/mob/mob.dm
@@ -1,3 +1,5 @@
+#define PROTOLOCK_ALL_ACCESS CONFIG_GET(flag/protolock_all_access)
+
 /mob/Initialize()
 	. = ..()
 	create_player_panel()
@@ -79,3 +81,9 @@
 
 	// All checks passed
 	return TRUE
+
+//Makes the protolocks able to be disabled
+/mob/can_use_production(obj/machinery/machine_target)
+	if(PROTOLOCK_ALL_ACCESS)
+		return TRUE
+	. = ..()


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
People have been complaining about the locks since their introduction, so this pr should fix the issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
suggested by MANY people, the locks system seems to be poorly received by players
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
no
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
balance: Removes the locks on protolathes and other machines
balance: Well actually makes it a config but it's set to disable the locks so potato tomato
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
