### PR TITLE
spelling fixes

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -96,8 +96,8 @@
 		activate_pin(1)
 
 /obj/item/integrated_circuit/input/med_scanner
-	name = "integrated medical analyser"
-	desc = "A very small version of the common medical analyser. This allows the machine to know how healthy someone is."
+	name = "integrated medical analyzer"
+	desc = "A very small version of the common medical analyzer. This allows the machine to know how healthy someone is."
 	icon_state = "medscan"
 	complexity = 4
 	inputs = list("target" = IC_PINTYPE_REF)
@@ -113,7 +113,7 @@
 	var/mob/living/H = get_pin_data_as_type(IC_INPUT, 1, /mob/living)
 	if(!istype(H)) //Invalid input
 		return
-	if(H.Adjacent(get_turf(src))) // Like normal analysers, it can't be used at range.
+	if(H.Adjacent(get_turf(src))) // Like normal analyzers, it can't be used at range.
 		var/total_health = round(H.health/H.getMaxHealth(), 0.01)*100
 		var/missing_health = H.getMaxHealth() - H.health
 
@@ -124,8 +124,8 @@
 	activate_pin(2)
 
 /obj/item/integrated_circuit/input/adv_med_scanner
-	name = "integrated adv. medical analyser"
-	desc = "A very small version of the medbot's medical analyser. This allows the machine to know how healthy someone is. \
+	name = "integrated adv. medical analyzer"
+	desc = "A very small version of the medbot's medical analyzer. This allows the machine to know how healthy someone is. \
 	This type is much more precise, allowing the machine to know much more about the target than a normal analyzer."
 	icon_state = "medscan_adv"
 	complexity = 12
@@ -164,7 +164,7 @@
 
 /obj/item/integrated_circuit/input/slime_scanner
 	name = "slime_scanner"
-	desc = "A very small version of the xenobio analyser. This allows the machine to know every needed properties of slime. Output mutation list is non-associative."
+	desc = "A very small version of the xenobio analyzer. This allows the machine to know every needed properties of slime. Output mutation list is non-associative."
 	icon_state = "medscan_adv"
 	complexity = 12
 	inputs = list("target" = IC_PINTYPE_REF)
@@ -207,7 +207,7 @@
 
 /obj/item/integrated_circuit/input/plant_scanner
 	name = "integrated plant analyzer"
-	desc = "A very small version of the plant analyser. This allows the machine to know all valuable parameters of plants in trays. \
+	desc = "A very small version of the plant analyzer. This allows the machine to know all valuable parameters of plants in trays. \
 			It can only scan plants, not seeds or fruits."
 	icon_state = "medscan_adv"
 	complexity = 12

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_tcomms_and_misc.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_tcomms_and_misc.dm
@@ -182,9 +182,9 @@
 	build_path = /obj/item/assembly/timer
 	category = list("initial", "Misc")
 
-/datum/design/voice_analyser
-	name = "Voice Analyser"
-	id = "voice_analyser"
+/datum/design/voice_analyzer
+	name = "Voice Analyzer"
+	id = "voice_analyzer"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 50)
 	build_path = /obj/item/assembly/voice

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -527,7 +527,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/pHmeter
-	name = "Chemical Analyser"
+	name = "Chemical Analyzer"
 	desc = "A a electrode attached to a small circuit box that will tell you the pH of a solution."
 	id   = "pHmeter"
 	build_type = PROTOLATHE

--- a/code/modules/ruins/spaceruin_code/oldstation.dm
+++ b/code/modules/ruins/spaceruin_code/oldstation.dm
@@ -16,10 +16,10 @@
 	resulting in the user being unable to see long distances.<br><br>The B01 is unlikely to see any form of mass production, but will serve as a base for future Hardsuit developments."
 
 /obj/item/paper/fluff/ruins/oldstation/protohealth
-	name = "Health Analyser Report"
-	info = "<b>*Health Analyser*</b><br><br>The portable Health Analyser is essentially a handheld variant of a health analyser. Years of research have concluded with this device which is \
+	name = "Health Analyzer Report"
+	info = "<b>*Health Analyzer*</b><br><br>The portable Health Analyzer is essentially a handheld variant of a health analyzer. Years of research have concluded with this device which is \
 	capable of diagnosing even the most critical, obscure or technical injuries any humanoid entity is suffering in an easy to understand format that even a non-trained health professional \
-	can understand.<br><br>The health analyser is expected to go into full production as standard issue medical kit."
+	can understand.<br><br>The health analyzer is expected to go into full production as standard issue medical kit."
 
 /obj/item/paper/fluff/ruins/oldstation/protogun
 	name = "K14 Energy Gun Report"
@@ -41,7 +41,7 @@
 	info = {"
 **Inventory**
 * (1) Prototype Hardsuit
-* (1)Health Analyser
+* (1)Health Analyzer
 * (1)Prototype Energy Gun
 * (1)Singularity Generation Disk
 __DO NOT REMOVE WITHOUT HE CAPTAIN AND RESEARCH DIRECTOR'S AUTHORISATION__
@@ -57,4 +57,4 @@ __DO NOT REMOVE WITHOUT HE CAPTAIN AND RESEARCH DIRECTOR'S AUTHORISATION__
 
 /obj/item/paper/fluff/ruins/oldstation/generator_manual
 	name = "S.U.P.E.R.P.A.C.M.A.N.-type portable generator manual"
-	info = "You can barely make out a faded sentence... <br><br> Wrench down the generator on top of a wire node connected to either a SMES input terminal or the power grid." 
+	info = "You can barely make out a faded sentence... <br><br> Wrench down the generator on top of a wire node connected to either a SMES input terminal or the power grid."

--- a/html/changelogs/archive/2018-02.yml
+++ b/html/changelogs/archive/2018-02.yml
@@ -303,7 +303,7 @@
   - tweak: The Scan with Debugger/Device button now reads Copy Ref and no longer sends
       you to the circuit's page when clicked
   - tweak: The assembly's menu is now slightly wider
-  - tweak: The advanced in "integrated advanced medical analyser" is now abbreviated
+  - tweak: The advanced in "integrated advanced medical analyzer" is now abbreviated
       to adv.
   Xhuis:
   - bugfix: The preference to lock action buttons in place is now correctly saved

--- a/modular_citadel/code/modules/reagents/objects/items.dm
+++ b/modular_citadel/code/modules/reagents/objects/items.dm
@@ -110,7 +110,7 @@
 	used = TRUE
 
 /obj/item/fermichem/pHmeter
-	name = "Chemistry Analyser"
+	name = "Chemistry Analyzer"
 	desc = "A a electrode attached to a small circuit box that will tell you the pH of a solution. The screen currently displays nothing."
 	icon_state = "pHmeter"
 	icon = 'icons/obj/chemical.dmi'

--- a/modular_splurt/code/modules/cargo/packs/goodies.dm
+++ b/modular_splurt/code/modules/cargo/packs/goodies.dm
@@ -111,7 +111,7 @@
 	contains = list( /obj/item/gunpart/riflebrush2stock, /obj/item/gunpart/riflebrush2barrel, /obj/item/ammo_box/g45l)
 
 /datum/supply_pack/goody/revolver45_single
-	name = ".45 Reolver Single-Pack"
+	name = ".45 Revolver Single-Pack"
 	desc = "Contains a parts kit to assemble a 45 Revolver Gun. Comes with a box of .45 Long"
 	cost = 800
 	contains = list( /obj/item/gunpart/revolver45cylinder, /obj/item/gunpart/revolver45frame, /obj/item/ammo_box/g45l)


### PR DESCRIPTION
Changes all instances of "Analyser" to "Analyzer" to make the spelling consistent.

Fixes the typo in the cargo console, from "Reolver" to "Revolver".

# About The Pull Request

spelling fix

## Why It's Good For The Game

spelling fix

## A Port?

no

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
spellcheck: fixed typos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
