### PR TITLE
[MIRRIOR] Personal Combat Messages Part 1 & 2

### DIFF
--- a/_maps/RandomZLevels/away_mission/caves.dmm
+++ b/_maps/RandomZLevels/away_mission/caves.dmm
@@ -890,15 +890,6 @@
 	},
 /area/awaymission/caves/research)
 "cQ" = (
-/obj/item/pickaxe{
-	attack_verb_continuous = list("ineffectively hit")
-	attack_verb_simple = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
-	throwforce = 1
-	},
 /turf/open/floor/plating/asteroid/basalt{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},

--- a/_maps/RandomZLevels/away_mission/caves.dmm
+++ b/_maps/RandomZLevels/away_mission/caves.dmm
@@ -638,14 +638,6 @@
 /obj/structure/closet/crate/miningcar{
 	name = "Mining cart"
 	},
-/obj/item/pickaxe{
-	name = "rusty pickaxe"
-	desc = "A pickaxe that's been left to rust."
-	attack_verb_continuous = list("ineffectively hits")
-	attack_verb_simple = list("ineffectively hit")
-	force = 1
-	throwforce = 1
-	},
 /turf/open/floor/plating/asteroid/basalt{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},

--- a/_maps/RandomZLevels/away_mission/caves.dmm
+++ b/_maps/RandomZLevels/away_mission/caves.dmm
@@ -639,7 +639,8 @@
 	name = "Mining cart"
 	},
 /obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
+	attack_verb_continuous = list("ineffectively hit")
+	attack_verb_simple = list("ineffectively hit");
 	desc = "A pickaxe thats been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";
@@ -899,7 +900,8 @@
 /area/awaymission/caves/research)
 "cQ" = (
 /obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
+	attack_verb_continuous = list("ineffectively hit")
+	attack_verb_simple = list("ineffectively hit");
 	desc = "A pickaxe thats been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";
@@ -1098,7 +1100,8 @@
 "ds" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
+	attack_verb_continuous = list("ineffectively hit")
+	attack_verb_simple = list("ineffectively hit");
 	desc = "A pickaxe thats been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";
@@ -1487,7 +1490,8 @@
 "eP" = (
 /obj/structure/table,
 /obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
+	attack_verb_continuous = list("ineffectively hit")
+	attack_verb_simple = list("ineffectively hit");
 	desc = "A pickaxe thats been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";
@@ -1495,7 +1499,8 @@
 	throwforce = 1
 	},
 /obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
+	attack_verb_continuous = list("ineffectively hit")
+	attack_verb_simple = list("ineffectively hit");
 	desc = "A pickaxe thats been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";
@@ -1852,7 +1857,8 @@
 	name = "Mining cart"
 	},
 /obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
+	attack_verb_continuous = list("ineffectively hit")
+	attack_verb_simple = list("ineffectively hit");
 	desc = "A pickaxe thats been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";

--- a/_maps/RandomZLevels/away_mission/caves.dmm
+++ b/_maps/RandomZLevels/away_mission/caves.dmm
@@ -1081,15 +1081,6 @@
 /area/awaymission/caves/BMP_asteroid/level_two)
 "ds" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/item/pickaxe{
-	attack_verb_continuous = list("ineffectively hit")
-	attack_verb_simple = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
-	throwforce = 1
-	},
 /turf/open/floor/plasteel,
 /area/awaymission/caves/BMP_asteroid/level_two)
 "dt" = (

--- a/_maps/RandomZLevels/away_mission/caves.dmm
+++ b/_maps/RandomZLevels/away_mission/caves.dmm
@@ -1462,24 +1462,6 @@
 /area/awaymission/caves/listeningpost)
 "eP" = (
 /obj/structure/table,
-/obj/item/pickaxe{
-	attack_verb_continuous = list("ineffectively hit")
-	attack_verb_simple = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
-	throwforce = 1
-	},
-/obj/item/pickaxe{
-	attack_verb_continuous = list("ineffectively hit")
-	attack_verb_simple = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
-	throwforce = 1
-	},
 /turf/open/floor/plasteel,
 /area/awaymission/caves/listeningpost)
 "eR" = (
@@ -1828,15 +1810,6 @@
 "fX" = (
 /obj/structure/closet/crate/miningcar{
 	name = "Mining cart"
-	},
-/obj/item/pickaxe{
-	attack_verb_continuous = list("ineffectively hit")
-	attack_verb_simple = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
-	throwforce = 1
 	},
 /obj/item/stack/sheet/mineral/adamantine{
 	amount = 15

--- a/_maps/RandomZLevels/away_mission/caves.dmm
+++ b/_maps/RandomZLevels/away_mission/caves.dmm
@@ -639,12 +639,11 @@
 	name = "Mining cart"
 	},
 /obj/item/pickaxe{
-	attack_verb_continuous = list("ineffectively hit")
-	attack_verb_simple = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
+	name = "rusty pickaxe"
+	desc = "A pickaxe that's been left to rust."
+	attack_verb_continuous = list("ineffectively hits")
+	attack_verb_simple = list("ineffectively hit")
+	force = 1
 	throwforce = 1
 	},
 /turf/open/floor/plating/asteroid/basalt{

--- a/_maps/splurt_maps/map_files/Smexistation/Snaxi_Splurt.dmm
+++ b/_maps/splurt_maps/map_files/Smexistation/Snaxi_Splurt.dmm
@@ -20642,7 +20642,8 @@
 /area/engineering/main/reactor_core)
 "hzH" = (
 /obj/item/melee/baseball_bat{
-	attack_verb = list("punished","smacked","pulverised","cracked");
+	attack_verb_continuous = list("punishs","smacks","pulverises","cracks")
+	attack_verb_simple = list("punish","smack","pulverise","crack");
 	desc = "An old bat with dried blood filling its crooks and crevices, this bat is used to quench sadistic thirst. If the mind doesn't break to this torture device, the body will break.";
 	name = "\improper Mind Breaker"
 	},

--- a/_maps/splurt_maps/map_files/Smexistation/Snaxi_Splurt.dmm
+++ b/_maps/splurt_maps/map_files/Smexistation/Snaxi_Splurt.dmm
@@ -20641,12 +20641,6 @@
 /turf/open/pool,
 /area/engineering/main/reactor_core)
 "hzH" = (
-/obj/item/melee/baseball_bat{
-	attack_verb_continuous = list("punishs","smacks","pulverises","cracks")
-	attack_verb_simple = list("punish","smack","pulverise","crack");
-	desc = "An old bat with dried blood filling its crooks and crevices, this bat is used to quench sadistic thirst. If the mind doesn't break to this torture device, the body will break.";
-	name = "\improper Mind Breaker"
-	},
 /obj/item/electropack,
 /obj/item/assembly/signaler,
 /obj/structure/table/reinforced,

--- a/_maps/splurt_maps/map_files/Smexistation_OLD/Snaxi_Splurt.dmm
+++ b/_maps/splurt_maps/map_files/Smexistation_OLD/Snaxi_Splurt.dmm
@@ -20107,7 +20107,8 @@
 /area/service/library)
 "hzH" = (
 /obj/item/melee/baseball_bat{
-	attack_verb = list("punished","smacked","pulverised","cracked");
+	attack_verb_continuous = list("punishs","smacks","pulverises","cracks")
+	attack_verb_simple = list("punish","smack","pulverise","crack");
 	desc = "An old bat with dried blood filling its crooks and crevices, this bat is used to quench sadistic thirst. If the mind doesn't break to this torture device, the body will break.";
 	name = "\improper Mind Breaker"
 	},

--- a/_maps/splurt_maps/map_files/Smexistation_OLD/Snaxi_Splurt.dmm
+++ b/_maps/splurt_maps/map_files/Smexistation_OLD/Snaxi_Splurt.dmm
@@ -20106,12 +20106,6 @@
 /turf/open/floor/carpet,
 /area/service/library)
 "hzH" = (
-/obj/item/melee/baseball_bat{
-	attack_verb_continuous = list("punishs","smacks","pulverises","cracks")
-	attack_verb_simple = list("punish","smack","pulverise","crack");
-	desc = "An old bat with dried blood filling its crooks and crevices, this bat is used to quench sadistic thirst. If the mind doesn't break to this torture device, the body will break.";
-	name = "\improper Mind Breaker"
-	},
 /obj/item/electropack,
 /obj/item/assembly/signaler,
 /obj/structure/table/reinforced,

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -219,23 +219,26 @@
 			return clamp(w_class * 6, 10, 100) // Multiply the item's weight class by 6, then clamp the value between 10 and 100
 
 /mob/living/proc/send_item_attack_message(obj/item/I, mob/living/user, hit_area, obj/item/bodypart/hit_bodypart)
-	var/message_verb = "attacked"
-	if(length(I.attack_verb))
-		message_verb = "[pick(I.attack_verb)]"
-	else if(!I.force)
+	if(!I.force && !length(I.attack_verb_simple) && !length(I.attack_verb_continuous))
 		return
+	var/message_verb_continuous = length(I.attack_verb_continuous) ? "[pick(I.attack_verb_continuous)]" : "attacks"
+	var/message_verb_simple = length(I.attack_verb_simple) ? "[pick(I.attack_verb_simple)]" : "attack"
 	var/message_hit_area = ""
 	if(hit_area)
 		message_hit_area = " in the [hit_area]"
-	var/attack_message = "[src] is [message_verb][message_hit_area] with [I]!"
-	var/attack_message_local = "You're [message_verb][message_hit_area] with [I]!"
+	var/attack_message_spectator = "[src] [message_verb_continuous][message_hit_area] with [I]!"
+	var/attack_message_victim = "Something [message_verb_continuous] you[message_hit_area] with [I]!"
+	var/attack_message_attacker = "You [message_verb_simple] [src][message_hit_area] with [I]!"
 	if(user in viewers(src, null))
-		attack_message = "[user] [message_verb] [src][message_hit_area] with [I]!"
-		attack_message_local = "[user] [message_verb] you[message_hit_area] with [I]!"
+		attack_message_spectator = "[user] [message_verb_continuous] [src][message_hit_area] with [I]!"
+		attack_message_victim = "[user] [message_verb_continuous] you[message_hit_area] with [I]!"
 	if(user == src)
-		attack_message_local = "You [message_verb] yourself[message_hit_area] with [I]"
-	visible_message("<span class='danger'>[attack_message]</span>",\
-		"<span class='userdanger'>[attack_message_local]</span>", null, COMBAT_MESSAGE_RANGE)
+		attack_message_victim = "You [message_verb_simple] yourself[message_hit_area] with [I]."
+	visible_message(span_danger("[attack_message_spectator]"),\
+		span_userdanger("[attack_message_victim]"), null, COMBAT_MESSAGE_RANGE, user)
+	if(is_blind())
+		to_chat(src, span_danger("Someone hits you[message_hit_area]!"))
+	to_chat(user, span_danger("[attack_message_attacker]"))
 	return 1
 
 /// How much stamina this takes to swing this is not for realism purposes hecc off.

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -162,8 +162,6 @@
 		return
 	if(is_muzzled())
 		return
-	if(!CheckActionCooldown(CLICK_CD_MELEE))
-		return
 	var/mob/living/carbon/ML = A
 	if(istype(ML))
 		var/dam_zone = pick(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
@@ -175,14 +173,17 @@
 		if(prob(75))
 			ML.apply_damage(rand(1,3), BRUTE, affecting, armor)
 			ML.visible_message("<span class='danger'>[name] bites [ML]!</span>", \
-							"<span class='userdanger'>[name] bites [ML]!</span>")
+							"<span class='userdanger'>[name] bites you!</span>", "<span class='hear'>You hear a chomp!</span>", COMBAT_MESSAGE_RANGE, name)
+			to_chat(name, "<span class='danger'>You bite [ML]!</span>")
 			if(armor >= 2)
 				return
 			for(var/thing in diseases)
 				var/datum/disease/D = thing
 				ML.ForceContractDisease(D)
 		else
-			ML.visible_message("<span class='danger'>[src] has attempted to bite [ML]!</span>")
+			ML.visible_message("<span class='danger'>[src]'s bite misses [ML]!</span>", \
+							"<span class='danger'>You avoid [src]'s bite!</span>", "<span class='hear'>You hear jaws snapping shut!</span>", COMBAT_MESSAGE_RANGE, src)
+			to_chat(src, "<span class='danger'>Your bite misses [ML]!</span>")
 	DelayNextAction()
 
 /*

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -21,8 +21,8 @@
 	if(extra_damage == A.dna.species.punchdamagelow)
 		playsound(D.loc, A.dna.species.miss_sound, 25, 1, -1)
 		D.visible_message("<span class='warning'>[A] has attempted to [atk_verb] [D]!</span>", \
-			"<span class='userdanger'>[A] has attempted to [atk_verb] [D]!</span>", null, COMBAT_MESSAGE_RANGE)
-		log_combat(A, D, "attempted to hit", atk_verb)
+			"<span class='danger'>You avoid [A]'s [atk_verb]!</span>", "<span class='hear'>You hear a swoosh!</span>", COMBAT_MESSAGE_RANGE, A)
+		to_chat(A, "<span class='warning'>Your [atk_verb] misses [D]!</span>")
 		return TRUE
 
 	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
@@ -31,7 +31,8 @@
 	playsound(D.loc, A.dna.species.attack_sound, 25, 1, -1)
 
 	D.visible_message("<span class='danger'>[A] has [atk_verb]ed [D]!</span>", \
-			"<span class='userdanger'>[A] has [atk_verb]ed [D]!</span>", null, COMBAT_MESSAGE_RANGE)
+			"<span class='userdanger'>You're [atk_verb]ed by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+	to_chat(A, "<span class='danger'>You [atk_verb]ed [D]!</span>")
 
 	D.apply_damage(rand(10,13) + extra_damage, STAMINA, affecting, armor_block)
 	log_combat(A, D, "punched (boxing) ")
@@ -39,7 +40,8 @@
 		var/knockout_prob = (D.getStaminaLoss() + rand(-15,15))*0.75
 		if((D.stat != DEAD) && prob(knockout_prob))
 			D.visible_message("<span class='danger'>[A] has knocked [D] out with a haymaker!</span>", \
-								"<span class='userdanger'>[A] has knocked [D] out with a haymaker!</span>")
+								"<span class='userdanger'>You're knocked unconscious by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+			to_chat(A, "<span class='danger'>You knock [D] out with a haymaker!</span>")
 			D.apply_effect(200,EFFECT_KNOCKDOWN,armor_block)
 			D.SetSleeping(100)
 			D.forcesay(GLOB.hit_appends)

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -46,8 +46,9 @@
 		return FALSE
 	var/damage = (damage_roll(A,D) + 5)
 	if(CHECK_MOBILITY(D, MOBILITY_STAND))
-		D.visible_message("<span class='warning'>[A] slams [D] into the ground!</span>", \
-						  	"<span class='userdanger'>[A] slams you into the ground!</span>")
+		D.visible_message("<span class='danger'>[A] kicks [D]'s head, knocking [D.p_them()] out!</span>", \
+						"<span class='userdanger'>You're knocked unconscious by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", null, A)
+		to_chat(A, "<span class='danger'>You kick [D]'s head, knocking [D.p_them()] out!</span>")
 		playsound(get_turf(A), 'sound/weapons/slam.ogg', 50, 1, -1)
 		D.apply_damage(damage, BRUTE)
 		D.DefaultCombatKnockdown(120)
@@ -60,8 +61,9 @@
 	var/damage = damage_roll(A,D)
 	if(!CHECK_MOBILITY(D, MOBILITY_STAND) && CHECK_MOBILITY(D, MOBILITY_USE))
 		log_combat(A, D, "knocked out (Head kick)(CQC)")
-		D.visible_message("<span class='warning'>[A] kicks [D]'s head, knocking [D.p_them()] out!</span>", \
-					  		"<span class='userdanger'>[A] kicks your head, knocking you out!</span>")
+		D.visible_message("<span class='danger'>[A] kicks [D] back!</span>", \
+						"<span class='userdanger'>You're kicked back by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+		to_chat(A, "<span class='danger'>You kick [D] back!</span>")
 		playsound(get_turf(A), 'sound/weapons/genhit1.ogg', 50, 1, -1)
 		D.SetSleeping(300)
 		D.apply_damage(damage + 5, BRUTE)
@@ -82,7 +84,9 @@
 		return FALSE
 	var/damage = (damage_roll(A,D) + 55)
 	log_combat(A, D, "pressured (CQC)")
-	D.visible_message("<span class='warning'>[A] punches [D]'s neck!</span>")
+	D.visible_message("<span class='danger'>[A] punches [D]'s neck!</span>", \
+	"<span class='userdanger'>Your neck is punched by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+	to_chat(A, "<span class='danger'>You punch [D]'s neck!</span>")
 	D.apply_damage(damage, STAMINA)
 	playsound(get_turf(A), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
 	return TRUE
@@ -96,7 +100,8 @@
 	if(!D.stat)
 		log_combat(A, D, "restrained (CQC)")
 		D.visible_message("<span class='warning'>[A] locks [D] into a restraining position!</span>", \
-							"<span class='userdanger'>[A] locks you into a restraining position!</span>")
+							"<span class='userdanger'>You're locked into a restraining position by [A]!</span>", "<span class='hear'>You hear shuffling and a muffled groan!</span>", null, A)
+		to_chat(A, "<span class='danger'>You lock [D] into a restraining position!</span>")
 		D.apply_damage(damage, STAMINA)
 		D.Stun(10)
 		restraining = TRUE
@@ -109,8 +114,9 @@
 	var/damage = damage_roll(A,D)
 	if(!D.stat)
 		log_combat(A, D, "consecutive CQC'd (CQC)")
-		D.visible_message("<span class='warning'>[A] strikes [D]'s abdomen, neck and back consecutively</span>", \
-							"<span class='userdanger'>[A] strikes your abdomen, neck and back consecutively!</span>")
+		D.visible_message("<span class='danger'>[A] strikes [D]'s abdomen, neck and back consecutively</span>", \
+						"<span class='userdanger'>Your abdomen, neck and back are struck consecutively by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+		to_chat(A, "<span class='danger'>You strike [D]'s abdomen, neck and back consecutively!</span>")
 		playsound(get_turf(D), 'sound/weapons/cqchit2.ogg', 50, 1, -1)
 		var/obj/item/I = D.get_active_held_item()
 		if(I && D.temporarilyRemoveItemFromInventory(I))
@@ -131,7 +137,8 @@
 			A.setGrabState(GRAB_AGGRESSIVE) //Instant agressive grab if on grab intent
 			log_combat(A, D, "grabbed", addition="aggressively")
 			D.visible_message("<span class='warning'>[A] violently grabs [D]!</span>", \
-								"<span class='userdanger'>[A] violently grabs you!</span>")
+								"<span class='userdanger'>You're grabbed violently by [A]!</span>", "<span class='hear'>You hear sounds of aggressive fondling!</span>", COMBAT_MESSAGE_RANGE, A)
+			to_chat(A, "<span class='danger'>You violently grab [D]!</span>")
 		return TRUE
 	return FALSE
 
@@ -143,22 +150,24 @@
 		return TRUE
 	log_combat(A, D, "attacked (CQC)")
 	A.do_attack_animation(D)
-	var/picked_hit_type = pick("CQC'd", "Big Bossed")
+	var/picked_hit_type = pick("CQC", "Big Boss")
 	var/bonus_damage = (damage_roll(A,D) + 7)
 	if(!CHECK_MOBILITY(D, MOBILITY_STAND))
 		bonus_damage += 5
-		picked_hit_type = "stomps on"
+		picked_hit_type = "stomp"
 	D.apply_damage(bonus_damage, BRUTE)
-	if(picked_hit_type == "kicks" || picked_hit_type == "stomps on")
+	if(picked_hit_type == "kick" || picked_hit_type == "stomp")
 		playsound(get_turf(D), 'sound/weapons/cqchit2.ogg', 50, 1, -1)
 	else
 		playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
-	D.visible_message("<span class='danger'>[A] [picked_hit_type] [D]!</span>", \
-					  "<span class='userdanger'>[A] [picked_hit_type] you!</span>")
-	log_combat(A, D, "[picked_hit_type] (CQC)")
+	D.visible_message("<span class='danger'>[A] [picked_hit_type]ed [D]!</span>", \
+					"<span class='userdanger'>You're [picked_hit_type]ed by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+	to_chat(A, "<span class='danger'>You [picked_hit_type] [D]!</span>")
+	log_combat(A, D, "[picked_hit_type]s (CQC)")
 	if(!CHECK_MOBILITY(A, MOBILITY_STAND) && !D.stat && CHECK_MOBILITY(D, MOBILITY_STAND))
-		D.visible_message("<span class='warning'>[A] leg sweeps [D]!", \
-							"<span class='userdanger'>[A] leg sweeps you!</span>")
+		D.visible_message("<span class='danger'>[A] leg sweeps [D]!", \
+						"<span class='userdanger'>Your legs are sweeped by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", null, A)
+		to_chat(A, "<span class='danger'>You leg sweep [D]!</span>")
 		playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 		D.apply_damage(bonus_damage, BRUTE)
 		D.DefaultCombatKnockdown(60)
@@ -178,8 +187,9 @@
 		A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 		if(damage >= stunthreshold)
 			I = D.get_active_held_item()
-			D.visible_message("<span class='warning'>[A] strikes [D]'s jaw with their hand!</span>", \
-							"<span class='userdanger'>[A] strikes your jaw, disorienting you!</span>")
+			D.visible_message("<span class='danger'>[A] strikes [D]'s jaw with their hand!</span>", \
+							"<span class='userdanger'>Your jaw is struck by [A], you feel disoriented!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+			to_chat(A, "<span class='danger'>You strike [D]'s jaw, leaving [D.p_them()] disoriented!</span>")
 			playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
 			D.drop_all_held_items()
 			D.Jitter(2)
@@ -187,16 +197,24 @@
 			D.apply_damage(damage*2 + 20, STAMINA)
 			D.apply_damage(damage*0.5, BRUTE)
 		else
-			D.visible_message("<span class='danger'>[A] strikes [D] in the chest!</span>", \
-							"<span class='userdanger'>[A] strikes in chest!</span>")
+			D.visible_message("<span class='danger'>[A] strikes [D]'s in the chest with their hand!</span>", \
+							"<span class='userdanger'>Your chest is struck by [A], you let out a gasp!</span>", "<span class='hear'>You hear a thunk!</span>", COMBAT_MESSAGE_RANGE, A)
+			to_chat(A, "<span class='warning'>You strike [D]'s chest, leaving [D.p_them()] gasping!</span>")
 			playsound(D, 'sound/weapons/cqchit1.ogg', 25, 1, -1)
 			D.apply_damage(damage + 15, STAMINA)
 			D.apply_damage(damage*0.5, BRUTE)
 		log_combat(A, D, "disarmed (CQC)", "[I ? " grabbing \the [I]" : ""]")
+		D.visible_message("<span class='danger'>[A] fails to disarm [D]!</span>", \
+			"<span class='userdanger'>You're nearly disarmed by [A]!</span>", "<span class='hear'>You hear a swoosh!</span>", COMBAT_MESSAGE_RANGE, A)
+		to_chat(A, "<span class='warning'>You fail to disarm [D]!</span>")
+		playsound(D, 'sound/weapons/punchmiss.ogg', 25, TRUE, -1)
+	log_combat(A, D, "disarmed (CQC)", "[I ? " grabbing \the [I]" : ""]")
 	if(restraining && A.pulling == D)
 		log_combat(A, D, "knocked out (Chokehold)(CQC)")
 		D.visible_message("<span class='danger'>[A] puts [D] into a chokehold!</span>", \
-							"<span class='userdanger'>[A] puts you into a chokehold!</span>")
+							"<span class='userdanger'>You're put into a chokehold by [A]!</span>", "<span class='hear'>You hear shuffling and a muffled groan!</span>", null, A)
+		to_chat(A, "<span class='danger'>You put [D] into a chokehold!</span>")
+		D.SetSleeping(400)
 		if(D.silent <= 10)
 			D.silent = clamp(D.silent + 10, 0, 10)
 		restraining = FALSE

--- a/code/datums/martial/mushpunch.dm
+++ b/code/datums/martial/mushpunch.dm
@@ -10,9 +10,10 @@
 		to_chat(A, "<span class='spider'><b>Your attack was interrupted!</b></span>")
 		return TRUE //martial art code was a mistake
 	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-	atk_verb = pick("punches", "smashes", "ruptures", "cracks")
-	D.visible_message("<span class='danger'>[A] [atk_verb] [D] with inhuman strength, sending [D.p_them()] flying backwards!</span>", \
-					  "<span class='userdanger'>[A] [atk_verb] you with inhuman strength, sending you flying backwards!</span>")
+	atk_verb = pick("punch", "smash", "crack")
+	D.visible_message("<span class='danger'>[A] [atk_verb]ed [D] with such inhuman strength that it sends [D.p_them()] flying backwards!</span>", \
+					"<span class='userdanger'>You're [atk_verb]ed by [A] with such inhuman strength that it sends you flying backwards!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", null, A)
+	to_chat(A, "<span class='danger'>You [atk_verb] [D] with such inhuman strength that it sends [D.p_them()] flying backwards!</span>")
 	D.apply_damage(damage, BRUTE) //KAPOW
 	playsound(D, 'sound/effects/meteorimpact.ogg', 25, 1, -1)
 	var/throwtarget = get_edge_target_turf(A, get_dir(A, get_step_away(D, A)))

--- a/code/datums/martial/plasma_fist.dm
+++ b/code/datums/martial/plasma_fist.dm
@@ -48,7 +48,8 @@
 /datum/martial_art/plasma_fist/proc/Throwback(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	var/damage = (damage_roll(A,D)*3)
 	D.visible_message("<span class='danger'>[A] has hit [D] with Plasma Punch!</span>", \
-								"<span class='userdanger'>[A] has hit [D] with Plasma Punch!</span>")
+								"<span class='userdanger'>You're hit with a Plasma Punch by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", null, A)
+	to_chat(A, "<span class='danger'>You hit [D] with Plasma Punch!</span>")
 	playsound(D.loc, 'sound/weapons/punch1.ogg', 50, 1, -1)
 	var/atom/throw_target = get_edge_target_turf(D, get_dir(D, get_step_away(D, A)))
 	D.throw_at(throw_target, 200, 4,A)
@@ -62,7 +63,8 @@
 	playsound(D.loc, 'sound/weapons/punch1.ogg', 50, 1, -1)
 	A.say("PLASMA FIST!", forced="plasma fist")
 	D.visible_message("<span class='danger'>[A] has hit [D] with THE PLASMA FIST TECHNIQUE!</span>", \
-								"<span class='userdanger'>[A] has hit [D] with THE PLASMA FIST TECHNIQUE!</span>")
+								"<span class='userdanger'>You're suddenly hit with THE PLASMA FIST TECHNIQUE by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", null, A)
+	to_chat(A, "<span class='danger'>You hit [D] with THE PLASMA FIST TECHNIQUE!</span>")
 	D.gib()
 	log_combat(A, D, "gibbed (Plasma Fist)")
 	return

--- a/code/datums/martial/psychotic_brawl.dm
+++ b/code/datums/martial/psychotic_brawl.dm
@@ -34,16 +34,18 @@
 					if(A.a_intent == INTENT_GRAB)
 						log_combat(A, D, "grabbed", addition="aggressively")
 						D.visible_message("<span class='warning'>[A] violently grabs [D]!</span>", \
-						  "<span class='userdanger'>[A] violently grabs you!</span>")
+						  "<span class='userdanger'>You're violently grabbed by [A]!</span>", "<span class='hear'>You hear sounds of aggressive fondling!</span>", null, A)
+						to_chat(A, "<span class='danger'>You violently grab [D]!</span>")
 						A.setGrabState(GRAB_AGGRESSIVE) //Instant aggressive grab
 					else
 						log_combat(A, D, "grabbed", addition="passively")
 						A.setGrabState(GRAB_PASSIVE)
 		if(4)
 			A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-			atk_verb = "headbutts"
-			D.visible_message("<span class='danger'>[A] [atk_verb] [D]!</span>", \
-					  "<span class='userdanger'>[A] [atk_verb] you!</span>")
+			atk_verb = "headbutt"
+			D.visible_message("<span class='danger'>[A] [atk_verb]s [D]!</span>", \
+							"<span class='userdanger'>You're [atk_verb]ed by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", null, A)
+			to_chat(A, "<span class='danger'>You [atk_verb] [D]!</span>")
 			playsound(get_turf(D), 'sound/weapons/punch1.ogg', 40, 1, -1)
 			D.apply_damage(damage*1.5, BRUTE, BODY_ZONE_HEAD)
 			A.apply_damage(damage, BRUTE, BODY_ZONE_HEAD)
@@ -53,9 +55,10 @@
 			D.DefaultCombatKnockdown(rand(5,30))//CIT CHANGE - makes stuns from martial arts always use Knockdown instead of Stun for the sake of consistency
 		if(5,6)
 			A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-			atk_verb = pick("punches", "kicks", "hits", "slams into")
-			D.visible_message("<span class='danger'>[A] [atk_verb] [D] with inhuman strength, sending [D.p_them()] flying backwards!</span>", \
-							  "<span class='userdanger'>[A] [atk_verb] you with inhuman strength, sending you flying backwards!</span>")
+			atk_verb = pick("kick", "hit", "slam")
+			D.visible_message("<span class='danger'>[A] [atk_verb]s [D] with such inhuman strength that it sends [D.p_them()] flying backwards!</span>", \
+							"<span class='userdanger'>You're [atk_verb]ed by [A] with such inhuman strength that it sends you flying backwards!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", null, A)
+			to_chat(A, "<span class='danger'>You [atk_verb] [D] with such inhuman strength that it sends [D.p_them()] flying backwards!</span>")
 			D.apply_damage(damage*2, BRUTE)
 			playsound(get_turf(D), 'sound/effects/meteorimpact.ogg', 25, 1, -1)
 			var/throwtarget = get_edge_target_turf(A, get_dir(A, get_step_away(D, A)))

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -216,7 +216,8 @@
 	slot_flags = ITEM_SLOT_BACK
 	throwforce = 20
 	throw_speed = 2
-	attack_verb = list("smashed", "slammed", "whacked", "thwacked")
+	attack_verb_continuous = list("smashes", "slams", "whacks", "thwacks")
+	attack_verb_simple = list("smash", "slam", "whack", "thwack")
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "bostaff0"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -109,8 +109,11 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	var/breakouttime = 0
 	var/reskinned = FALSE
 
-	var/list/attack_verb //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
-	var/list/species_exception = null	// list() of species types, if a species cannot put items in a certain slot, but species type is in list, it will be able to wear that item
+//Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
+	var/list/attack_verb_continuous
+	var/list/attack_verb_simple
+// list() of species types, if a species cannot put items in a certain slot, but species type is in list, it will be able to wear that item
+	var/list/species_exception = null
 
 	var/mob/thrownby = null
 
@@ -180,8 +183,10 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 /obj/item/Initialize(mapload)
 
-	if(attack_verb)
-		attack_verb = typelist("attack_verb", attack_verb)
+	if(attack_verb_continuous)
+		attack_verb_continuous = typelist("attack_verb_continuous", attack_verb_continuous)
+	if(attack_verb_simple)
+		attack_verb_simple = typelist("attack_verb_simple", attack_verb_simple)
 
 	. = ..()
 	for(var/path in actions_types)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -7,7 +7,8 @@
 	name = "area modification item"
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "blueprints"
-	attack_verb = list("attacked", "bapped", "hit")
+	attack_verb_continuous = list("attacks", "baps", "hits")
+	attack_verb_simple = list("attack", "bap", "hit")
 	var/fluffnotice = "Nobody's gonna read this stuff!"
 	var/in_use = FALSE
 

--- a/code/game/objects/items/broom.dm
+++ b/code/game/objects/items/broom.dm
@@ -10,7 +10,8 @@
 	throw_speed = 3
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("swept", "brushed off", "bludgeoned", "whacked")
+	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
+	attack_verb_simple = list("saw", "tear", "lacerate", "cut", "chop", "dice")
 	resistance_flags = FLAMMABLE
 
 /obj/item/broom/Initialize(mapload)

--- a/code/game/objects/items/chainsaw.dm
+++ b/code/game/objects/items/chainsaw.dm
@@ -14,7 +14,8 @@
 	throw_speed = 2
 	throw_range = 4
 	custom_materials = list(/datum/material/iron=13000)
-	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
+	attack_verb_continuous = list("burns", "sings")
+	attack_verb_simple = list("burn", "sing")
 	hitsound = "swing_hit"
 	sharpness = SHARP_EDGED
 	actions_types = list(/datum/action/item_action/startchainsaw)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -50,7 +50,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		item_state = "cigon"
 		name = "lit match"
 		desc = "A match. This one is lit."
-		attack_verb = list("burnt","singed")
+		attack_verb_continuous = list("burns", "sings")
+		attack_verb_simple = list("burn", "sing")
 		START_PROCESSING(SSobj, src)
 		update_icon()
 
@@ -64,7 +65,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		item_state = "cigoff"
 		name = "burnt match"
 		desc = "A match. This one has seen better days."
-		attack_verb = list("flicked")
+		attack_verb_continuous = list("flicks")
+		attack_verb_simple = list("flick")
 		STOP_PROCESSING(SSobj, src)
 
 /obj/item/match/dropped(mob/user)
@@ -173,7 +175,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	lit = TRUE
 	name = "lit [name]"
-	attack_verb = list("burnt", "singed")
+	attack_verb_continuous = list("burns", "sings")
+	attack_verb_simple = list("burn", "sing")
 	hitsound = 'sound/items/welder.ogg'
 	damtype = "fire"
 	force = 4
@@ -568,13 +571,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		force = 5
 		damtype = "fire"
 		hitsound = 'sound/items/welder.ogg'
-		attack_verb = list("burnt", "singed")
+		attack_verb_continuous = list("burns", "sings")
+		attack_verb_simple = list("burn", "sing")
 		set_light(2, 0.6, LIGHT_COLOR_FIRE)
 		START_PROCESSING(SSobj, src)
 	else
 		hitsound = "swing_hit"
 		force = 0
-		attack_verb = null //human_defense.dm takes care of it
+		attack_verb_continuous = null
+		attack_verb_simple = null
 		set_light(0)
 		STOP_PROCESSING(SSobj, src)
 	update_icon()

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -112,7 +112,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3
 	throw_range = 7
-	attack_verb = list("HONKED")
+	attack_verb_continuous = list("HONKS")
+	attack_verb_simple = list("HONK")
 	var/moodlet = "honk" //used to define which kind of moodlet is added to the honked target
 	var/list/honksounds = list('sound/items/bikehorn.ogg' = 1)
 
@@ -167,13 +168,15 @@
 /obj/item/bikehorn/silver
 	name = "silver bike horn"
 	desc = "A shiny bike horn handcrafted in the artisan workshops of Mars, with superior kevlar-reinforced rubber bulb attached to a polished plasteel reed horn."
-	attack_verb = list("elegantly HONKED")
+	attack_verb_continuous = list("elegantly HONKS")
+	attack_verb_simple = list("elegantly HONK")
 	icon_state = "silverhorn"
 
 /obj/item/bikehorn/bluespacehonker
 	name = "bluespace bike horn"
 	desc = "A normal bike horn colored blue and has bluespace dust held in to reed horn allowing for silly honks through space and time, into your in childhood."
-	attack_verb = list("HONKED in bluespace", "HONKED", "quantumly HONKED")
+	attack_verb_continuous = list("HONKS in bluespace", "HONKS", "quantumly HONKS")
+	attack_verb_simple = list("HONKED in bluespace", "HONKED", "quantumly HONKED")
 	icon_state = "bluespacehonker"
 	moodlet = "bshonk"
 

--- a/code/game/objects/items/courtroom.dm
+++ b/code/game/objects/items/courtroom.dm
@@ -10,7 +10,8 @@
 	force = 5
 	throwforce = 6
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("bashed", "battered", "judged", "whacked")
+	attack_verb_continuous = list("bashes", "batters", "judges", "whacks")
+	attack_verb_simple = list("bash", "batter", "judge", "whack")
 	resistance_flags = FLAMMABLE
 
 /obj/item/gavelhammer/suicide_act(mob/user)

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -4,7 +4,8 @@
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "suspiciousphone"
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("dumped")
+	attack_verb_continuous = list("dumps")
+	attack_verb_simple = list("dump")
 	var/dumped = FALSE
 
 /obj/item/suspiciousphone/attack_self(mob/user)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -28,7 +28,8 @@
 
 	var/crayon_color = "red"
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("attacked", "coloured")
+	attack_verb_continuous = list("attacks", "colours")
+	attack_verb_simple = list("attack", "colour")
 	grind_results = list()
 	var/paint_color = "#FF0000" //RGB
 

--- a/code/game/objects/items/devices/doorCharge.dm
+++ b/code/game/objects/items/devices/doorCharge.dm
@@ -11,7 +11,8 @@
 	throw_speed = 1
 	item_flags = NOBLUDGEON
 	force = 3
-	attack_verb = list("blown up", "exploded", "detonated")
+	attack_verb_continuous = list("blows up", "explodes", "detonates")
+	attack_verb_simple = list("blown up", "exploded", "detonated")
 	custom_materials = list(/datum/material/iron=50, /datum/material/glass=30)
 
 /obj/item/doorCharge/ex_act(severity, target, origin)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -198,7 +198,8 @@ effective or pretty fucking useless.
 	icon_state = "utilitybelt"
 	item_state = "utility"
 	slot_flags = ITEM_SLOT_BELT
-	attack_verb = list("whipped", "lashed", "disciplined")
+	attack_verb_continuous = list("whips", "lashes", "disciplines")
+	attack_verb_simple = list("whip", "lash", "discipline")
 
 	var/mob/living/carbon/human/user = null
 	var/charge = 300

--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -19,7 +19,8 @@
 	armour_penetration = 35
 	var/saber_color = "green"
 	light_color = "#00ff00"//green
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	max_integrity = 200
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 70)
 	resistance_flags = FIRE_PROOF
@@ -282,7 +283,8 @@
 	armour_penetration = 60
 	light_color = "#37FFF7"
 	rainbow_colors = list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF","#FF00FF", "#3399ff", "#ff9900", "#fb008b", "#9800ff", "#00ffa3", "#ccff00")
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "destroyed", "ripped", "devastated", "shredded")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	spinnable = FALSE
 	total_mass_on = 4
 	slowdown_wielded = 1

--- a/code/game/objects/items/electrostaff.dm
+++ b/code/game/objects/items/electrostaff.dm
@@ -12,7 +12,8 @@
 	throwforce = 15			//if you are a madman and finish someone off with this, power to you.
 	throw_speed = 1
 	item_flags = NO_MAT_REDEMPTION
-	attack_verb = list("struck", "beaten", "thwacked", "pulped")
+	attack_verb_continuous = list("strucks", "beats", "thwacks", "pulps")
+	attack_verb_simple = list("struck", "beat", "thwack", "pulp")
 	total_mass = 5		//yeah this is a heavy thing, beating people with it while it's off is not going to do you any favors. (to curb stun-kill rampaging without it being on)
 	block_parry_data = /datum/block_parry_data/electrostaff
 	attack_speed = CLICK_CD_MELEE

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -12,7 +12,8 @@
 	throw_range = 7
 	force = 10
 	custom_materials = list(/datum/material/iron = 90)
-	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
+	attack_verb_continuous = list("slams", "whacks", "bashes", "thunks", "batters", "bludgeons", "thrashes")
+	attack_verb_simple = list("slam", "whack", "bash", "thunk", "batter", "bludgeon", "thrash")
 	dog_fashion = /datum/dog_fashion/back
 	resistance_flags = FIRE_PROOF
 	var/max_water = 50

--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -11,7 +11,8 @@
 	throwforce = 15
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
-	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
+	attack_verb_continuous = list("attacks", "chops", "cleaves", "tears", "lacerates", "cuts")
+	attack_verb_simple = list("attack", "chop", "cleave", "tear", "lacerate", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
 	max_integrity = 200

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -15,7 +15,8 @@
 	w_class = WEIGHT_CLASS_GIGANTIC
 	force = 12
 	total_mass = TOTAL_MASS_NORMAL_ITEM // average toolbox
-	attack_verb = list("robusted")
+	attack_verb_continuous = list("robusts")
+	attack_verb_simple = list("robust")
 	hitsound = 'sound/weapons/smash.ogg'
 	drop_sound = 'sound/items/handling/toolbox_drop.ogg'
 	pickup_sound = 'sound/items/handling/toolbox_pickup.ogg'

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -311,7 +311,8 @@
 	w_class = WEIGHT_CLASS_HUGE
 	hitsound = 'sound/weapons/sear.ogg'
 	damtype = BURN
-	attack_verb = list("punched", "cross countered", "pummeled")
+	attack_verb_continuous = list("punches", "cross counters", "pummels")
+	attack_verb_simple = list("punch", "cross counter", "pummel")
 	total_mass = TOTAL_MASS_HAND_REPLACEMENT
 
 /obj/item/nullrod/godhand/Initialize(mapload)
@@ -354,7 +355,8 @@
 	block_chance = 30
 	sharpness = SHARP_EDGED
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 
 /obj/item/nullrod/claymore/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
 	if(attack_type & ATTACK_TYPE_PROJECTILE) // Don't bring a sword to a gunfight
@@ -379,7 +381,8 @@
 	name = "sacred chainsaw sword"
 	desc = "Suffer not a heretic to live."
 	slot_flags = ITEM_SLOT_BELT
-	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
+	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
+	attack_verb_simple = list("saw", "tear", "lacerate", "cut", "chop", "dice")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	tool_behaviour = TOOL_SAW
 	toolspeed = 1.5 //slower than a real saw
@@ -440,7 +443,8 @@
 	force = 4.13
 	throwforce = 1
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 
 /obj/item/nullrod/scythe
 	icon_state = "scythe1"
@@ -453,7 +457,8 @@
 	armour_penetration = 35
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_EDGED
-	attack_verb = list("chopped", "sliced", "cut", "reaped")
+	attack_verb_continuous = list("chops", "slices", "cuts", "reaps")
+	attack_verb_simple = list("chop", "slice", "cut", "reap")
 
 /obj/item/nullrod/scythe/Initialize(mapload)
 	. = ..()
@@ -466,7 +471,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	name = "high frequency blade"
 	desc = "Bad references are the DNA of the soul."
-	attack_verb = list("chopped", "sliced", "cut", "zandatsu'd")
+	attack_verb_continuous = list("chops", "slices", "cuts", "zandatsu's")
+	attack_verb_simple = list("chop", "slice", "cut", "zandatsu")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 
 
@@ -487,7 +493,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	name = "possessed blade"
 	desc = "When the station falls into chaos, it's nice to have a friend by your side."
-	attack_verb = list("chopped", "sliced", "cut")
+	attack_verb_continuous = list("chops", "slices", "cuts")
+	attack_verb_simple= list("chop", "slice", "cut")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	var/possessed = FALSE
 
@@ -550,7 +557,8 @@
 	chaplain_spawnable = FALSE
 	force = 30
 	slot_flags = ITEM_SLOT_BELT
-	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
+	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
+	attack_verb_simple = list("saw", "tear", "lacerate", "cut", "chop", "dice")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	tool_behaviour = TOOL_SAW
 	toolspeed = 0.5
@@ -564,7 +572,8 @@
 	desc = "This war hammer cost the chaplain forty thousand space dollars."
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_HUGE
-	attack_verb = list("smashed", "bashed", "hammered", "crunched")
+	attack_verb_continuous = list("smashes", "bashes", "hammers", "crunches")
+	attack_verb_simple = list("smash", "bash", "hammer", "crunch")
 
 /obj/item/nullrod/chainsaw
 	name = "chainsaw hand"
@@ -576,7 +585,8 @@
 	w_class = WEIGHT_CLASS_HUGE
 	item_flags = ABSTRACT
 	sharpness = SHARP_EDGED
-	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
+	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
+	attack_verb_simple = list("saw", "tear", "lacerate", "cut", "chop", "dice")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	total_mass = TOTAL_MASS_HAND_REPLACEMENT
 	tool_behaviour = TOOL_SAW
@@ -595,7 +605,8 @@
 	desc = "Used for absolutely hilarious sacrifices."
 	hitsound = 'sound/items/bikehorn.ogg'
 	sharpness = SHARP_EDGED
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 
 /obj/item/nullrod/pride_hammer
 	icon_state = "pride"
@@ -608,7 +619,8 @@
 	throwforce = 15
 	w_class = 4
 	slot_flags = ITEM_SLOT_BACK
-	attack_verb = list("attacked", "smashed", "crushed", "splattered", "cracked")
+	attack_verb_continuous = list("attacks", "smashes", "crushes", "splatters", "cracks")
+	attack_verb_simple = list("attack", "smash", "crush", "splatter", "crack")
 	hitsound = 'sound/weapons/resonator_blast.ogg'
 
 /obj/item/nullrod/pride_hammer/afterattack(atom/A as mob|obj|turf|area, mob/user, proximity)
@@ -631,7 +643,8 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 12
 	reach = 2
-	attack_verb = list("whipped", "lashed")
+	attack_verb_continuous = list("whips", "lashes")
+	attack_verb_simple = list("whip", "lash")
 	hitsound = 'sound/weapons/chainhit.ogg'
 
 /obj/item/nullrod/fedora
@@ -646,7 +659,8 @@
 	throw_range = 7
 	throwforce = 30
 	sharpness = SHARP_EDGED
-	attack_verb = list("enlightened", "redpilled")
+	attack_verb_continuous = list("enlightens", "redpills")
+	attack_verb_simple = list("enlighten", "redpill")
 
 /obj/item/nullrod/armblade
 	name = "dark blessing"
@@ -681,7 +695,8 @@
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	force = 15
-	attack_verb = list("bitten", "eaten", "fin slapped")
+	attack_verb_continuous = list("bites", "eats", "fin slaps")
+	attack_verb_simple = list("bite", "eat", "fin slap")
 	hitsound = 'sound/weapons/bite.ogg'
 	var/used_blessing = FALSE
 
@@ -701,7 +716,8 @@
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_NONE
 	hitsound = "swing_hit"
-	attack_verb = list("smashed", "slammed", "whacked", "thwacked")
+	attack_verb_continuous = list("smashes", "slams", "whacks", "thwacks")
+	attack_verb_simple = list("smash", "slam", "whack", "thwack")
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "bostaff0"
 	item_state = "bostaff0"
@@ -757,7 +773,8 @@
 	sharpness = SHARP_EDGED
 	slot_flags = null
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	item_flags = SLOWS_WHILE_IN_HAND
 
 /obj/item/nullrod/tribal_knife/Initialize(mapload)
@@ -804,7 +821,8 @@
 	name = "unholy pitchfork"
 	w_class = WEIGHT_CLASS_NORMAL
 	desc = "Holding this makes you look absolutely devilish."
-	attack_verb = list("poked", "impaled", "pierced", "jabbed")
+	attack_verb_continuous = list("pokes", "impales", "pierces", "jabs")
+	attack_verb_simple = list("poke", "impale", "pierce", "jab")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
 
@@ -817,7 +835,8 @@
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("bashes", "smacks", "whacks")
+	attack_verb_continuous = list("bashes", "smacks", "whacks")
+	attack_verb_simple = list("bash", "smack", "whack")
 
 /obj/item/nullrod/rosary
 	icon_state = "rosary"
@@ -826,7 +845,8 @@
 	desc = "A set of prayer beads used by many of the more traditional religions in space"
 	force = 4
 	throwforce = 0
-	attack_verb = list("whipped", "repented", "lashed", "flagellated")
+	attack_verb_continuous = list("whips", "repents", "lashs", "flagellates")
+	attack_verb_continuous = list("whip", "repente", "lash", "flagellate")
 	//skyrat edit - wowie the first wrist slot item
 	slot_flags = ITEM_SLOT_WRISTS | ITEM_SLOT_BELT
 	//

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -25,7 +25,8 @@
 	throw_range = 5
 	custom_materials = list(/datum/material/iron=80)
 	flags_1 = CONDUCT_1
-	attack_verb = list("attacked", "stabbed", "poked")
+	attack_verb_continuous = list("attacks", "stabs", "pokes")
+	attack_verb_simple = list("attack", "stab", "poke")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 30)
 	sharpness = SHARP_POINTY
@@ -76,7 +77,8 @@
 	throw_speed = 3
 	throw_range = 6
 	custom_materials = list(/datum/material/iron=12000)
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_POINTY
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 	var/bayonet = FALSE	//Can this be attached to a gun?
@@ -112,7 +114,8 @@
 	throw_speed = 3
 	throw_range = 6
 	custom_materials = list(/datum/material/iron=12000)
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_POINTY
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 	var/bayonet = FALSE	//Can this be attached to a gun?
@@ -176,7 +179,8 @@
 	force = 15
 	throwforce = 10
 	custom_materials = list(/datum/material/iron=18000)
-	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("cleaves", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("cleave", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_price = PRICE_EXPENSIVE
 
@@ -188,7 +192,8 @@
 	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE)
 	force = 16
 	throwforce = 16
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "cut")
+	attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "cuts")
+	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "cut")
 	bayonet = TRUE
 
 /obj/item/kitchen/knife/combat/survival
@@ -265,7 +270,8 @@
 	desc = "A makeshift glass shiv."
 	force = 8
 	throwforce = 12//fuck git
-	attack_verb = list("shanked", "shivved")
+	attack_verb_continuous = list("shanks", "shivs")
+	attack_verb_simple = list("shank", "shiv")
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
 	custom_materials = list(/datum/material/glass=400)
 
@@ -291,7 +297,8 @@
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 1.5)
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
+	attack_verb_continuous = list("bashes", "batters", "bludgeons", "thrashes", "whacks")
+	attack_verb_simple = list("bash", "batter", "bludgeon", "thrash", "whack")
 	custom_price = PRICE_ALMOST_CHEAP
 
 /obj/item/kitchen/rollingpin/suicide_act(mob/living/carbon/user)
@@ -308,7 +315,8 @@
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 1.5)
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
+	attack_verb_continuous = list("bashes", "batters", "bludgeons", "thrashes", "whacks")
+	attack_verb_simple = list("bash", "batter", "bludgeon", "thrash", "whack")
 	custom_price = PRICE_ALMOST_CHEAP
 
 /obj/item/kitchen/unrollingpin/suicide_act(mob/living/carbon/user)
@@ -320,7 +328,8 @@
 /obj/item/kitchen/knife/scimitar
 	name = "scimitar knife"
 	desc = "A knife used to cleanly butcher. Its razor-sharp edge has been honed for butchering, but has been poorly maintained over the years."
-	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("cleaves", "slashes", "stabbes", "slices", "tore", "rips", "dices", "cuts")
+	attack_verb_simple = list("cleave", "slash", "stab", "slice", "torn", "rip", "dice", "cut")
 
 /obj/item/kitchen/knife/scimitar/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -81,7 +81,7 @@
 	w_class_on = WEIGHT_CLASS_HUGE
 	flags_1 = CONDUCT_1
 	armour_penetration = 100
-	attack_verb_off = list("attacked", "chopped", "cleaved", "torn", "cut")
+	attack_verb_off = list("attacks", "chops", "cleaves", "tears", "lacerates", "cuts")
 	attack_verb_on = list()
 	light_color = "#40ceff"
 	total_mass = null
@@ -99,7 +99,7 @@
 	force = 3
 	throwforce = 5
 	hitsound = "swing_hit" //it starts deactivated
-	attack_verb_off = list("tapped", "poked")
+	attack_verb_off = list("taps", "pokes")
 	throw_speed = 3
 	throw_range = 5
 	sharpness = SHARP_EDGED

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -22,7 +22,8 @@
 	bare_wound_bonus = 10
 	reach = 2
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
+	attack_verb_continuous = list("flogs", "whips", "lashs", "disciplines")
+	attack_verb_simple = list("flog", "whip", "lash", "discipline")
 	hitsound = 'sound/weapons/chainhit.ogg'
 	custom_materials = list(/datum/material/iron = 1000)
 
@@ -42,7 +43,8 @@
 	force = 20
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "impaled", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
 	total_mass = TOTAL_MASS_HAND_REPLACEMENT
 
@@ -64,7 +66,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	armour_penetration = 75
 	sharpness = SHARP_EDGED
-	attack_verb = list("slashed", "cut")
+	attack_verb_continuous = list("slashes", "cuts")
+	attack_verb_simple = list("slash", "cut")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	custom_materials = list(/datum/material/iron = 1000)
 	total_mass = 3.4
@@ -170,7 +173,8 @@
 	obj_flags = UNIQUE_RENAME
 	w_class = WEIGHT_CLASS_BULKY
 	sharpness = SHARP_POINTY //It cant be sharpend cook -_-
-	attack_verb = list("stabs", "punctures", "pierces", "pokes")
+	attack_verb_continuous = list("slashes", "stings", "prickles", "pokes")
+	attack_verb_simple = list("slash", "sting", "prickle", "poke")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	total_mass = 0.4
 	item_flags = ITEM_CAN_PARRY | NEEDS_PERMIT
@@ -439,7 +443,8 @@
 		item_state = on_item_state
 		w_class = weight_class_on
 		force = force_on
-		attack_verb = list("smacked", "struck", "cracked", "beaten")
+		attack_verb_continuous = list("smacks", "strikes", "cracks", "beats")
+		attack_verb_simple = list("smack", "strike", "crack", "beat")
 		AddElement(/datum/element/sword_point)
 		if(!silent)
 			user?.visible_message("<span class='warning'>[user] extends [src] with a flick of their wrist!</span>")
@@ -450,7 +455,8 @@
 		slot_flags = ITEM_SLOT_BELT
 		w_class = WEIGHT_CLASS_SMALL
 		force = force_off
-		attack_verb = list("hit", "poked")
+		attack_verb_continuous = list("hits", "pokes")
+		attack_verb_simple = list("hit", "poke")
 		RemoveElement(/datum/element/sword_point)
 		if(!silent)
 			user?.visible_message("<span class='warning'>[user] collapses [src] back down!</span>")
@@ -599,7 +605,8 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 15
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
+	attack_verb_continuous = list("flogs", "whips", "lashes", "disciplines")
+	attack_verb_simple = list("flog", "whip", "lash", "discipline")
 	hitsound = 'sound/weapons/whip.ogg'
 
 /obj/item/melee/curator_whip/afterattack(target, mob/user, proximity_flag)
@@ -618,7 +625,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NONE
 	force = 0
-	attack_verb = list("hit", "poked")
+	attack_verb_continuous = list("hits", "pokes")
+	attack_verb_simple = list("hit", "poke")
 	var/obj/item/reagent_containers/food/snacks/sausage/held_sausage
 	var/static/list/ovens
 	var/on = FALSE
@@ -737,7 +745,8 @@
 	throwforce = 8
 	block_chance = 10
 	armour_penetration = 50
-	attack_verb = list("smacked", "struck", "cracked", "beaten")
+	attack_verb_continuous = list("smacks", "strikes", "cracks", "beats")
+	attack_verb_simple = list("smack", "strike", "crack", "beat")
 	var/overlay_state = "mace_handle"
 	var/mutable_appearance/overlay
 

--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -6,8 +6,8 @@
 	var/throwforce_on = 20
 	var/icon_state_on = "axe1"
 	var/hitsound_on = 'sound/weapons/blade1.ogg'
-	var/list/attack_verb_on = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	var/list/attack_verb_off = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	var/list/attack_verb_on = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	var/list/attack_verb_off = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	w_class = WEIGHT_CLASS_SMALL
 	var/bonus_active = FALSE //If the faction damage bonus is active
 	var/list/nemesis_factions //Any mob with a faction that exists in this list will take bonus damage/effects
@@ -15,14 +15,16 @@
 	var/clumsy_check = TRUE
 	var/total_mass_on //Total mass in ounces when transformed. Primarily for balance purposes. Don't think about it too hard.
 
-/obj/item/melee/transforming/Initialize(mapload)
+/obj/item/melee/transforming/Initialize()
 	. = ..()
 	if(active)
 		if(attack_verb_on.len)
-			attack_verb = attack_verb_on
+			attack_verb_continuous = attack_verb_on
 	else
 		if(attack_verb_off.len)
-			attack_verb = attack_verb_off
+			attack_verb_continuous = attack_verb_off
+		if(embedding)
+			updateEmbedding()
 	if(sharpness)
 		AddComponent(/datum/component/butchering, 50, 100, 0, hitsound)
 
@@ -52,7 +54,7 @@
 		hitsound = hitsound_on
 		throw_speed = 4
 		if(attack_verb_on.len)
-			attack_verb = attack_verb_on
+			attack_verb_continuous = attack_verb_on
 		if(embedding)
 			updateEmbedding()
 		icon_state = icon_state_on
@@ -63,7 +65,7 @@
 		hitsound = initial(hitsound)
 		throw_speed = initial(throw_speed)
 		if(attack_verb_off.len)
-			attack_verb = attack_verb_off
+			attack_verb_continuous = attack_verb_off
 		if(embedding)
 			updateEmbedding()
 		icon_state = initial(icon_state)

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -258,4 +258,5 @@
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "skub"
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("skubbed")
+	attack_verb_continuous = list("skubs")
+	attack_verb_simple = list("skub")

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -10,7 +10,8 @@
 	throw_speed = 3
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("mopped", "bashed", "bludgeoned", "whacked")
+	attack_verb_continuous = list("mops", "bashes", "bludgeons", "whacks")
+	attack_verb_simple = list("mop", "bash", "bludgeon", "whack")
 	resistance_flags = FLAMMABLE
 	var/mopping = 0
 	var/mopcount = 0

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -11,7 +11,8 @@
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	force = 5
-	attack_verb = list("bashed", "carried")
+	attack_verb_continuous = list("bashes", "carries")
+	attack_verb_simple = list("bash", "carry")
 	w_class = WEIGHT_CLASS_BULKY
 	throw_speed = 2
 	throw_range = 3

--- a/code/game/objects/items/pitchfork.dm
+++ b/code/game/objects/items/pitchfork.dm
@@ -7,7 +7,8 @@
 	force = 7
 	throwforce = 15
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("attacked", "impaled", "pierced")
+	attack_verb_continuous = list("attacks", "impales", "pierces")
+	attack_verb_simple = list("attack", "impale", "pierce")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
 	max_integrity = 200

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -3,7 +3,8 @@
 	desc = "This is the special coder plush, do not steal."
 	icon = 'icons/obj/plushes.dmi'
 	icon_state = "debug"
-	attack_verb = list("thumped", "whomped", "bumped")
+	attack_verb_continuous = list("thumps", "whomps", "bumps")
+	attack_verb_simple = list("thump", "whomp", "bump")
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE
 	var/list/squeak_override //Weighted list; If you want your plush to have different squeak sounds use this
@@ -147,7 +148,7 @@
 			item_state = P.item_state
 			icon = P.icon
 			squeak_override = P.squeak_override
-			attack_verb = P.attack_verb
+			attack_verb_continuous = P.attack_verb_continuous
 			gender = P.gender
 			qdel(P)
 	if(jsonlist["name"])
@@ -162,7 +163,7 @@
 		var/static/config_sprites = file("config/plushies/sprites.dmi")
 		icon = config_sprites
 	if(jsonlist["attack_verb"])
-		attack_verb = jsonlist["attack_verb"]
+		attack_verb_continuous = jsonlist["attack_verb"]
 	if(jsonlist["squeak_override"])
 		squeak_override = jsonlist["squeak_override"]
 	if(squeak_override)
@@ -485,14 +486,16 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "An adorable stuffed toy that resembles a space carp."
 	icon_state = "carpplush"
 	item_state = "carp_plushie"
-	attack_verb = list("bitten", "eaten", "fin slapped")
+	attack_verb_continuous = list("bites", "eats", "fin slaps")
+	attack_verb_simple = list("bite", "eat", "fin slap")
 	squeak_override = list('sound/weapons/bite.ogg'=1)
 
 /obj/item/toy/plush/bubbleplush
 	name = "bubblegum plushie"
 	desc = "The friendly red demon that gives good miners gifts."
 	icon_state = "bubbleplush"
-	attack_verb = list("rends")
+	attack_verb_continuous = list("rents")
+	attack_verb_simple = list("rent")
 	squeak_override = list('sound/magic/demon_attack1.ogg'=1)
 
 /obj/item/toy/plush/plushvar
@@ -604,7 +607,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "An adorable stuffed toy that resembles a lizardperson."
 	icon_state = "plushie_lizard"
 	item_state = "plushie_lizard"
-	attack_verb = list("clawed", "hissed", "tail slapped")
+	attack_verb_continuous = list("claws", "hisses", "tail slaps")
+	attack_verb_simple = list("claw", "hiss", "tail slap")
 	squeak_override = list('sound/weapons/slash.ogg' = 1)
 
 /obj/item/toy/plush/lizardplushie/kobold
@@ -624,7 +628,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "A stuffed toy that resembles a syndicate nuclear operative. The tag claims operatives to be purely fictitious."
 	icon_state = "plushie_nuke"
 	item_state = "plushie_nuke"
-	attack_verb = list("shot", "nuked", "detonated")
+	attack_verb_continuous = list("shoots", "nukes", "detonates")
+	attack_verb_simple = list("shoot", "nuke", "detonate")
 	squeak_override = list('sound/effects/hit_punch.ogg' = 1)
 
 /obj/item/toy/plush/slimeplushie
@@ -632,7 +637,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "An adorable stuffed toy that resembles a slime. It is practically just a hacky sack."
 	icon_state = "plushie_slime"
 	item_state = "plushie_slime"
-	attack_verb = list("blorbled", "slimed", "absorbed", "glomped")
+	attack_verb_continuous = list("blorbles", "slimes", "absorbs")
+	attack_verb_simple = list("blorble", "slime", "absorb")
 	squeak_override = list('sound/effects/blobattack.ogg' = 1)
 	gender = FEMALE	//given all the jokes and drawings, I'm not sure the xenobiologists would make a slimeboy
 
@@ -652,7 +658,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "A cute toy that resembles an even cuter bee."
 	icon_state = "plushie_bee"
 	item_state = "plushie_bee"
-	attack_verb = list("stung")
+	attack_verb_continuous = list("stings")
+	attack_verb_simple = list("sting")
 	gender = FEMALE
 	squeak_override = list('modular_citadel/sound/voice/scream_moth.ogg' = 1)
 
@@ -669,7 +676,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "A toy lamp plushie, doesn't actually make light, but it still toggles on and off. Click clack!"
 	icon_state = "plushie_lamp"
 	item_state = "plushie_lamp"
-	attack_verb = list("lit", "flickered", "flashed")
+	attack_verb_continuous = list("lit", "flickers", "flashs")
+	attack_verb_simple = list("lit", "flicker", "flash")
 	squeak_override = list('sound/weapons/magout.ogg' = 1)
 
 /obj/item/toy/plush/drake
@@ -677,49 +685,56 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "A large beast from lavaland turned into a marketable plushie!"
 	icon_state = "drake"
 	item_state = "drake"
-	attack_verb = list("bit", "devoured", "burned")
+	attack_verb_continuous = list("bits", "devoures", "burns")
+	attack_verb_simple = list("bit", "devour", "burn")
 
 /obj/item/toy/plush/deer
 	name = "deer plushie"
 	desc = "Oh deer, a plushie!"
 	icon_state = "deer"
 	item_state = "deer"
-	attack_verb = list("bleated", "rammed", "kicked")
+	attack_verb_continuous = list("bleats", "rams", "kicks")
+	attack_verb_simple = list("bleat", "ram", "kick")
 
 /obj/item/toy/plush/box
 	name = "cardboard plushie"
 	desc = "A toy box plushie, it holds cotten. Only a baddie would place a bomb through the postal system..."
 	icon_state = "box"
 	item_state = "box"
-	attack_verb = list("open", "closed", "packed", "hidden", "rigged", "bombed", "sent", "gave")
+	attack_verb_continuous = list("opens", "closes", "packs", "hidden", "rigged", "bombed", "sent", "gave")
+	attack_verb_simple = list("open", "close", "pack", "hid", "rig", "bomb", "sent", "gave")
 
 /obj/item/toy/plush/slaggy
 	name = "slag plushie"
 	desc = "A piece of slag with some googly eyes and a drawn on mouth."
 	icon_state = "slaggy"
 	item_state = "slaggy"
-	attack_verb = list("melted", "refined", "stared")
+	attack_verb_continuous = list("melts", "refines", "stares")
+	attack_verb_simple = list("melt", "refine", "stare")
 
 /obj/item/toy/plush/mr_buckety
 	name = "bucket plushie"
 	desc = "A bucket that is missing its handle with some googly eyes and a drawn on mouth."
 	icon_state = "mr_buckety"
 	item_state = "mr_buckety"
-	attack_verb = list("filled", "dumped", "stared")
+	attack_verb_continuous = list("fills", "dumps", "stares")
+	attack_verb_simple = list("fill", "dump", "stare")
 
 /obj/item/toy/plush/dr_scanny
 	name = "scanner plushie"
 	desc = "A old outdated scanner that has been modified to have googly eyes, a dawn on mouth and, heart."
 	icon_state = "dr_scanny"
 	item_state = "dr_scanny"
-	attack_verb = list("scanned", "beeped", "stared")
+	attack_verb_continuous = list("scans", "beeps", "stares")
+	attack_verb_simple = list("scan", "beep", "stare")
 
 /obj/item/toy/plush/borgplushie
 	name = "K9 plushie"
 	desc = "An adorable stuffed toy of a robot."
 	icon_state = "securityk9"
 	item_state = "securityk9"
-	attack_verb = list("beeped", "booped", "pinged")
+	attack_verb_continuous = list("beeps", "boops", "pings")
+	attack_verb_simple = list("beep", "boop", "ping")
 	squeak_override = list('sound/machines/beep.ogg' = 1)
 
 /obj/item/toy/plush/borgplushie/medihound
@@ -742,7 +757,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "A little stuffed toy AI core... it appears to be malfunctioning."
 	icon_state = "malfai"
 	item_state = "malfai"
-	attack_verb = list("hacked", "detonated", "overloaded")
+	attack_verb_continuous = list("hacks", "detonates", "overloads")
+	attack_verb_simple = list("hack", "detonate", "overload")
 	squeak_override = list('sound/machines/beep.ogg' = 9, 'sound/machines/buzz-two.ogg' = 1)
 
 /obj/item/toy/plush/snakeplushie
@@ -750,7 +766,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "An adorable stuffed toy that resembles a snake. Not to be mistaken for the real thing."
 	icon_state = "plushie_snake"
 	item_state = "plushie_snake"
-	attack_verb = list("bitten", "hissed", "tail slapped")
+	attack_verb_continuous = list("bites", "hisses", "tail slaps")
+	attack_verb_simple = list("bite", "hiss", "tail slap")
 	squeak_override = list('modular_citadel/sound/voice/hiss.ogg' = 1)
 
 /obj/item/toy/plush/mammal
@@ -765,14 +782,16 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "An adorable stuffed toy resembling a fox."
 	icon_state = "fox"
 	item_state = "fox"
-	attack_verb = list("yipped", "geckered", "yapped")
+	attack_verb_continuous = list("yips", "geckers", "yaps")
+	attack_verb_simple = list("yip", "gecker", "yap")
 
 /obj/item/toy/plush/mammal/dog
 	name = "dog plushie"
 	icon_state = "corgi"
 	item_state = "corgi"
 	desc = "An adorable stuffed toy that resembles a dog."
-	attack_verb = list("barked", "boofed", "borked")
+	attack_verb_continuous = list("barks", "boofs", "borks")
+	attack_verb_simple = list("bark", "boof", "bork")
 	squeak_override = list(
 	'modular_citadel/sound/voice/bark1.ogg' = 1,
 	'modular_citadel/sound/voice/bark2.ogg' = 1
@@ -803,7 +822,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "An adorable stuffed plushie that resembles an avian."
 	icon_state = "bird"
 	item_state = "bird"
-	attack_verb = list("peeped", "beeped", "poofed")
+	attack_verb_continuous = list("peeps", "beeps", "poofs")
+	attack_verb_simple = list("peep", "beep", "poof")
 	squeak_override = list('modular_citadel/sound/voice/peep.ogg' = 1)
 	can_random_spawn = FALSE
 
@@ -820,7 +840,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "An adorable stuffed toy that resembles a feline."
 	icon_state = "cat"
 	item_state = "cat"
-	attack_verb = list("headbutt", "scritched", "bit")
+	attack_verb_continuous = list("headbutts", "scritches", "bites")
+	attack_verb_simple = list("headbutt", "scritch", "bit")
 	squeak_override = list('modular_citadel/sound/voice/nya.ogg' = 1)
 	can_random_spawn = FALSE
 
@@ -829,7 +850,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "An affectionate stuffed toy that resembles a certain medcat, comes complete with battery operated wagging tail!! You get the impression she's cheering you on to to find happiness and be kind to people."
 	icon_state = "fermis"
 	item_state = "fermis"
-	attack_verb = list("cuddled", "petpatted", "wigglepurred")
+	attack_verb_continuous = list("cuddles", "petpats", "wigglepurrs")
+	attack_verb_simple = list("cuddle", "petpat", "wigglepurr")
 	squeak_override = list('modular_citadel/sound/voice/merowr.ogg' = 1)
 
 /obj/item/toy/plush/teddybear
@@ -843,14 +865,16 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	desc = "Fewer pinches than a real one, but it still clicks."
 	icon_state = "crab"
 	item_state = "crab"
-	attack_verb = list("clicked", "clacked", "pinched")
+	attack_verb_continuous = list("clicks", "clacks", "pinchs")
+	attack_verb_simple = list("click", "clack", "pinch")
 
 /obj/item/toy/plush/gondola
 	name = "gondola plushie"
 	desc = "Just looking at it seems to calm you down. Please do not eat it though."
 	icon_state = "gondola"
 	item_state = "gondola"
-	attack_verb = list("calmed", "smiled", "peaced")
+	attack_verb_continuous = list("calms", "smiles", "peaces")
+	attack_verb_simple = list("calm", "smile", "peace")
 
 /obj/item/toy/plush/hairball
 	name = "Hairball"
@@ -859,7 +883,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	unstuffable = TRUE
 	young = TRUE // Your own mouth-baby.
 	squeak_override = list('sound/misc/splort.ogg'=1)
-	attack_verb = list("sploshed", "splorted", "slushed")
+	attack_verb_continuous = list("sploshes", "splorts", "slushs")
+	attack_verb_simple = list("splosh", "splort", "slush")
 	can_random_spawn = FALSE
 
 /obj/item/toy/plush/plushling
@@ -932,7 +957,7 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 		icon_state = victim.icon_state
 		item_state = victim.item_state
 		squeak_override = victim.squeak_override
-		attack_verb = victim.attack_verb
+		attack_verb_continuous = victim.attack_verb_continuous
 	new /obj/effect/decal/cleanable/ash(get_turf(victim))
 	qdel(victim)
 

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -7,7 +7,8 @@
 	desc = "A gas-powered cannon that can fire any object loaded into it."
 	w_class = WEIGHT_CLASS_BULKY
 	force = 8 //Very heavy
-	attack_verb = list("bludgeoned", "smashed", "beaten")
+	attack_verb_continuous = list("bludgeons", "smashes", "beats")
+	attack_verb_simple = list("bludgeon", "smash", "beat")
 	icon = 'icons/obj/pneumaticCannon.dmi'
 	icon_state = "pneumaticCannon"
 	item_state = "bulldog"

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -7,7 +7,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
 	item_flags = NEEDS_PERMIT
-	attack_verb = list("whacked", "fisted", "power-punched")
+	attack_verb_continuous = list("whacks", "fists", "power-punches")
+	attack_verb_simple = list("whack", "fist", "power-punch")
 	force = 20
 	throwforce = 10
 	throw_range = 7

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -5,7 +5,8 @@
 	icon_state = "banner"
 	item_state = "banner"
 	force = 8
-	attack_verb = list("forcefully inspired", "violently encouraged", "relentlessly galvanized")
+	attack_verb_continuous = list("forcefully inspires", "violently encourages", "relentlessly galvanizes")
+	attack_verb_simple = list("forcefully inspire", "violently encourage", "relentlessly galvanize")
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
 	var/inspiration_available = TRUE //If this banner can be used to inspire crew

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -204,7 +204,8 @@
 	throw_range = 3
 	w_class = WEIGHT_CLASS_BULKY
 	custom_materials = list(/datum/material/glass=7500, /datum/material/iron=1000)
-	attack_verb = list("shoved", "bashed")
+	attack_verb_continuous = list("shoves", "bashes")
+	attack_verb_simple = list("shove", "bash")
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 	var/repair_material = /obj/item/stack/sheet/mineral/titanium
 	var/can_shatter = TRUE
@@ -549,7 +550,8 @@
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("shoved", "bashed")
+	attack_verb_continuous = list("shoves", "bashes")
+	attack_verb_simple = list("shove", "bash")
 	throw_range = 5
 	force = 3
 	throwforce = 3

--- a/code/game/objects/items/signs.dm
+++ b/code/game/objects/items/signs.dm
@@ -4,7 +4,8 @@
 	desc = "It's blank."
 	force = 5
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("bashed","smacked")
+	attack_verb_continuous = list("bashes", "smacks")
+	attack_verb_simple = list("bash", "smack")
 	resistance_flags = FLAMMABLE
 
 	var/label = ""

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -14,7 +14,8 @@
 	armour_penetration = 10
 	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
+	attack_verb_continuous = list("attacks", "pokes", "jabs", "tears", "lacerates", "gores")
+	attack_verb_simple = list("attack", "poke", "jab", "tear", "lacerate", "gore")
 	sharpness = SHARP_EDGED
 	max_integrity = 200
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 30)
@@ -133,7 +134,8 @@
 	desc = "Recovered from the aftermath of a revolt aboard Defense Outpost Theta Aegis, in which a seemingly endless tide of Assistants caused heavy casualities among Nanotrasen military forces."
 	throwforce = 20
 	throw_speed = 4
-	attack_verb = list("gored")
+	attack_verb_continuous = list("gores")
+	attack_verb_simple = list("gore")
 	var/clonechance = 50
 	var/clonedamage = 12
 	var/clonespeed = 0
@@ -178,7 +180,8 @@
 	armour_penetration = 15				//Enhanced armor piercing
 	custom_materials = null
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
+	attack_verb_continuous = list("attacks", "pokes", "jabs", "tears", "lacerates", "gores")
+	attack_verb_simple = list("attack", "poke", "jab", "tear", "lacerate", "gore")
 	sharpness = SHARP_EDGED
 	icon_prefix = "bone_spear"
 

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -66,7 +66,8 @@
 	singular_name = "bluespace polycrystal"
 	desc = "A stable polycrystal, made of fused-together bluespace crystals. You could probably break one off."
 	custom_materials = list(/datum/material/bluespace=MINERAL_MATERIAL_AMOUNT)
-	attack_verb = list("bluespace polybashed", "bluespace polybattered", "bluespace polybludgeoned", "bluespace polythrashed", "bluespace polysmashed")
+	attack_verb_continuous = list("bluespace polybashes", "bluespace polybatters", "bluespace polybludgeons", "bluespace polythrashes", "bluespace polysmashes")
+	attack_verb_simple = list("bluespace polybash", "bluespace polybatter", "bluespace polybludgeon", "bluespace polythrash", "bluespace polysmash")
 	novariants = TRUE
 	grind_results = list(/datum/reagent/bluespace = 20)
 	point_value = 30

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -21,7 +21,8 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	throw_range = 7
 	custom_materials = list(/datum/material/iron=1000)
 	max_amount = 50
-	attack_verb = list("hit", "bludgeoned", "whacked")
+	attack_verb_continuous = list("hits", "bludgeons", "whacks")
+	attack_verb_simple = list("hit", "bludgeon", "whack")
 	hitsound = 'sound/items/trayhit1.ogg'
 	embedding = list()
 	novariants = TRUE

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -288,7 +288,8 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	custom_materials = list(/datum/material/glass=MINERAL_MATERIAL_AMOUNT)
-	attack_verb = list("stabbed", "slashed", "sliced", "cut")
+	attack_verb_continuous = list("stabs", "slashes", "slices", "cuts")
+	attack_verb_simple = list("stab", "slash", "slice", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	resistance_flags = ACID_PROOF
 	armor = list(MELEE = 100, BULLET = 0, LASER = 0, ENERGY = 100, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 100)

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -8,7 +8,8 @@
 	max_amount = 50
 	throw_speed = 1
 	throw_range = 3
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "smashed")
+	attack_verb_continuous = list("bashes", "batters", "bludgeons", "thrashes", "smashes")
+	attack_verb_simple = list("bash", "batter", "bludgeon", "thrash", "smash")
 	novariants = FALSE
 	///this is used for girders in the creation of walls/false walls
 	var/sheettype = null

--- a/code/game/objects/items/stacks/tiles/light.dm
+++ b/code/game/objects/items/stacks/tiles/light.dm
@@ -4,7 +4,8 @@
 	desc = "A floor tile, made out of glass. It produces light."
 	icon_state = "tile_e"
 	flags_1 = CONDUCT_1
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "smashed")
+	attack_verb_continuous = list("bashes", "batters", "bludgeons", "thrashes", "smashes")
+	attack_verb_simple = list("bash", "batter", "bludgeon", "thrash", "smash")
 	turf_type = /turf/open/floor/light
 	var/state = 0
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -7,7 +7,8 @@
 	lefthand_file = 'icons/mob/inhands/equipment/belt_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/belt_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
-	attack_verb = list("whipped", "lashed", "disciplined")
+	attack_verb_continuous = list("whips", "lashes", "disciplines")
+	attack_verb_simple = list("whip", "lash", "discipline")
 	max_integrity = 300
 	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
 	var/content_overlays = FALSE //If this is true, the belt will gain overlays based on what it's holding
@@ -822,7 +823,8 @@
 	force = 5
 	throwforce = 15
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("bashed", "slashes", "prods", "pokes")
+	attack_verb_continuous = list("bashes", "slashes", "prods", "pokes")
+	attack_verb_simple = list("bash", "slash", "prod", "poke")
 	fitting_swords = list(/obj/item/melee/rapier)
 	starting_sword = /obj/item/melee/rapier
 

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -241,7 +241,8 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 	hitsound = 'sound/weapons/sear.ogg'
 	damtype = BURN
 	name = "Syndicate Tome"
-	attack_verb = list("attacked", "burned", "blessed", "damned", "scorched")
+	attack_verb_continuous = list("attacks", "burns", "blesses", "damns", "scorches")
+	attack_verb_simple = list("attack", "burn", "bless", "damn", "scorch")
 	var/uses = 1
 
 /obj/item/storage/book/bible/syndicate/attack_self(mob/living/carbon/human/H)

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -10,7 +10,8 @@
 	throw_speed = 2
 	throw_range = 4
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
+	attack_verb_continuous = list("bashes", "batters", "bludgeons", "thrashes", "whacks")
+	attack_verb_simple = list("bash", "batter", "bludgeon", "thrash", "whack")
 	resistance_flags = FLAMMABLE
 	max_integrity = 150
 	var/folder_path = /obj/item/folder //this is the path of the folder that gets spawned in New()

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -125,7 +125,8 @@
 	throw_speed = 2
 	throw_range = 4
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
+	attack_verb_continuous = list("bashes", "batters", "bludgeons", "thrashes", "whacks")
+	attack_verb_simple = list("bash", "batter", "bludgeon", "thrash", "whack")
 
 /obj/item/storage/secure/briefcase/PopulateContents()
 	new /obj/item/paper(src)

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -13,7 +13,8 @@ GLOBAL_LIST_EMPTY(rubber_toolbox_icons)
 	throw_speed = 2
 	throw_range = 7
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("robusted")
+	attack_verb_continuous = list("robusts")
+	attack_verb_simple = list("robust")
 	hitsound = 'sound/weapons/smash.ogg'
 	drop_sound = 'sound/items/handling/toolbox_drop.ogg'
 	pickup_sound = 'sound/items/handling/toolbox_pickup.ogg'
@@ -204,7 +205,8 @@ GLOBAL_LIST_EMPTY(rubber_toolbox_icons)
 	has_latches = FALSE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	w_class = WEIGHT_CLASS_HUGE
-	attack_verb = list("robusted", "crushed", "smashed")
+	attack_verb_continuous = list("robusts", "crushs", "smashs")
+	attack_verb_simple = list("robust", "crush", "smash")
 	can_rubberify = FALSE
 	var/fabricator_type = /obj/item/clockwork/replica_fabricator/scarab
 
@@ -379,7 +381,8 @@ GLOBAL_LIST_EMPTY(rubber_toolbox_icons)
 	damtype = STAMINA
 	force += 3 //to compensate the higher stamina K.O. threshold compared to actual health.
 	throwforce += 3
-	attack_verb += "bounced"
+	attack_verb_continuous += "bounces"
+	attack_verb_simple += "bounce"
 	hitsound = 'sound/effects/clownstep1.ogg'
 	if(!GLOB.rubber_toolbox_icons[icon_state])
 		generate_rubber_toolbox_icon()
@@ -401,7 +404,8 @@ GLOBAL_LIST_EMPTY(rubber_toolbox_icons)
 	damtype = STAMINA
 	force = 15
 	throwforce = 15
-	attack_verb = list("robusted", "bounced")
+	attack_verb_continuous = list("robusts", "bounces")
+	attack_verb_simple = list("robust", "bounce")
 	can_rubberify = FALSE //we are already the future.
 
 /obj/item/storage/toolbox/rubber/Initialize(mapload)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -12,7 +12,8 @@
 	force = 10
 	throwforce = 7
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("beaten")
+	attack_verb_continuous = list("beats")
+	attack_verb_simple = list("beat")
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 0, RAD = 0, FIRE = 80, ACID = 80)
 	attack_speed = CLICK_CD_MELEE
 

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -16,7 +16,8 @@
 	drop_sound = 'sound/items/handling/crowbar_drop.ogg'
 	pickup_sound = 'sound/items/handling/crowbar_pickup.ogg'
 
-	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
+	attack_verb_continuous = list("attacks", "bashes", "batters", "bludgeons", "whacks")
+	attack_verb_simple = list("attack", "bash", "batter", "bludgeon", "whack")
 	tool_behaviour = TOOL_CROWBAR
 	toolspeed = 1
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 30)

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -15,7 +15,8 @@
 	throw_speed = 3
 	throw_range = 5
 	custom_materials = list(/datum/material/iron=75)
-	attack_verb = list("stabbed")
+	attack_verb_continuous = list("stabs")
+	attack_verb_simple = list("stab")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 	tool_behaviour = TOOL_SCREWDRIVER
@@ -137,7 +138,8 @@
 	throwforce = 8
 	throw_speed = 2
 	throw_range = 3//it's heavier than a screw driver/wrench, so it does more damage, but can't be thrown as far
-	attack_verb = list("drilled", "screwed", "jabbed","whacked")
+	attack_verb_continuous = list("drills", "screws", "jabs", "whacks")
+	attack_verb_simple = list("drill", "screw", "jab", "whack")
 	hitsound = 'sound/items/drill_hit.ogg'
 	usesound = 'sound/items/drill_use.ogg'
 	toolspeed = 0.25

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -14,7 +14,8 @@
 	throw_range = 7
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=80)
-	attack_verb = list("pinched", "nipped")
+	attack_verb_continuous = list("pinches", "nips")
+	attack_verb_simple = list("pinch", "nip")
 	hitsound = 'sound/items/wirecutter.ogg'
 	usesound = 'sound/items/wirecutter.ogg'
 	drop_sound = 'sound/items/handling/wirecutter_drop.ogg'

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -16,7 +16,8 @@
 	drop_sound = 'sound/items/handling/wrench_drop.ogg'
 	pickup_sound = 'sound/items/handling/wrench_pickup.ogg'
 
-	attack_verb = list("bashed", "battered", "bludgeoned", "whacked")
+	attack_verb_continuous = list("bashes", "batters", "bludgeons", "whacks")
+	attack_verb_simple = list("bash", "batter", "bludgeon", "whack")
 	tool_behaviour = TOOL_WRENCH
 	toolspeed = 1
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 30)
@@ -80,7 +81,8 @@
 	force = 8 //might or might not be too high, subject to change
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 8
-	attack_verb = list("drilled", "screwed", "jabbed")
+	attack_verb_continuous = list("drills", "screws", "jabs")
+	attack_verb_simple = list("drill", "screw", "jab")
 	toolspeed = 0.25
 
 /obj/item/wrench/power/attack_self(mob/user)
@@ -101,7 +103,8 @@
 	force = 2 //MEDICAL
 	throwforce = 4
 
-	attack_verb = list("wrenched", "medicaled", "tapped", "jabbed", "whacked")
+	attack_verb_continuous = list("heals", "medicals", "taps", "pokes", "analyzes") //"cobbyed"
+	attack_verb_simple = list("heal", "medical", "tap", "poke", "analyze")
 
 /obj/item/wrench/medical/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is praying to the medical wrench to take [user.p_their()] soul. It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -148,7 +148,8 @@
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=10, /datum/material/glass=10)
-	attack_verb = list("struck", "pistol whipped", "hit", "bashed")
+	attack_verb_continuous = list("strikes", "pistol whips", "hits", "bashes")
+	attack_verb_simple = list("strike", "pistol whip", "hit", "bash")
 	var/bullets = 7
 
 /obj/item/toy/gun/examine(mob/user)
@@ -224,7 +225,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	var/active = 0
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("attacked", "struck", "hit")
+	attack_verb_continuous = list("attacks", "strikes", "hits")
+	attack_verb_simple = list("attack", "strike", "hit")
 	var/hacked = FALSE
 	total_mass = 0.4
 	var/total_mass_on = TOTAL_MASS_TOY_SWORD
@@ -297,7 +299,8 @@
 	item_state = "cxsword"
 	active = FALSE
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("poked", "jabbed", "hit")
+	attack_verb_continuous = list("pokes", "jabs", "hits")
+	attack_verb_simple = list("poke", "jab", "hit")
 	light_color = "#37FFF7"
 	activation_sound = 'sound/weapons/nebon.ogg'
 	deactivation_sound = 'sound/weapons/neboff.ogg'
@@ -384,7 +387,8 @@
 	item_state = "arm_blade"
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
-	attack_verb = list("pricked", "absorbed", "gored")
+	attack_verb_continuous = list("pricks", "absorbs", "gores")
+	attack_verb_simple = list("prick", "absorb", "gore")
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE
 
@@ -401,7 +405,8 @@
 	hitsound = 'sound/weapons/smash.ogg'
 	drop_sound = 'sound/items/handling/toolbox_drop.ogg'
 	pickup_sound = 'sound/items/handling/toolbox_pickup.ogg'
-	attack_verb = list("robusted")
+	attack_verb_continuous = list("robusts")
+	attack_verb_simple = list("robust")
 
 /obj/item/toy/windupToolbox/attack_self(mob/user)
 	if(!active)
@@ -447,7 +452,8 @@
 	throw_speed = 3
 	throw_range = 5
 	block_parry_data = null
-	attack_verb = list("attacked", "struck", "hit")
+	attack_verb_continuous = list("attacks", "strikes", "hits")
+	attack_verb_simple = list("attack", "strike", "hit")
 	total_mass_on = TOTAL_MASS_TOY_SWORD
 	sharpness = SHARP_NONE
 
@@ -465,7 +471,8 @@
 	throw_speed = 3
 	throw_range = 5
 
-	attack_verb = list("attacked", "struck", "hit")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices")
+	attack_verb_simple = list("attack", "slash", "stab", "slice")
 	total_mass_on = TOTAL_MASS_TOY_SWORD
 	slowdown_wielded = 0
 	sharpness = SHARP_NONE
@@ -495,7 +502,8 @@
 	throwforce = 5
 	total_mass = null
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices")
+	attack_verb_simple = list("attack", "slash", "stab", "slice")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
 /obj/item/toy/katana/suicide_act(mob/living/carbon/user)
@@ -1098,8 +1106,6 @@
 	newobj.throw_speed = newobj.card_throw_speed
 	newobj.card_throw_range = sourceobj.card_throw_range
 	newobj.throw_range = newobj.card_throw_range
-	newobj.card_attack_verb = sourceobj.card_attack_verb
-	newobj.attack_verb = newobj.card_attack_verb
 
 /*
 || Syndicate playing cards, for pretending you're Gambit and playing poker for the nuke disk. ||

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -9,7 +9,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3
 	throw_range = 7
-	attack_verb = list("banned")
+	attack_verb_continuous = list("bans")
+	attack_verb_simple = list("ban")
 	max_integrity = 200
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 70)
 	resistance_flags = FIRE_PROOF
@@ -43,7 +44,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throwforce = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 
 /obj/item/sord/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is trying to impale [user.p_them()]self with [src]! It might be a suicide attempt if it weren't so shitty.</span>", \
@@ -63,7 +65,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 40
 	throwforce = 10
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	block_chance = 50
 	sharpness = SHARP_EDGED
 	max_integrity = 200
@@ -93,7 +96,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	slot_flags = null
 	block_chance = 0 //RNG WON'T HELP YOU NOW, PANSY
 	light_range = 3
-	attack_verb = list("brutalized", "eviscerated", "disemboweled", "hacked", "carved", "cleaved") //ONLY THE MOST VISCERAL ATTACK VERBS
+	attack_verb_continuous = list("brutalizes", "eviscerates", "disembowels", "hacks", "carves", "cleaves") //ONLY THE MOST VISCERAL ATTACK VERBS
+	attack_verb_simple = list("brutalize", "eviscerate", "disembowel", "hack", "carve", "cleave")
 	var/notches = 0 //HOW MANY PEOPLE HAVE BEEN SLAIN WITH THIS BLADE
 	var/obj/item/disk/nuclear/nuke_disk //OUR STORED NUKE DISK
 
@@ -246,7 +250,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throwforce = 10
 	w_class = WEIGHT_CLASS_HUGE
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	block_chance = 50
 	sharpness = SHARP_EDGED
 	max_integrity = 200
@@ -317,7 +322,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	var/stamina_damage_increment = 5 //how much extra damage do we do when in non-harm mode
 	throwforce = 10
 	damtype = STAMINA
-	attack_verb = list("whacked", "smacked", "struck")
+	attack_verb_continuous = list("hits", "bludgeons", "whacks", "bonks")
+	attack_verb_simple = list("hit", "bludgeon", "whack", "bonk")
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
 	hitsound = 'sound/weapons/woodbonk.ogg'
 	var/harm = FALSE // TRUE = brute, FALSE = stam
@@ -380,13 +386,15 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	if(harm)
 		force -= stamina_damage_increment
 		damtype = BRUTE
-		attack_verb = list("bashed", "smashed", "attacked")
+		attack_verb_continuous = list("bashs", "smashs", "attacks")
+		attack_verb_simple = list("bash", "smash", "attack")
 		bare_wound_bonus = 15 // having your leg smacked by a wooden stick is probably not great for it if it's naked
 		wound_bonus = 0
 	else
 		force += stamina_damage_increment
 		damtype = STAMINA
-		attack_verb = list("whacked", "smacked", "struck")
+		attack_verb_continuous = list("whacks", "smacks", "strucks")
+		attack_verb_simple = list("whacks", "smacks", "struck")
 		bare_wound_bonus = 0
 		wound_bonus = 0
 	to_chat(user, "<span class='notice'>[src] is now [harm ? "harmful" : "not quite as harmful"].</span>")
@@ -580,7 +588,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throwforce = 10
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=75)
-	attack_verb = list("hit", "bludgeoned", "whacked", "bonked")
+	attack_verb_continuous = list("hits", "bludgeons", "whacks", "bonks")
+	attack_verb_simple = list("hit", "bludgeon", "whack", "bonk")
 	wound_bonus = -10
 
 /obj/item/wirerod/Initialize(mapload)
@@ -674,7 +683,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throw_range = 6
 	custom_materials = list(/datum/material/iron=12000)
 	hitsound = 'sound/weapons/genhit.ogg'
-	attack_verb = list("stubbed", "poked")
+	attack_verb_continuous = list("stubs", "pokes")
+	attack_verb_simple = list("stub", "poke")
 	resistance_flags = FIRE_PROOF
 	var/extended = 0
 
@@ -686,7 +696,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		w_class = WEIGHT_CLASS_NORMAL
 		throwforce = 23
 		icon_state = "switchblade_ext"
-		attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+		attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+		attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 		hitsound = 'sound/weapons/bladeslice.ogg'
 		sharpness = SHARP_EDGED
 	else
@@ -694,7 +705,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		w_class = WEIGHT_CLASS_SMALL
 		throwforce = 5
 		icon_state = "switchblade"
-		attack_verb = list("stubbed", "poked")
+		attack_verb_continuous = list("stubs", "pokes")
+		attack_verb_simple = list("stub", "poke")
 		hitsound = 'sound/weapons/genhit.ogg'
 		sharpness = SHARP_NONE
 
@@ -712,7 +724,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throw_speed = 3
 	throw_range = 4
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("called", "rang")
+	attack_verb_continuous = list("calls", "rings")
+	attack_verb_simple = list("call", "ring")
 	hitsound = 'sound/weapons/ring.ogg'
 
 /obj/item/phone/suicide_act(mob/user)
@@ -734,7 +747,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throwforce = 5
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=50)
-	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed")
+	attack_verb_continuous = list("bludgeons", "whacks", "disciplines", "thrashes")
+	attack_verb_simple = list("bludgeon", "whack", "discipline", "thrash")
 
 /obj/item/staff
 	name = "wizard staff"
@@ -749,7 +763,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
 	armour_penetration = 100
-	attack_verb = list("bludgeoned", "whacked", "disciplined")
+	attack_verb_continuous = list("bludgeons", "whacks", "disciplines")
+	attack_verb_simple = list("bludgeon", "whack", "discipline")
 	resistance_flags = FLAMMABLE
 
 /obj/item/staff/broom
@@ -802,7 +817,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throw_range = 0
 	throw_speed = 0
 	sharpness = SHARP_EDGED
-	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
+	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
+	attack_verb_simple = list("saw", "tear", "lacerate", "cut", "chop", "dice")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	total_mass = TOTAL_MASS_HAND_REPLACEMENT
 	tool_behaviour = TOOL_SAW
@@ -833,7 +849,9 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throwforce = 10
 	throw_speed = 5
 	throw_range = 2
-	attack_verb = list("busted")
+	attack_verb_continuous = list("clubs", "bludgeons")
+	attack_verb_simple = list("club", "bludgeon")
+
 	var/impressiveness = 45
 
 /obj/item/statuebust/Initialize(mapload)
@@ -855,7 +873,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throwforce = 1 // why are you throwing a club do you even weapon
 	throw_speed = 1
 	throw_range = 1
-	attack_verb = list("clubbed", "bludgeoned")
+	attack_verb_continuous = list("clubs", "bludgeons")
+	attack_verb_simple = list("club", "bludgeon")
 
 /obj/item/melee/chainofcommand/tailwhip
 	name = "liz o' nine tails"
@@ -876,7 +895,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 12
 	throwforce = 4
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("smacked", "whacked", "slammed", "smashed")
+	attack_verb_continuous = list("smacks", "whacks", "slams", "smashes")
+	attack_verb_simple = list("smack", "whack", "slam", "smash")
 	///The vehicle counterpart for the board
 	var/board_item_type = /obj/vehicle/ridden/scooter/skateboard
 
@@ -926,7 +946,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 10
 	wound_bonus = -10
 	throwforce = 12
-	attack_verb = list("beat", "smacked")
+	attack_verb_continuous = list("beats", "smacks")
+	attack_verb_simple = list("beat", "smack")
 	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 3.5)
 	w_class = WEIGHT_CLASS_HUGE
 	var/homerun_ready = 0
@@ -1066,7 +1087,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		w_class = weight_class_on
 		force = force_on
 		throwforce = throwforce_on
-		attack_verb = list("beat", "smacked")
+		attack_verb_continuous = list("beats", "smacks")
+		attack_verb_simple = list("beat", "smack")
 	else
 		to_chat(user, desc["local_off"])
 		icon_state = off_icon_state
@@ -1074,7 +1096,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		w_class = WEIGHT_CLASS_SMALL
 		force = force_off
 		throwforce = throwforce_off
-		attack_verb = list("drubbed", "beaned")
+		attack_verb_continuous = list("drubs", "beans")
+		attack_verb_simple = list("drub", "bean")
 	playsound(src.loc, on_sound, 50, 1)
 	add_fingerprint(user)
 
@@ -1088,7 +1111,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	force = 1
 	throwforce = 1
-	attack_verb = list("swatted", "smacked")
+	attack_verb_continuous = list("swats", "smacks")
+	attack_verb_simple = list("swat", "smack")
 	hitsound = 'sound/effects/snap.ogg'
 	w_class = WEIGHT_CLASS_SMALL
 	//Things in this list will be instantly splatted.  Flyman weakness is handled in the flyman species weakness proc.
@@ -1124,7 +1148,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 0
 	throwforce = 0
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
-	attack_verb = list("bopped")
+	attack_verb_continuous = list("bops")
+	attack_verb_simple = list("bop")
 
 /obj/item/circlegame/Initialize(mapload)
 	. = ..()
@@ -1226,7 +1251,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 0
 	throwforce = 0
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
-	attack_verb = list("slapped")
+	attack_verb_continuous = list("slaps")
+	attack_verb_simple = list("slap")
 	hitsound = 'sound/effects/snap.ogg'
 
 /obj/item/slapper/attack(mob/M, mob/living/carbon/human/user)
@@ -1410,7 +1436,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throwforce = 20
 	throw_speed = 4
 	sharpness = SHARP_EDGED
-	attack_verb = list("cut", "sliced", "diced")
+	attack_verb_continuous = list("cuts", "slices", "dices")
+	attack_verb_simple = list("cut", "slice", "dice")
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -303,7 +303,8 @@
 	throw_speed = 3
 	throw_range = 5
 	custom_materials = list(/datum/material/iron=75)
-	attack_verb = list("stabs")
+	attack_verb_continuous = list("stabs")
+	attack_verb_simple = list("stab")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 	drop_sound = 'sound/items/handling/screwdriver_drop.ogg'

--- a/code/modules/antagonists/bloodsucker/items/bloodsucker_stake.dm
+++ b/code/modules/antagonists/bloodsucker/items/bloodsucker_stake.dm
@@ -24,7 +24,8 @@
 	item_state = "wood" // In-hand Icon
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi' // File for in-hand icon
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	attack_verb = list("staked")
+	attack_verb_continuous = list("stakes")
+	attack_verb_simple = list("stake")
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/antagonists/bloodsucker/objects/bloodsucker_crypt.dm
+++ b/code/modules/antagonists/bloodsucker/objects/bloodsucker_crypt.dm
@@ -354,7 +354,7 @@
 	if(!istype(I))
 		I = user.get_inactive_held_item()
 	// Create Strings
-	var/method_string =  I?.attack_verb?.len ? pick(I.attack_verb) : pick("harmed","tortured","wrenched","twisted","scoured","beaten","lashed","scathed")
+	var/method_string =  I?.attack_verb_continuous?.len ? pick(I.attack_verb_continuous) : pick("harms","tortures","wrenchs","twists","scoures","beats","lashs","scathes")
 	var/weapon_string = I ? I.name : pick("bare hands","hands","fingers","fists")
 	// Weapon Bonus + SFX
 	if(I)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -173,7 +173,8 @@
 	throw_speed = 0
 	armour_penetration = 20
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
 	wound_bonus = -60
 	bare_wound_bonus = 20

--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/brass_claw.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/brass_claw.dm
@@ -16,7 +16,8 @@
 	throw_speed = 0
 	armour_penetration = 20
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")
 	sharpness = SHARP_EDGED
 	wound_bonus = 5
 	bare_wound_bonus = 15

--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
@@ -9,7 +9,8 @@
 	throwforce = 25
 	armour_penetration = 10
 	sharpness = SHARP_POINTY
-	attack_verb = list("stabbed", "poked", "slashed")
+	attack_verb_continuous = list("attacks", "impales", "stabs", "tears", "lacerates", "gores")
+	attack_verb_simple = list("attack", "impale", "stab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	w_class = WEIGHT_CLASS_BULKY
 	block_parry_data = /datum/block_parry_data/ratvarian_spear

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -60,7 +60,8 @@
 	wound_bonus = -80
 	bare_wound_bonus = 30
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")
 
 /obj/item/melee/cultblade/Initialize(mapload)
 	. = ..()
@@ -116,7 +117,8 @@
 	throw_range = 3
 	sharpness = SHARP_EDGED
 	light_color = "#ff0000"
-	attack_verb = list("cleaved", "slashed", "torn", "hacked", "ripped", "diced", "carved")
+	attack_verb_continuous = list("cleaves", "slashes", "tears", "lacerates", "hacks", "rips", "dices", "carves")
+	attack_verb_simple = list("cleave", "slash", "tear", "lacerate", "hack", "rip", "dice", "carve")
 	icon_state = "cultbastard"
 	item_state = "cultbastard"
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -709,7 +711,8 @@
 	throw_speed = 2
 	armour_penetration = 30
 	block_chance = 30
-	attack_verb = list("attacked", "impaled", "stabbed", "torn", "gored")
+	attack_verb_continuous = list("attacks", "impales", "stabs", "tears", "lacerates", "gores")
+	attack_verb_simple = list("attack", "impale", "stab", "tear", "lacerate", "gore")
 	sharpness = SHARP_EDGED
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	var/datum/action/innate/cult/spear/spear_act
@@ -983,7 +986,8 @@
 	throw_speed = 1
 	throw_range = 4
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("bumped", "prodded")
+	attack_verb_continuous = list("bumps", "prods")
+	attack_verb_simple = list("bump", "prod")
 	hitsound = 'sound/weapons/smash.ogg'
 	var/illusions = 2
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -60,7 +60,8 @@
 	force = 17
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "tore", "lacerated", "ripped", "diced", "rended")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")
 
 /obj/item/melee/sickly_blade/attack(mob/living/target, mob/living/user)
 	if(!(IS_HERETIC(user) || IS_HERETIC_MONSTER(user)))
@@ -292,7 +293,8 @@
 	throwforce = 20
 	embedding = list(embed_chance=75, jostle_chance=2, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=3, jostle_pain_mult=5, rip_time=15)
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "tore", "lacerated", "ripped", "diced", "rended")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")
 	///turfs that you cannot draw carvings on
 	var/static/list/blacklisted_turfs = typecacheof(list(/turf/closed,/turf/open/space,/turf/open/lava))
 	///A check to see if you are in process of drawing a rune

--- a/code/modules/arousal/toys/dildos.dm
+++ b/code/modules/arousal/toys/dildos.dm
@@ -90,22 +90,26 @@
 /obj/item/dildo/knotted
 	dildo_shape 		= "knotted"
 	name 				= "knotted dildo"
-	attack_verb 		= list("penetrated", "knotted", "slapped", "inseminated")
+	attack_verb_continuous = list("penetrates", "knotts", "slaps", "inseminates")
+	attack_verb_simple = list("penetrate", "knott", "slap", "inseminate")
 
 /obj/item/dildo/human
 	dildo_shape 		= "human"
 	name 				= "human dildo"
-	attack_verb = list("penetrated", "slapped", "inseminated")
+	attack_verb_continuous = list("penetrates", "slaps", "inseminates")
+	attack_verb_simple = list("penetrate", "slap", "inseminate")
 
 /obj/item/dildo/plain
 	dildo_shape 		= "plain"
 	name 				= "plain dildo"
-	attack_verb 		= list("penetrated", "slapped", "inseminated")
+	attack_verb_continuous = list("penetrates", "slaps", "inseminates")
+	attack_verb_simple = list("penetrate", "slap", "inseminate")
 
 /obj/item/dildo/flared
 	dildo_shape 		= "flared"
 	name 				= "flared dildo"
-	attack_verb 		= list("penetrated", "slapped", "neighed", "gaped", "prolapsed", "inseminated")
+	attack_verb_continuous = list("penetrates", "slaps", "neighes", "gapes", "prolapses", "inseminates")
+	attack_verb_simple = list("penetrate", "slap", "neighe", "gape", "prolapse", "inseminate")
 
 /obj/item/dildo/flared/huge
 	name 				= "The Penetrator"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -99,7 +99,8 @@
 	force = 10
 	throwforce = 10
 	throw_speed = 4
-	attack_verb = list("sliced")
+	attack_verb_continuous = list("slices")
+	attack_verb_simple = list("slice")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
 
@@ -206,7 +207,8 @@
 	force = 10
 	throwforce = 20
 	throw_speed = 4
-	attack_verb = list("sliced")
+	attack_verb_continuous = list("slices")
+	attack_verb_simple = list("slice")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
 	vision_correction = 1
@@ -269,7 +271,8 @@
 	force = 10
 	throwforce = 10
 	throw_speed = 4
-	attack_verb = list("sliced")
+	attack_verb_continuous = list("slices")
+	attack_verb_simple = list("slice")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
 
@@ -289,7 +292,8 @@
 	force = 10
 	throwforce = 10
 	throw_speed = 4
-	attack_verb = list("sliced")
+	attack_verb_continuous = list("slices")
+	attack_verb_simple = list("slice")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
 	glass_colour_type = /datum/client_colour/glass_colour/orange

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -210,7 +210,8 @@
 	force = 10
 	throwforce = 10
 	throw_speed = 4
-	attack_verb = list("sliced")
+	attack_verb_continuous = list("slices")
+	attack_verb_simple = list("slice")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
 

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -6,7 +6,8 @@
 	siemens_coefficient = 0.5
 	body_parts_covered = HANDS
 	slot_flags = ITEM_SLOT_GLOVES
-	attack_verb = list("challenged")
+	attack_verb_continuous = list("challenges")
+	attack_verb_simple = list("challenge")
 	var/transfer_prints = FALSE
 	var/transfer_blood = 0
 	strip_delay = 20

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -253,7 +253,8 @@
 	throw_speed = 2
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("warned", "cautioned", "smashed")
+	attack_verb_continuous = list("warns", "cautions", "smashes")
+	attack_verb_simple = list("warn", "caution", "smash")
 	resistance_flags = NONE
 	dynamic_hair_suffix = ""
 

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -634,7 +634,8 @@
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
 	body_parts_covered = CHEST|GROIN
-	attack_verb = list("warned", "cautioned", "smashed")
+	attack_verb_continuous = list("warns", "cautions", "smashes")
+	attack_verb_simple = list("warn", "caution", "smash")
 	armor = list(MELEE = 5, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
 
 /obj/item/clothing/suit/petharness

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -85,7 +85,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	item_state = "beer"
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("stabbed", "slashed", "attacked")
+	attack_verb_continuous = list("stabs", "slashes", "attacks")
+	attack_verb_simple = list("stab", "slash", "attack")
 	var/icon/broken_outline = icon('icons/obj/drinks.dmi', "broken")
 	sharpness = SHARP_EDGED
 
@@ -644,7 +645,8 @@
 	throw_range = 0
 	w_class = WEIGHT_CLASS_TINY
 	item_state = "beer"
-	attack_verb = list("boop", "thunked", "shown")
+	attack_verb_continuous = list("boops", "thunks", "shows")
+	attack_verb_simple = list("boop", "thunk", "show")
 
 /obj/item/export/bottle/gin
 	icon_state = "ginbottle"

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -437,7 +437,8 @@
 	throwforce = 10
 	block_chance = 50
 	armour_penetration = 75
-	attack_verb = list("slapped", "slathered")
+	attack_verb_continuous = list("slaps", "slathers")
+	attack_verb_simple = list("slap", "slather")
 	w_class = WEIGHT_CLASS_BULKY
 	tastes = list("cherry" = 1, "crepe" = 1)
 	foodtype = GRAIN | FRUIT | SUGAR

--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -28,7 +28,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 2
 	throw_range = 3
-	attack_verb = list("pomfed")
+	attack_verb_continuous = list("pomfs")
+	attack_verb_simple = list("pomf")
 	var/cotton_type = /obj/item/stack/sheet/cotton
 	var/cotton_name = "raw cotton"
 
@@ -73,6 +74,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 2
 	throw_range = 3
-	attack_verb = list("bashed", "battered", "bludgeoned", "whacked")
+	attack_verb_continuous = list("bashes", "batters", "bludgeons", "whacks")
+	attack_verb_simple = list("bash", "batter", "bludgeon", "whack")
 	cotton_type = /obj/item/stack/sheet/cotton/durathread
 	cotton_name = "raw durathread"

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -227,7 +227,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 1
 	throw_range = 3
-	attack_verb = list("roasted", "scorched", "burned")
+	attack_verb_continuous = list("roasts", "scorches", "burns")
+	attack_verb_simple = list("roast", "scorch", "burn")
 	grind_results = list(/datum/reagent/consumable/capsaicin = 0, /datum/reagent/consumable/condensedcapsaicin = 0)
 	tastes = list("cooked sunflower" = 1)
 

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -267,7 +267,8 @@
 	force = 5
 	throwforce = 5
 	hitsound = 'sound/weapons/klonk.ogg'
-	attack_verb = list("klonked", "donked", "bonked")
+	attack_verb_continuous = list("klonks", "donks", "bonks")
+	attack_verb_simple = list("klonk", "donk", "bonk")
 	distill_reagent = "creme_de_coconut"
 	var/opened = FALSE
 	var/carved = FALSE

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -44,7 +44,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 1
 	throw_range = 3
-	attack_verb = list("stung")
+	attack_verb_continuous = list("stings")
+	attack_verb_simple = list("sting")
 
 /obj/item/reagent_containers/food/snacks/grown/nettle/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is eating some of [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/modules/hydroponics/grown/pineapple.dm
+++ b/code/modules/hydroponics/grown/pineapple.dm
@@ -22,7 +22,8 @@
 	force = 4
 	throwforce = 8
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("stung", "pined")
+	attack_verb_continuous = list("stings", "pines")
+	attack_verb_simple = list("sting", "pine")
 	throw_speed = 1
 	throw_range = 5
 	slice_path = /obj/item/reagent_containers/food/snacks/pineappleslice

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -39,7 +39,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 2
 	throw_range = 3
-	attack_verb = list("bashed", "battered", "bludgeoned", "whacked")
+	attack_verb_continuous = list("bashes", "batters", "bludgeons", "whacks")
+	attack_verb_simple = list("bash", "batter", "bludgeon", "whack")
 	var/plank_type = /obj/item/stack/sheet/mineral/wood
 	var/plank_name = "wooden planks"
 	var/static/list/accepted = typecacheof(list(/obj/item/reagent_containers/food/snacks/grown/tobacco,

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -77,7 +77,8 @@
 	throwforce = 7
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=50)
-	attack_verb = list("slashed", "sliced", "cut", "clawed")
+	attack_verb_continuous = list("slashes", "slices", "cuts", "claws")
+	attack_verb_simple = list("slash", "slice", "cut", "claw")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
 /obj/item/cultivator/suicide_act(mob/user)
@@ -105,7 +106,8 @@
 	throw_speed = 3
 	throw_range = 4
 	custom_materials = list(/datum/material/iron = 15000)
-	attack_verb = list("chopped", "torn", "cut")
+	attack_verb_continuous = list("chops", "tears", "lacerates", "cuts")
+	attack_verb_simple = list("chop", "tear", "lacerate", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
 
@@ -139,7 +141,8 @@
 	flags_1 = CONDUCT_1
 	armour_penetration = 20
 	slot_flags = ITEM_SLOT_BACK
-	attack_verb = list("chopped", "sliced", "cut", "reaped")
+	attack_verb_continuous = list("chops", "slices", "cuts", "reaps")
+	attack_verb_simple = list("chop", "slice", "cut", "reap")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	var/swiping = FALSE
 

--- a/code/modules/instruments/instruments/item.dm
+++ b/code/modules/instruments/instruments/item.dm
@@ -112,7 +112,8 @@
 	desc = "It's made of wood and has bronze strings."
 	icon_state = "guitar"
 	item_state = "guitar"
-	attack_verb = list("played metal on", "serenaded", "crashed", "smashed")
+	attack_verb_continuous = list("plays metal on", "serenades", "crashes", "smashes")
+	attack_verb_simple = list("play metal on", "serenade", "crash", "smash")
 	hitsound = 'sound/weapons/stringsmash.ogg'
 	allowed_instrument_ids = "guitar"
 
@@ -122,7 +123,8 @@
 	icon_state = "eguitar"
 	item_state = "eguitar"
 	force = 12
-	attack_verb = list("played metal on", "shredded", "crashed", "smashed")
+	attack_verb_continuous = list("plays metal on", "shreds", "crashes", "smashes")
+	attack_verb_simple = list("play metal on", "shred", "crash", "smash")
 	hitsound = 'sound/weapons/stringsmash.ogg'
 	allowed_instrument_ids = "eguitar"
 
@@ -153,7 +155,8 @@
 	icon_state = "trumpet"
 	item_state = "trombone"
 	force = 0
-	attack_verb = list("played","jazzed","trumpeted","mourned","dooted","spooked")
+	attack_verb_continuous = list("plays", "jazzes", "trumpets", "mourns", "doots", "spooks")
+	attack_verb_simple = list("play", "jazz", "trumpet", "mourn", "doot", "spook")
 
 /obj/item/instrument/trumpet/spectral/Initialize(mapload)
 	. = ..()
@@ -176,7 +179,8 @@
 	icon_state = "saxophone"
 	item_state = "saxophone"
 	force = 0
-	attack_verb = list("played","jazzed","saxxed","mourned","dooted","spooked")
+	attack_verb_continuous = list("plays", "jazzes", "saxxes", "mourns", "doots", "spooks")
+	attack_verb_simple = list("play", "jazz", "sax", "mourn", "doot", "spook")
 
 /obj/item/instrument/saxophone/spectral/Initialize(mapload)
 	. = ..()
@@ -199,7 +203,8 @@
 	icon_state = "trombone"
 	item_state = "trombone"
 	force = 0
-	attack_verb = list("played","jazzed","tromboned","mourned","dooted","spooked")
+	attack_verb_continuous = list("plays", "jazzes", "trumpets", "mourns", "doots", "spooks")
+	attack_verb_simple = list("play", "jazz", "trumpet", "mourn", "doot", "spook")
 
 /obj/item/instrument/trombone/spectral/Initialize(mapload)
 	. = ..()
@@ -248,7 +253,8 @@
 	item_state = "bike_horn"
 	lefthand_file = 'icons/mob/inhands/equipment/horns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/horns_righthand.dmi'
-	attack_verb = list("beautifully honks")
+	attack_verb_continuous = list("beautifully honks")
+	attack_verb_simple = list("beautifully honk")
 	allowed_instrument_ids = "bikehorn"
 	w_class = WEIGHT_CLASS_TINY
 	force = 0
@@ -261,7 +267,8 @@
 	desc = "A 'Mura' brand banjo. It's pretty much just a drum with a neck and strings."
 	icon_state = "banjo"
 	item_state = "banjo"
-	attack_verb = list("scruggs-styled", "hum-diggitied", "shin-digged", "clawhammered")
+	attack_verb_continuous = list("scruggs-styles", "hum-diggitys", "shin-digs", "clawhammers")
+	attack_verb_simple = list("scruggs-style", "hum-diggity", "shin-dig", "clawhammer")
 	hitsound = 'sound/weapons/banjoslap.ogg'
 	allowed_instrument_ids = "banjo"
 

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -212,7 +212,8 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL	 //upped to three because books are, y'know, pretty big. (and you could hide them inside eachother recursively forever)
-	attack_verb = list("bashed", "whacked", "educated")
+	attack_verb_continuous = list("bashes", "whacks", "educates")
+	attack_verb_simple = list("bash", "whack", "educate")
 	resistance_flags = FLAMMABLE
 	drop_sound = 'sound/items/handling/book_drop.ogg'
 	pickup_sound = 'sound/items/handling/book_pickup.ogg'

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -16,7 +16,8 @@
 	armour_penetration = 10
 	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("smashed", "crushed", "cleaved", "chopped", "pulped")
+	attack_verb_continuous = list("smashes", "crushes", "cleaves", "chops", "pulps")
+	attack_verb_simple = list("smash", "crush", "cleave", "chop", "pulp")
 	sharpness = SHARP_EDGED
 	actions_types = list(/datum/action/item_action/toggle_light)
 	obj_flags = UNIQUE_RENAME
@@ -183,7 +184,8 @@
 	desc = "A modified design of a proto-kinetic crusher, it is still little more of a combination of various mining tools cobbled together \
 	and kit-bashed into a high-tech cleaver on a stick - with a handguard and a goliath hide grip. While it is still of little use to any \
 	but the most skilled and/or suicidal miners against local fauna, it's an elegant weapon for a more civilized hunter."
-	attack_verb = list("stabbed", "diced", "sliced", "cleaved", "chopped", "lacerated", "cut", "jabbed", "punctured")
+	attack_verb_continuous = list("stabs", "dices", "slices", "cleaves", "chops", "lacerates", "cuts", "jabs", "punctures")
+	attack_verb_simple = list("stab", "dice", "slice", "cleave", "chop", "lacerate", "cut", "jab", "puncture")
 	icon_state = "crusher-glaive"
 	item_state = "crusher0-glaive"
 	block_parry_data = /datum/block_parry_data/crusherglaive
@@ -248,7 +250,8 @@
 	often fielded by those who wish to spit in the eyes of God. Sacrifices outright damage for \
 	a reliance on backstabs and the ability to stagger fauna on a parry, \
 	slowing them and increasing the time between their special attacks."
-	attack_verb = list("pummeled", "punched", "jabbed", "hammer-fisted", "uppercut", "slammed")
+	attack_verb_continuous = list("pummeles", "punchs", "jabs", "hammer-fists", "uppercuts", "slams")
+	attack_verb_simple = list("pummele", "punch", "jab", "hammer-fist", "uppercut", "slam")
 	hitsound = 'sound/weapons/resonator_blast.ogg'
 	sharpness = SHARP_NONE // use your survival dagger or smth
 	icon_state = "crusher-hands"

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -15,7 +15,8 @@
 	tool_behaviour = TOOL_MINING
 	toolspeed = 1
 	usesound = list('sound/effects/picaxe1.ogg', 'sound/effects/picaxe2.ogg', 'sound/effects/picaxe3.ogg')
-	attack_verb = list("hit", "pierced", "sliced", "attacked")
+	attack_verb_continuous = list("hits", "pierces", "slices", "attacks")
+	attack_verb_simple = list("hit", "pierce", "slice", "attack")
 	var/digrange = 1
 
 /obj/item/pickaxe/attack_self(mob/user)
@@ -154,7 +155,8 @@
 	item_state = "shovel"
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=350)
-	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
+	attack_verb_continuous = list("bashes", "bludgeones", "thrashes", "whacks")
+	attack_verb_simple = list("bash", "bludgeone", "thrash", "whack")
 	sharpness = SHARP_EDGED
 
 /obj/item/shovel/Initialize(mapload)
@@ -198,5 +200,6 @@
 	throwforce = 12
 	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.7
-	attack_verb = list("slashed", "impaled", "stabbed", "sliced")
+	attack_verb_continuous = list("slashs", "impales", "stabs", "slices")
+	attack_verb_simple = list("slash", "impale", "stab", "slice")
 	sharpness = SHARP_EDGED

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -920,7 +920,8 @@
 	force = 1
 	throwforce = 1
 	hitsound = 'sound/effects/ghost2.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")
 	var/summon_cooldown = 0
 	var/list/mob/dead/observer/spirits
 
@@ -1268,7 +1269,8 @@
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
 	force = 15
-	attack_verb = list("clubbed", "beat", "pummeled")
+	attack_verb_continuous = list("clubs", "beats", "pummels")
+	attack_verb_simple = list("club", "beat", "pummel")
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	actions_types = list(/datum/action/item_action/vortex_recall, /datum/action/item_action/toggle_unfriendly_fire)
 	var/cooldown_time = 15 //how long the cooldown between non-melee ranged attacks is

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -8,7 +8,8 @@
 	zone = BODY_ZONE_HEAD
 	slot = ORGAN_SLOT_BRAIN
 	organ_flags = ORGAN_VITAL
-	attack_verb = list("attacked", "slapped", "whacked")
+	attack_verb_continuous = list("attacks", "slaps", "whacks")
+	attack_verb_simple = list("attack", "slap", "whack")
 	///The brain's organ variables are significantly more different than the other organs, with half the decay rate for balance reasons, and twice the maxHealth
 	decay_factor = STANDARD_ORGAN_DECAY	/ 2		//30 minutes of decaying to result in a fully damaged brain, since a fast decay rate would be unfun gameplay-wise
 	healing_factor = STANDARD_ORGAN_HEALING / 2

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -32,8 +32,8 @@ In all, this is a lot like the monkey code. /N
 				M.do_attack_animation(src, ATTACK_EFFECT_BITE)
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 				visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
-						"<span class='userdanger'>[M.name] bites [src]!</span>", null, COMBAT_MESSAGE_RANGE, null, M,
-						"<span class='danger'>You bite [src]!</span>")
+						"<span class='userdanger'>[M.name] bites you!</span>", "<span class='hear'>You hear a chomp!</span>", COMBAT_MESSAGE_RANGE, M)
+				to_chat(M, "<span class='danger'>You bite [src]!</span>")
 				adjustBruteLoss(1)
 				log_combat(M, src, "attacked")
 				updatehealth()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -520,10 +520,9 @@
 		return
 
 /mob/living/carbon/send_item_attack_message(obj/item/I, mob/living/user, hit_area, obj/item/bodypart/hit_bodypart, totitemdamage)
-	var/message_verb = "attacked"
-	if(length(I.attack_verb))
-		message_verb = "[pick(I.attack_verb)]"
-	else if(!I.force)
+	var/message_verb_continuous = length(I.attack_verb_continuous) ? "[pick(I.attack_verb_continuous)]" : "attacks"
+	var/message_verb_simple = length(I.attack_verb_simple) ? "[pick(I.attack_verb_simple)]" : "attack"
+	if(!I.force)
 		return
 
 	var/extra_wound_details = ""
@@ -540,13 +539,16 @@
 	var/message_hit_area = ""
 	if(hit_area)
 		message_hit_area = " in the [hit_area]"
-	var/attack_message = "[src] is [message_verb][message_hit_area] with [I][extra_wound_details]!"
-	var/attack_message_local = "You're [message_verb][message_hit_area] with [I][extra_wound_details]!"
+	var/attack_message_spectator = "[src] [message_verb_continuous][message_hit_area] with [I][extra_wound_details]!"
+	var/attack_message_victim = "You're [message_verb_continuous][message_hit_area] with [I][extra_wound_details]!"
+	var/attack_message_attacker = "You [message_verb_simple] [src][message_hit_area] with [I]!"
 	if(user in viewers(src, null))
-		attack_message = "[user] [message_verb] [src][message_hit_area] with [I][extra_wound_details]!"
-		attack_message_local = "[user] [message_verb] you[message_hit_area] with [I][extra_wound_details]!"
+		attack_message_spectator = "[user] [message_verb_continuous] [src][message_hit_area] with [I][extra_wound_details]!"
+		attack_message_victim = "[user] [message_verb_continuous] you[message_hit_area] with [I][extra_wound_details]!"
 	if(user == src)
-		attack_message_local = "You [message_verb] yourself[message_hit_area] with [I][extra_wound_details]"
-	visible_message("<span class='danger'>[attack_message]</span>",\
-		"<span class='userdanger'>[attack_message_local]</span>", null, COMBAT_MESSAGE_RANGE)
+		attack_message_victim = "You [message_verb_simple] yourself[message_hit_area] with [I][extra_wound_details]!"
+	visible_message("<span class='danger'>[attack_message_spectator]</span>",\
+		"<span class='userdanger'>[attack_message_victim]</span>", null, COMBAT_MESSAGE_RANGE, user)
+	if(user != src)
+		to_chat(user, "<span class='danger'>[attack_message_attacker]</span>")
 	return TRUE

--- a/code/modules/newscaster/newspaper.dm
+++ b/code/modules/newscaster/newspaper.dm
@@ -6,7 +6,8 @@
 	lefthand_file = 'icons/mob/inhands/misc/books_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/books_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("bapped")
+	attack_verb_continuous = list("baps")
+	attack_verb_simple = list("bap")
 	var/screen = 0
 	var/pages = 0
 	var/curr_page = 0

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -22,7 +22,8 @@
 	armour_penetration = 50
 	w_class = WEIGHT_CLASS_NORMAL
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	slot_flags = ITEM_SLOT_BELT
 	sharpness = SHARP_EDGED
 	obj_flags = UNIQUE_RENAME // here is a shitpost and i cannot wait for ninjas naming their sword very rude things

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -224,9 +224,8 @@
  * (Alan) Edaggers
  */
 /obj/item/pen/edagger
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut") //these wont show up if the pen is off
-	// attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts") //these won't show up if the pen is off
-	// attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
+	attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts") //these won't show up if the pen is off
+	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
 	var/on = FALSE
 

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -11,9 +11,8 @@
 	throw_range = 7
 	custom_materials = list(/datum/material/iron=60)
 	pressure_resistance = 2
-	attack_verb = list("stamped")
-	// attack_verb_continuous = list("stamps")
-	// attack_verb_simple = list("stamp")
+	attack_verb_continuous = list("stamps")
+	attack_verb_simple = list("stamp")
 
 /obj/item/stamp/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] stamps 'VOID' on [user.p_their()] forehead, then promptly falls over, dead.</span>")

--- a/code/modules/pool/pool_noodles.dm
+++ b/code/modules/pool/pool_noodles.dm
@@ -11,7 +11,8 @@
 	throwforce = 1
 	throw_speed = 10 //weeee
 	hitsound = 'sound/weapons/tap.ogg'
-	attack_verb = list("flogged", "poked", "jabbed", "slapped", "annoyed")
+	attack_verb_continuous = list("flogs", "pokes", "jabs", "slaps", "annoys")
+	attack_verb_simple = list("flog", "poke", "jab", "slap", "annoy")
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -507,7 +507,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	custom_materials = list(/datum/material/iron=10, /datum/material/glass=5)
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
-	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
+	attack_verb_continuous = list("whips", "lashes", "disciplines", "flogs")
+	attack_verb_simple = list("whip", "lash", "discipline", "flog")
 	singular_name = "cable piece"
 	full_w_class = WEIGHT_CLASS_SMALL
 	grind_results = list(/datum/reagent/copper = 2) //2 copper per cable in the coil

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -17,7 +17,8 @@
 	throw_range = 5
 	force = 5
 	item_flags = NEEDS_PERMIT
-	attack_verb = list("struck", "hit", "bashed")
+	attack_verb_continuous = list("strikes", "hits", "bashes")
+	attack_verb_simple = list("strike", "hit", "bash")
 	attack_speed = CLICK_CD_RANGE
 	var/ranged_attack_speed = CLICK_CD_RANGE
 	var/melee_attack_speed = CLICK_CD_MELEE

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -343,7 +343,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM
 	force = 16 //it has a hook on it
-	attack_verb = list("slashed", "hooked", "stabbed")
+	attack_verb_continuous = list("slashes", "hooks", "stabs")
+	attack_verb_simple = list("slash", "hook", "stab")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	//our hook gun!
 	var/obj/item/gun/magic/hook/bounty/hook

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -123,7 +123,8 @@
 	item_state = "plasmacutter"
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma)
 	flags_1 = CONDUCT_1
-	attack_verb = list("attacked", "slashed", "cut", "sliced")
+	attack_verb_continuous = list("attacks", "slashes", "cuts", "slices")
+	attack_verb_simple = list("attack", "slash", "cut", "slice")
 	force = 12
 	sharpness = SHARP_EDGED
 	inaccuracy_modifier = 0.25

--- a/code/modules/projectiles/guns/magic/motivation.dm
+++ b/code/modules/projectiles/guns/magic/motivation.dm
@@ -13,7 +13,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
 	max_integrity = 200
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -6,7 +6,8 @@
 	item_state = "pen"
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("poked")
+	attack_verb_continuous = list("pokes")
+	attack_verb_simple = list("poke")
 	var/fail_message = "<span class='warning'>INVALID USER.</span>"
 	var/selfdestruct = 0 // Explode when user check is failed.
 	var/force_replace = 0 // Can forcefully replace other pins.

--- a/code/modules/reagents/reagent_containers/rags.dm
+++ b/code/modules/reagents/reagent_containers/rags.dm
@@ -124,7 +124,8 @@
 	force = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	mutantrace_variation = STYLE_DIGITIGRADE
-	attack_verb = list("whipped")
+	attack_verb_continuous = list("whips")
+	attack_verb_simple = list("whip")
 	hitsound = 'sound/items/towelwhip.ogg'
 	volume = 10
 	total_mass = 2

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -425,19 +425,24 @@ Burning extracts:
 	switch(damtype)
 		if(BRUTE)
 			hitsound = 'sound/weapons/bladeslice.ogg'
-			attack_verb = list("slashed","sliced","cut")
+			attack_verb_continuous = list("slashes", "slices", "cuts")
+			attack_verb_simple = list("slash", "slice", "cut")
 		if(BURN)
 			hitsound = 'sound/weapons/sear.ogg'
-			attack_verb = list("burned","singed","heated")
+			attack_verb_continuous = list("slashes", "slices", "cuts")
+			attack_verb_simple = list("slash", "slice", "cut")
 		if(TOX)
 			hitsound = 'sound/weapons/pierce.ogg'
-			attack_verb = list("poisoned","dosed","toxified")
+			attack_verb_continuous = list("poisons", "doses", "toxifies")
+			attack_verb_simple = list("poison", "dose", "toxify")
 		if(OXY)
 			hitsound = 'sound/effects/space_wind.ogg'
-			attack_verb = list("suffocated","winded","vacuumed")
+			attack_verb_continuous = list("suffocates", "winds", "vacuums")
+			attack_verb_simple = list("suffocate", "wind", "vacuum")
 		if(CLONE)
 			hitsound = 'sound/items/geiger/ext1.ogg'
-			attack_verb = list("irradiated","mutated","maligned")
+			attack_verb_continuous = list("irradiates", "mutates", "maligns")
+			attack_verb_simple = list("irradiate", "mutate", "malign")
 	return ..()
 
 /obj/item/shield/adamantineshield
@@ -453,7 +458,8 @@ Burning extracts:
 	force = 0
 	throw_range = 1 //How far do you think you're gonna throw a solid crystalline shield...?
 	throw_speed = 2
-	attack_verb = list("bashed","pounded","slammed")
+	attack_verb_continuous = list("bashs","pounds","slams")
+	attack_verb_simple = list("bash","pound","slam")
 	item_flags = SLOWS_WHILE_IN_HAND
 
 /obj/item/shield/adamantineshield/ComponentInitialize()

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -58,7 +58,8 @@
 		be possessed by the devil? This arm appears to be possessed by no \
 		one though."
 	icon_state = "default_human_l_arm"
-	attack_verb = list("slapped", "punched")
+	attack_verb_continuous = list("slaps", "punches")
+	attack_verb_simple = list("slap", "punch")
 	max_damage = 50
 	disable_threshold = 75
 	max_stamina_damage = 50
@@ -120,7 +121,8 @@
 	desc = "Over 87% of humans are right handed. That figure is much lower \
 		among humans missing their right arm."
 	icon_state = "default_human_r_arm"
-	attack_verb = list("slapped", "punched")
+	attack_verb_continuous = list("slaps", "punches")
+	attack_verb_simple = list("slap", "punch")
 	max_damage = 50
 	disable_threshold = 75
 	body_zone = BODY_ZONE_R_ARM
@@ -183,7 +185,8 @@
 	desc = "Some athletes prefer to tie their left shoelaces first for good \
 		luck. In this instance, it probably would not have helped."
 	icon_state = "default_human_l_leg"
-	attack_verb = list("kicked", "stomped")
+	attack_verb_continuous = list("kicks", "stomps")
+	attack_verb_simple = list("kick", "stomp")
 	max_damage = 50
 	disable_threshold = 75
 	body_zone = BODY_ZONE_L_LEG
@@ -242,7 +245,8 @@
 		The hokey pokey has certainly changed a lot since space colonisation."
 	// alternative spellings of 'pokey' are availible
 	icon_state = "default_human_r_leg"
-	attack_verb = list("kicked", "stomped")
+	attack_verb_continuous = list("kicks", "stomps")
+	attack_verb_simple = list("kick", "stomp")
 	max_damage = 50
 	body_zone = BODY_ZONE_R_LEG
 	body_part = LEG_RIGHT

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -13,7 +13,8 @@
 /obj/item/bodypart/l_arm/robot
 	name = "cyborg left arm"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
-	attack_verb = list("slapped", "punched")
+	attack_verb_continuous = list("slaps", "punches")
+	attack_verb_simple = list("slap", "punch")
 	item_state = "buildpipe"
 	icon = 'icons/mob/augmentation/augments.dmi'
 	flags_1 = CONDUCT_1
@@ -36,7 +37,8 @@
 /obj/item/bodypart/r_arm/robot
 	name = "cyborg right arm"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
-	attack_verb = list("slapped", "punched")
+	attack_verb_continuous = list("slaps", "punches")
+	attack_verb_simple = list("slap", "punch")
 	item_state = "buildpipe"
 	icon = 'icons/mob/augmentation/augments.dmi'
 	flags_1 = CONDUCT_1
@@ -59,7 +61,8 @@
 /obj/item/bodypart/l_leg/robot
 	name = "cyborg left leg"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
-	attack_verb = list("kicked", "stomped")
+	attack_verb_continuous = list("kicks", "stomps")
+	attack_verb_simple = list("kick", "stomp")
 	item_state = "buildpipe"
 	icon = 'icons/mob/augmentation/augments.dmi'
 	flags_1 = CONDUCT_1
@@ -82,7 +85,8 @@
 /obj/item/bodypart/r_leg/robot
 	name = "cyborg right leg"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
-	attack_verb = list("kicked", "stomped")
+	attack_verb_continuous = list("kicks", "stomps")
+	attack_verb_simple = list("kick", "stomp")
 	item_state = "buildpipe"
 	icon = 'icons/mob/augmentation/augments.dmi'
 	flags_1 = CONDUCT_1

--- a/code/modules/surgery/nutcracker.dm
+++ b/code/modules/surgery/nutcracker.dm
@@ -6,7 +6,8 @@
 	force = 10
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("smashed", "beaten", "crushed")
+	attack_verb_continuous = list("smashs", "beats", "crushs")
+	attack_verb_simple = list("smash", "beat", "crush")
 
 /obj/item/nutcracker/proc/gib_head(mob/living/carbon/M)
 	var/obj/item/bodypart/head = M.get_bodypart("head")

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -17,7 +17,8 @@
 	var/beating = 1
 	var/no_pump = FALSE
 	var/icon_base = "heart"
-	attack_verb = list("beat", "thumped")
+	attack_verb_continuous = list("beats", "thumps")
+	attack_verb_simple = list("beat", "thump")
 	var/beat = BEAT_NONE//is this mob having a heatbeat sound played? if so, which?
 
 	var/failed = FALSE		//to prevent constantly running failing code

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -4,7 +4,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_STOMACH
-	attack_verb = list("gored", "squished", "slapped", "digested")
+	attack_verb_continuous = list("gores", "squishes", "slaps", "digests")
+	attack_verb_simple = list("gore", "squish", "slap", "digest")
 	desc = "Onaka ga suite imasu."
 	var/disgust_metabolism = 1
 

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -6,7 +6,8 @@
 	icon_state = "tonguenormal"
 	zone = BODY_ZONE_PRECISE_MOUTH
 	slot = ORGAN_SLOT_TONGUE
-	attack_verb = list("licked", "slobbered", "slapped", "frenched", "tongued")
+	attack_verb_continuous = list("licks", "slobbers", "slaps", "frenches", "tongues")
+	attack_verb_simple = list("lick", "slobber", "slap", "french", "tongue")
 	var/list/languages_possible
 	var/say_mod = null
 	var/taste_sensitivity = 15 // lower is more sensitive.
@@ -177,7 +178,8 @@
 	icon_state = "tonguebone"
 	say_mod = "rattles"
 	organ_flags = ORGAN_NO_SPOIL
-	attack_verb = list("bitten", "chattered", "chomped", "enamelled", "boned")
+	attack_verb_continuous = list("bites", "chatters", "chomps", "enamelles", "bones")
+	attack_verb_simple = list("bite", "chatter", "chomp", "enamel", "bone")
 	taste_sensitivity = 101 // skeletons cannot taste anything
 	maxHealth = 75 //Take brute damage instead
 	var/chattering = FALSE
@@ -215,7 +217,8 @@
 	organ_flags = ORGAN_NO_SPOIL
 	icon_state = "tonguerobot"
 	say_mod = "states"
-	attack_verb = list("beeped", "booped")
+	attack_verb_continuous = list("beeps", "boops")
+	attack_verb_simple = list("beep", "boop")
 	initial_accents = list(/datum/accent/span/robot)
 	taste_sensitivity = 25 // not as good as an organic tongue
 	maxHealth = 100 //RoboTongue!
@@ -260,7 +263,8 @@
 	desc = "A sophisticated ethereal organ, capable of synthesising speech via electrical discharge."
 	icon_state = "electrotongue"
 	say_mod = "crackles"
-	attack_verb = list("shocked", "jolted", "zapped")
+	attack_verb_continuous = list("shocks", "jolts", "zaps")
+	attack_verb_simple = list("shock", "jolt", "zap")
 	taste_sensitivity = 101 // Not a tongue, they can't taste shit
 	var/static/list/languages_possible_ethereal = typecacheof(list(
 		/datum/language/common,

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -65,7 +65,8 @@
 	item_flags = SURGICAL_TOOL
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("attacked", "pinched")
+	attack_verb_continuous = list("attacks", "pinchs")
+	attack_verb_simple = list("attack", "pinch")
 	tool_behaviour = TOOL_HEMOSTAT
 	toolspeed = 1
 
@@ -82,7 +83,8 @@
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
 	toolspeed = 0.5
-	attack_verb = list("attacked", "pinched")
+	attack_verb_continuous = list("attacks", "pinchs")
+	attack_verb_simple = list("attack", "pinch")
 
 /obj/item/hemostat/ashwalker
 	name = "femurstat"
@@ -103,7 +105,8 @@
 	item_flags = SURGICAL_TOOL
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("burnt")
+	attack_verb_continuous = list("burns")
+	attack_verb_simple = list("burn")
 	tool_behaviour = TOOL_CAUTERY
 	toolspeed = 1
 	heat = 3500
@@ -121,7 +124,8 @@
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
 	toolspeed = 0.5
-	attack_verb = list("burnt")
+	attack_verb_continuous = list("burns")
+	attack_verb_simple = list("burn")
 
 /obj/item/cautery/ashwalker
 	name = "coretery"
@@ -143,7 +147,8 @@
 	flags_1 = CONDUCT_1
 	force = 15
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("drilled")
+	attack_verb_continuous = list("drills")
+	attack_verb_simple = list("drill")
 	tool_behaviour = TOOL_DRILL
 	toolspeed = 1
 
@@ -188,7 +193,8 @@
 	force = 10
 	w_class = WEIGHT_CLASS_SMALL
 	toolspeed = 0.5
-	attack_verb = list("drilled")
+	attack_verb_continuous = list("drills")
+	attack_verb_simple = list("drill")
 
 /obj/item/scalpel
 	name = "scalpel"
@@ -205,7 +211,8 @@
 	throw_range = 5
 	custom_materials = list(/datum/material/iron=4000, /datum/material/glass=1000)
 	item_flags = SURGICAL_TOOL
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashs", "stabs", "slices", "tears", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "rip", "dice", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_POINTY
 	tool_behaviour = TOOL_SCALPEL
@@ -266,7 +273,8 @@
 	throw_speed = 3
 	throw_range = 5
 	custom_materials = list(/datum/material/iron=4000, /datum/material/glass=1000)
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashs", "stabs", "slices", "tears", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "rip", "dice", "cut")
 	toolspeed = 0.5
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_POINTY
@@ -300,7 +308,8 @@
 	throw_speed = 2
 	throw_range = 5
 	custom_materials = list(/datum/material/iron=10000, /datum/material/glass=6000)
-	attack_verb = list("attacked", "slashed", "sawed", "cut")
+	attack_verb_continuous = list("attacks", "slashs", "saws", "cuts")
+	attack_verb_simple = list("attack", "slash", "saw", "cut")
 	sharpness = SHARP_EDGED
 	tool_behaviour = TOOL_SAW
 	toolspeed = 1
@@ -330,7 +339,8 @@
 	throw_range = 5
 	custom_materials = list(/datum/material/iron=10000, /datum/material/glass=6000)
 	toolspeed = 0.5
-	attack_verb = list("attacked", "slashed", "sawed", "cut")
+	attack_verb_continuous = list("attacks", "slashs", "saws", "cuts")
+	attack_verb_simple = list("attack", "slash", "saw", "cut")
 	sharpness = SHARP_EDGED
 
 /obj/item/circular_saw/ashwalker
@@ -347,7 +357,8 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "surgical_drapes"
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("slapped")
+	attack_verb_continuous = list("slapped")
+	attack_verb_simple = list("slapped")
 
 /obj/item/surgical_drapes/attack(mob/living/M, mob/user)
 	if(!attempt_initiate_surgery(src, M, user))
@@ -463,7 +474,8 @@
 	flags_1 = CONDUCT_1
 	item_flags = SURGICAL_TOOL
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("corrected", "properly set")
+	attack_verb_continuous = list("corrects", "properly sets")
+	attack_verb_simple = list("correct", "properly set")
 	tool_behaviour = TOOL_BONESET
 	toolspeed = 1
 

--- a/modular_citadel/code/modules/custom_loadout/custom_items.dm
+++ b/modular_citadel/code/modules/custom_loadout/custom_items.dm
@@ -38,7 +38,8 @@
 	item_state = "darksabre"
 	lefthand_file = 'modular_citadel/icons/mob/inhands/stunsword_left.dmi'
 	righthand_file = 'modular_citadel/icons/mob/inhands/stunsword_right.dmi'
-	attack_verb = list("attacked", "struck", "hit")
+	attack_verb_continuous = list("attacks", "strucks", "hits")
+	attack_verb_simple = list("attack", "struck", "hit")
 
 /obj/item/toy/darksabre/get_belt_overlay()
 	return mutable_appearance('icons/obj/custom.dmi', "darksheath-darksabre")
@@ -115,7 +116,8 @@
 	icon_state = "carrot"
 	item_state = "carrot"
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("slapped")
+	attack_verb_continuous = list("slaps")
+	attack_verb_simple = list("slap")
 	resistance_flags = FLAMMABLE
 	squeak_override = list('sound/items/bikehorn.ogg'= 1)
 
@@ -148,7 +150,8 @@
 	icon_state = "pine_c"
 	item_state = "pine_c"
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("slapped")
+	attack_verb_continuous = list("slaps")
+	attack_verb_simple = list("slap")
 	resistance_flags = FLAMMABLE
 	squeak_override = list('sound/misc/server-ready.ogg'= 1)
 
@@ -548,7 +551,8 @@
 	icon = 'icons/obj/custom.dmi'
 	icon_state = "fritz"
 	item_state = "fritz"
-	attack_verb = list("barked", "boofed", "shotgun'd")
+	attack_verb_continuous = list("barks", "boofs", "shotgun'ns")
+	attack_verb_simple = list("barks", "boof", "shotgun'n")
 	obj_flags = UNIQUE_RENAME
 	unique_reskin = list(
 		"Goodboye" = list("icon_state" = "fritz"),

--- a/modular_citadel/code/modules/eventmaps/Spookystation/JTGSZwork.dm
+++ b/modular_citadel/code/modules/eventmaps/Spookystation/JTGSZwork.dm
@@ -1078,7 +1078,8 @@ GLOBAL_LIST_INIT(hay_recipes, list ( \
 	throw_speed = 1
 	throw_range = 2
 	max_amount = 500
-	attack_verb = list("tickled", "poked", "whipped")
+	attack_verb_continuous = list("tickles", "pokes", "whips")
+	attack_verb_simple = list("tickle", "poke", "whip")
 	hitsound = 'sound/weapons/grenadelaunch.ogg'
 
 /obj/item/stack/sheet/hay/Initialize(mapload, new_amount, merge = TRUE)

--- a/modular_sand/code/game/objects/items/cosmetics.dm
+++ b/modular_sand/code/game/objects/items/cosmetics.dm
@@ -57,7 +57,8 @@
 	throw_speed = 3
 	throw_range = 6
 	hitsound = 'sound/weapons/genhit.ogg'
-	attack_verb = list("stubbed", "poked")
+	attack_verb_continuous = list("stubs", "pokes")
+	attack_verb_simple = list("stub", "poke")
 	extended = 0
 	var/extended_force = 17 //I decided to not add bleeding but because of that, but increased damage, wounds will kill the guy pretty quickly anyways
 	var/extended_throwforce = 10
@@ -75,7 +76,8 @@
 		w_class = WEIGHT_CLASS_SMALL //if it becomes normal you can decapitate a guy with a straight razor
 		throwforce = extended_throwforce
 		icon_state = extended_icon_state
-		attack_verb = list("slashed", "stabbed", "sliced", "slit", "shaved", "diced", "cut")
+		attack_verb_continuous = list("slashs", "stabs", "slices", "slits", "shaves", "dices", "cuts")
+		attack_verb_simple = list("slash", "stab", "slice", "slit", "shave", "dice", "cut")
 		hitsound = 'sound/weapons/bladeslice.ogg'
 		sharpness = SHARP_EDGED
 		tool_behaviour = TOOL_SCALPEL
@@ -84,7 +86,8 @@
 		w_class = WEIGHT_CLASS_TINY
 		throwforce = initial(throwforce)
 		icon_state = initial(icon_state)
-		attack_verb = list("stubbed", "poked")
+		attack_verb_continuous = list("stubs", "pokes")
+		attack_verb_simple = list("stub", "poke")
 		hitsound = 'sound/weapons/genhit.ogg'
 		sharpness = SHARP_NONE
 		tool_behaviour = null

--- a/modular_sand/code/game/objects/items/plushes/goat_boss.dm
+++ b/modular_sand/code/game/objects/items/plushes/goat_boss.dm
@@ -71,7 +71,8 @@
 	icon_state = "kinggoat"
 	throwforce = 8
 	force = 8
-	attack_verb = list("chomped")
+	attack_verb_continuous = list("chomps")
+	attack_verb_simple = list("chomp")
 	gender = MALE
 
 /obj/item/toy/plush/goatplushie/angry/kinggoat/ascendedkinggoat

--- a/modular_sand/code/modules/clothing/wrists/_wrists.dm
+++ b/modular_sand/code/modules/clothing/wrists/_wrists.dm
@@ -9,6 +9,7 @@
 	siemens_coefficient = 0.5
 	body_parts_covered = HANDS
 	slot_flags = ITEM_SLOT_WRISTS
-	attack_verb = list("slapped on the wrist")
+	attack_verb_continuous = list("slaps on the wrist")
+	attack_verb_simple = list("slap on the wrist")
 	strip_delay = 20
 	equip_delay_other = 40

--- a/modular_sand/code/modules/clothing/wrists/watches.dm
+++ b/modular_sand/code/modules/clothing/wrists/watches.dm
@@ -5,7 +5,8 @@
 	icon_state = "clockwork_slab"
 	item_state = "clockwork_slab"
 	body_parts_covered = HAND_LEFT | ARM_LEFT
-	attack_verb = list("showed the time to")
+	attack_verb_continuous = list("shows the time to")
+	attack_verb_simple = list("show the time to")
 
 /obj/item/clothing/wrists/clockwork_watch/examine(mob/user)
 	. = ..()

--- a/modular_sand/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/modular_sand/code/modules/mining/equipment/kinetic_crusher.dm
@@ -324,7 +324,8 @@
 	armour_penetration = 20
 	custom_materials = list(/datum/material/titanium=3150, /datum/material/glass=2075, /datum/material/gold=3000, /datum/material/diamond=5000)
 	hitsound = 'modular_sand/sound/weapons/zweihanderslice.ogg'
-	attack_verb = list("smashed", "crushed", "cleaved", "chopped", "pulped")
+	attack_verb_continuous = list("smashs", "crushs", "cleaves", "chops", "pulps")
+	attack_verb_simple = list("smash", "crush", "cleave", "chop", "pulp")
 	sharpness = SHARP_EDGED
 	var/list/trophies = list()
 	var/charged = TRUE

--- a/modular_sand/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/modular_sand/code/modules/mining/lavaland/necropolis_chests.dm
@@ -212,7 +212,8 @@
 	var/hitsound_on = 'sound/weapons/bladeslice.ogg'
 	armour_penetration = 50
 	light_color = "#ff0000"//BLOOD RED
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "rip", "dice", "cut")
 	block_chance = 0
 	var/block_chance_on = 50
 	max_integrity = 400
@@ -941,7 +942,8 @@
 	block_chance = 20 //again, slight buff
 	armour_penetration = 200 //the armor penetration is really what makes this unique and actually worth it so boomp it
 	hitsound = 'modular_sand/sound/sif/sif_slash.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut", "gutted", "gored")
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts", "guts", "gores")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "rip", "dice", "cut", "gut", "gore")
 	sharpness = SHARP_EDGED
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
@@ -1089,7 +1091,8 @@
 	custom_materials = list(/datum/material/diamond=10000, /datum/material/titanium=20000, /datum/material/plasma=20000)
 	usesound = 'sound/weapons/drill.ogg'
 	hitsound = 'sound/weapons/drill.ogg'
-	attack_verb = list("drilled")
+	attack_verb_continuous = list("drills")
+	attack_verb_simple = list("drill")
 	var/cooldowntime = 50
 	var/cooldown = 0
 	var/digrange = 7

--- a/modular_sand/code/modules/misc/misc.dm
+++ b/modular_sand/code/modules/misc/misc.dm
@@ -9,7 +9,8 @@
 	throw_speed = 5
 	throw_range = 20
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("hit")
+	attack_verb_continuous = list("hits")
+	attack_verb_simple = list("hit")
 	hitsound = 'sound/weapons/smash.ogg'
 
 /obj/item/misc/potato/examine_more(mob/user)

--- a/modular_sand/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/fanaticminer.dm
+++ b/modular_sand/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/fanaticminer.dm
@@ -238,7 +238,8 @@
 	lefthand_file = 'modular_sand/icons/mob/inhands/weapons/axes_lefthand.dmi'
 	righthand_file = 'modular_sand/icons/mob/inhands/weapons/axes_righthand.dmi'
 	item_state = "diamondaxe"
-	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("slashs", "slices", "tears", "rips", "dices", "cuts")
+	attack_verb_simple = list("slash", "slice", "tear", "rip", "dice", "cut")
 	w_class = WEIGHT_CLASS_BULKY
 	force = 20
 	throwforce = 18

--- a/modular_splurt/code/game/objects/items/holy_weapons.dm
+++ b/modular_splurt/code/game/objects/items/holy_weapons.dm
@@ -8,7 +8,8 @@
 	righthand_file = 'modular_splurt/icons/mob/inhands/weapons/melee_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("smacked", "struck", "cracked", "beaten")
+	attack_verb_continuous = list("smacks", "strucks", "cracks", "beats")
+	attack_verb_simple = list("smack", "struck", "crack", "beat")
 
 /obj/item/nullrod/papal_staff
 	name = "papal staff"
@@ -19,7 +20,8 @@
 	lefthand_file = 'modular_splurt/icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'modular_splurt/icons/mob/inhands/weapons/melee_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("smacked", "struck", "cracked", "beaten", "purified")
+	attack_verb_continuous = list("smacks", "struck", "cracks", "beats", "purifies")
+	attack_verb_simple = list("smack", "struck", "crack", "beat", "purify")
 
 /obj/item/clothing/head/mitre
 	name = "papal mitre"

--- a/modular_splurt/code/game/objects/items/plaguedoc.dm
+++ b/modular_splurt/code/game/objects/items/plaguedoc.dm
@@ -58,7 +58,8 @@
 	throw_speed = 3
 	throw_range = 7
 	toolspeed = 1
-	attack_verb = list("attacked", "slashed", "sawed", "cut")
+	attack_verb_continuous = list("attacks", "slashs", "saws", "cuts")
+	attack_verb_simple = list("attack", "slash", "saw", "cut")
 	sharpness = SHARP_EDGED
 
 /obj/item/storage/backpack/docbag
@@ -113,4 +114,5 @@
 	throwforce = 5
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=50)
-	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed")
+	attack_verb_continuous = list("bludgeones", "whacks", "disciplines", "thrashs")
+	attack_verb_simple = list("bludgeone", "whack", "discipline", "thrash")

--- a/modular_splurt/code/game/objects/items/plushes.dm
+++ b/modular_splurt/code/game/objects/items/plushes.dm
@@ -4,7 +4,8 @@
 	icon = 'modular_splurt/icons/obj/plushes.dmi'
 	icon_state = "chaotic_toaster"
 	item_state = "chaotic_toaster"
-	attack_verb = list("beeped", "booped", "pinged")
+	attack_verb_continuous = list("beeps", "boops", "pings")
+	attack_verb_simple = list("beep", "boop", "ping")
 	squeak_override = list('sound/machines/beep.ogg' = 1)
 
 /obj/item/toy/plush/Synth

--- a/modular_splurt/code/game/objects/items/weaponry.dm
+++ b/modular_splurt/code/game/objects/items/weaponry.dm
@@ -11,7 +11,8 @@
 	throwforce = 0
 	force = 5
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
+	attack_verb_continuous = list("flogs", "whips", "lashs", "disciplines")
+	attack_verb_simple = list("flog", "whip", "lash", "discipline")
 	hitsound = 'sound/weapons/whip.ogg'
 
 /obj/item/bdsm_whip/ridingcrop
@@ -28,7 +29,7 @@
 /obj/item/bdsm_whip/attack(mob/M, mob/user)
 	if(user.zone_selected == BODY_ZONE_PRECISE_GROIN)
 		playsound(loc, 'sound/weapons/whip.ogg', 30)
-		M.visible_message(span_userdanger("[user] has [pick(attack_verb)] [M] on the ass!"))
+		M.visible_message(span_userdanger("[user] has [pick(attack_verb_simple)] [M] on the ass!"))
 	else
 		return ..(M, user)
 
@@ -46,7 +47,8 @@
 	force = 30
 	throwforce = 10
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb_continuous = list("attacks", "slashs", "stabs", "slices", "tears", "rips", "dices", "cuts")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)

--- a/modular_splurt/code/game/objects/items/weaponry/armyknife.dm
+++ b/modular_splurt/code/game/objects/items/weaponry/armyknife.dm
@@ -9,7 +9,8 @@
 	throwforce = 3
 	throw_speed = 4
 	throw_range = 5
-	attack_verb = list("whacked")
+	attack_verb_continuous = list("whacks")
+	attack_verb_simple = list("whack")
 	hitsound = 'sound/weapons/genhit.ogg'
 	usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 
@@ -34,7 +35,8 @@
 	throwforce = 3
 	throw_speed = 4
 	throw_range = 5
-	attack_verb = list("stabbed", "screwed", "jabbed","whacked")
+	attack_verb_continuous = list("stabs", "screws", "jabs","whacks")
+	attack_verb_simple = list("stab", "screw", "jab","whack")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 	toolspeed = 1.1
@@ -63,7 +65,8 @@
 	throwforce = 3
 	throw_speed = 4
 	throw_range = 5
-	attack_verb = list("cut", "whacked")
+	attack_verb_continuous = list("cuts", "whacks")
+	attack_verb_simple = list("cut", "whack")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	toolspeed = 1.1
 
@@ -89,7 +92,8 @@
 	throw_speed = 4
 	throw_range = 5
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("stabbed", "slashed", "cut")
+	attack_verb_continuous = list("stabs", "slashs", "cuts")
+	attack_verb_simple = list("stab", "slash", "cut")
 
 /obj/item/armyknife/blade/attack_self(mob/user)
 	playsound(get_turf(user), 'sound/weapons/batonextend.ogg', 50, 1)

--- a/modular_splurt/code/modules/antagonists/wendigo/mob/organs_bodyparts.dm
+++ b/modular_splurt/code/modules/antagonists/wendigo/mob/organs_bodyparts.dm
@@ -36,23 +36,27 @@
 /obj/item/bodypart/l_arm/wendigo
 	dismemberable = FALSE
 	max_damage = INFINITY
-	attack_verb = list("slashed", "clawed", "mauled")
+	attack_verb_continuous = list("slashs", "claws", "mauls")
+	attack_verb_simple = list("slash", "claw", "maul")
 	animal_origin = WENDIGO_BODYPART
 
 /obj/item/bodypart/r_arm/wendigo
 	dismemberable = FALSE
 	max_damage = INFINITY
-	attack_verb = list("slashed", "clawed", "mauled")
+	attack_verb_continuous = list("slashs", "claws", "mauls")
+	attack_verb_simple = list("slash", "claw", "maul")
 	animal_origin = WENDIGO_BODYPART
 
 /obj/item/bodypart/l_leg/wendigo
 	dismemberable = FALSE
 	max_damage = INFINITY
-	attack_verb = list("pounded", "stomped", "stamped", "kicked")
+	attack_verb_continuous = list("pounds", "stomps", "stamps", "kicks")
+	attack_verb_simple = list("pound", "stomp", "stamp", "kick")
 	animal_origin = WENDIGO_BODYPART
 
 /obj/item/bodypart/r_leg/wendigo
 	dismemberable = FALSE
 	max_damage = INFINITY
-	attack_verb = list("pounded", "stomped", "stamped", "kicked")
+	attack_verb_continuous = list("pounds", "stomps", "stamps", "kicks")
+	attack_verb_simple = list("pound", "stomp", "stamp", "kick")
 	animal_origin = WENDIGO_BODYPART

--- a/modular_splurt/code/modules/arousal/toys/dildos.dm
+++ b/modular_splurt/code/modules/arousal/toys/dildos.dm
@@ -2,7 +2,8 @@
 	name 				= "bitch breaker"
 	desc 				= "You can barely carry this thing! Meant for... \"advanced\" interrogation techniques."
 	dildo_size 			= 5
-	attack_verb 		= list("penetrated", "slapped", "gaped", "prolapsed", "inseminated", "destroyed", "broke", "demolished", "whacked")
+	attack_verb_continuous 		= list("penetrates", "slaps", "gapes", "prolapses", "inseminates", "destroyes", "breaks", "demolishes", "whackes")
+	attack_verb_simple 		= list("penetrates", "slaps", "gapes", "prolapses", "inseminates", "destroyes", "break", "demolish", "whack")
 
 /obj/item/dildo/flared/gigantic/suicide_act(mob/living/user)
 	if(do_after(user,45,target=src))

--- a/modular_splurt/code/modules/cargo/packs/goodies.dm
+++ b/modular_splurt/code/modules/cargo/packs/goodies.dm
@@ -14,7 +14,8 @@
 	throw_range = 6
 	custom_materials = list(/datum/material/iron=1200)
 	hitsound = 'sound/weapons/genhit.ogg'
-	attack_verb = list("stubbed", "poked")
+	attack_verb_continuous = list("stubs", "pokes")
+	attack_verb_simple = list("stub", "poke")
 	resistance_flags = FIRE_PROOF
 	extended = 0
 
@@ -26,7 +27,8 @@
 		w_class = WEIGHT_CLASS_NORMAL
 		throwforce = 23
 		icon_state = "butterflyknife_open"
-		attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+		attack_verb_continuous = list("slashs", "stabs", "slices", "tears", "rips", "dice", "cuts")
+		attack_verb_simple = list("slash", "stab", "slice", "tear", "rip", "dice", "cut")
 		hitsound = 'sound/weapons/bladeslice.ogg'
 		sharpness = SHARP_EDGED
 	else
@@ -34,7 +36,8 @@
 		w_class = WEIGHT_CLASS_SMALL
 		throwforce = 5
 		icon_state = "butterflyknife"
-		attack_verb = list("stubbed", "poked")
+		attack_verb_continuous = list("stubs", "pokes")
+		attack_verb_simple = list("stub", "poke")
 		hitsound = 'sound/weapons/genhit.ogg'
 		sharpness = SHARP_NONE
 

--- a/modular_splurt/code/modules/cargo/sweatshop/sweatshop.dm
+++ b/modular_splurt/code/modules/cargo/sweatshop/sweatshop.dm
@@ -14,7 +14,8 @@
 	sharpness = TRUE
 	w_class = WEIGHT_CLASS_HUGE
 	custom_materials = list(/datum/material/iron=50)
-	attack_verb = list("slashed", "sawed")
+	attack_verb_continuous = list("slashes", "saws")
+	attack_verb_simple = list("slash", "saw")
 
 /obj/item/carpentry/hammer
 	name = "hammer"
@@ -25,7 +26,8 @@
 	sharpness = FALSE
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=100)
-	attack_verb = list("bonked", "nailed")
+	attack_verb_continuous = list("bonks", "nails")
+	attack_verb_simple = list("bonk", "nail")
 
 /obj/item/carpentry/glue
 	name = "glue"
@@ -35,7 +37,8 @@
 	sharpness = FALSE
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/plastic=25)
-	attack_verb = list("glued", "coughed")
+	attack_verb_continuous = list("glues", "coughs")
+	attack_verb_simple = list("glue", "cough")
 
 /obj/item/carpentry/borer
 	name = "manual borer"
@@ -45,7 +48,8 @@
 	sharpness = TRUE
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=25)
-	attack_verb = list("bored", "drilled")
+	attack_verb_continuous = list("bores", "drills")
+	attack_verb_simple = list("bore", "drill")
 
 /obj/item/carpentry/sandpaper
 	name = "sandpaper strip"
@@ -55,7 +59,8 @@
 	sharpness = FALSE
 	w_class = WEIGHT_CLASS_TINY
 	custom_materials = list(/datum/material/glass=1) //lmao
-	attack_verb = list("sanded", "licked")
+	attack_verb_continuous = list("sands", "licks")
+	attack_verb_simple = list("sand", "lick")
 
 /obj/item/nails
 	name = "metal nails"
@@ -66,7 +71,8 @@
 	sharpness = TRUE
 	w_class = WEIGHT_CLASS_TINY
 	custom_materials = list(/datum/material/iron=10)
-	attack_verb = list("nailed", "screwed")
+	attack_verb_continuous = list("nails", "screws")
+	attack_verb_simple = list("nail", "screw")
 
 /obj/item/cushion
 	name = "basic cushion"
@@ -76,7 +82,8 @@
 	force = 0
 	sharpness = FALSE
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("thomped", "thwacked")
+	attack_verb_continuous = list("thomps", "thwacks")
+	attack_verb_simple = list("thomp", "thwack")
 
 /obj/item/cushion/silk
 	name = "silk cushion"

--- a/modular_splurt/code/modules/cargo/sweatshop/wooden.dm
+++ b/modular_splurt/code/modules/cargo/sweatshop/wooden.dm
@@ -5,7 +5,8 @@
 	desc = "You shouldn't see this!"
 	icon = 'modular_splurt/icons/obj/cargo/sweatshop/wooden.dmi'
 	sharpness = FALSE
-	attack_verb = list("slapped", "thunked")
+	attack_verb_continuous = list("slaps", "thunks")
+	attack_verb_simple = list("slap", "thunk")
 	var/sawobj = /obj/item/genital_equipment/condom
 	var/glueobj = /obj/item/dildo
 	var/sandobj = /obj/item/carpentry/sandpaper
@@ -43,7 +44,8 @@
 	icon_state = "peg"
 	force = 1
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("donked", "thunked")
+	attack_verb_continuous = list("donks", "thunks")
+	attack_verb_simple = list("donk", "thunk")
 	glueobj = /obj/item/processed/wood/gluepeg
 
 //glue
@@ -54,15 +56,18 @@
 	icon_state = "gluepeg"
 	force = 1
 	w_class = WEIGHT_CLASS_TINY
-	attack_verb = list("pegged", "thunked")
+	attack_verb_continuous = list("pegs", "thunks")
+	attack_verb_simple = list("peg", "thunk")
 
 /obj/item/processed/wood/glueblock
 	name = "glued wood block"
 	desc = "A wooden block. With a bunch of glue used for securing."
 	icon_state = "glueblock"
+	icon_state = "glueblock"
 	force = 2
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("blocked", "thunked")
+	attack_verb_continuous = list("blocks", "thunks")
+	attack_verb_simple = list("block", "thunk")
 
 //seat
 /obj/item/processed/wood/seat
@@ -71,7 +76,8 @@
 	icon_state = "seat"
 	force = 2
 	w_class = WEIGHT_CLASS_SMALL
-	attack_verb = list("slapped", "thunked")
+	attack_verb_continuous = list("slaps", "thunks")
+	attack_verb_simple = list("slap", "thunk")
 
 
 //Stool steps. There's probably an easier way to do this, but I cannot be assed rn, I'll refine after PR

--- a/modular_splurt/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
@@ -19,14 +19,16 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 	desc = "The jaws of the law. Very sharp."
 	icon_state = "jaws_2"
 	force = 10 //Lowered to match secborg. No reason it should be more than a secborg's baton.
-	attack_verb = list("chomped", "bit", "ripped", "mauled", "enforced")
+	attack_verb_continuous = list("chomps", "bites", "rips", "mauls", "enforces")
+	attack_verb_simple = list("chomp", "bite", "rip", "maule", "enforce")
 
 /obj/item/dogborg/jaws/small
 	name = "puppy jaws"
 	desc = "Rubberized teeth designed to protect accidental harm. Sharp enough for specialized tasks however."
 	icon_state = "jaws_2"
 	force = 6
-	attack_verb = list("nibbled", "bit", "gnawed", "chomped", "nommed")
+	attack_verb_continuous = list("nibbles", "bites", "gnawes", "chomps", "noms")
+	attack_verb_simple = list("nibble", "bite", "gnawe", "chomp", "nom")
 	var/status = 0
 
 /obj/item/dogborg/jaws/attack(atom/A, mob/living/silicon/robot/user)
@@ -41,7 +43,8 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 			icon_state = "jaws"
 			desc = "The jaws of the law."
 			force = 12
-			attack_verb = list("chomped", "bit", "ripped", "mauled", "enforced")
+			attack_verb_continuous = list("chomps", "bites", "rips", "mauls", "enforces")
+			attack_verb_simple = list("chomp", "bite", "rip", "maul", "enforce")
 			status = 1
 			to_chat(user, span_notice("Your jaws are now [status ? "Combat" : "Pup'd"]."))
 		else
@@ -49,7 +52,8 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 			icon_state = "smalljaws"
 			desc = "The jaws of a small dog."
 			force = 5
-			attack_verb = list("nibbled", "bit", "gnawed", "chomped", "nommed")
+			attack_verb_continuous = list("nibbles", "bites", "gnawes", "chomps", "noms")
+			attack_verb_simple = list("nibble", "bite", "gnawe", "chomp", "nom")
 			status = 0
 			if(R.emagged)
 				to_chat(user, span_notice("Your jaws are now [status ? "Combat" : "Pup'd"]."))
@@ -65,7 +69,8 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 	flags_1 = CONDUCT_1
 	force = 0
 	throwforce = 0
-	attack_verb = list("nuzzles", "pushes", "boops")
+	attack_verb_continuous = list("nuzzles", "pushes", "boops")
+	attack_verb_simple = list("nuzzle", "push", "boop")
 	w_class = 1
 
 /obj/item/analyzer/nose/attack_self(mob/user)
@@ -127,7 +132,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 	if(!proximity)
 		return
 	do_attack_animation(target, null, src)
-	user.visible_message(span_notice("[user] [pick(attack_verb)] \the [target.name] with their nose!"))
+	user.visible_message(span_notice("[user] [pick(attack_verb_simple)] \the [target.name] with their nose!"))
 
 //Delivery
 /obj/item/storage/bag/borgdelivery

--- a/modular_splurt/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/modular_splurt/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -158,7 +158,8 @@
 	throw_speed = 3
 	throw_range = 6
 	hitsound = 'sound/weapons/genhit.ogg'
-	attack_verb = list("stubbed", "poked")
+	attack_verb_continuous = list("stubs", "pokes")
+	attack_verb_simple = list("stub", "poke")
 	resistance_flags = NONE
 
 /obj/item/gunpart/pistol22frame

--- a/modular_splurt/code/modules/surgery/organs/augments_arms.dm
+++ b/modular_splurt/code/modules/surgery/organs/augments_arms.dm
@@ -23,7 +23,8 @@
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_BULKY
 	sharpness = SHARP_POINTY
-	attack_verb = list("slashed", "cut")
+	attack_verb_continuous = list("slashs", "cuts")
+	attack_verb_simple = list("slash", "cut")
 
 // Synth power cord interaction override
 /obj/item/apc_powercord/afterattack(atom/target, mob/user, proximity_flag, click_parameters)


### PR DESCRIPTION
# About The Pull Request

Adds more "personalized" combat messages for all participants in a fight: the attacker, the victim and the spectators. This ports in both part 1 and 2 to a extent, light amounts of part 1 due to a few errors being worked on and most of part 2 that is applicable to splurts current code.

How people see messages involving combat right now:
![64606066-13c65700-d3ce-11e9-8a80-037fb2091910](https://user-images.githubusercontent.com/51891267/235596910-e7ecd8bb-168f-4bb0-80ba-24057e1f7786.png)
How people would see messages involving combat after:
![90008909-c7525e00-dca5-11ea-9b95-02c2b009f5f9](https://user-images.githubusercontent.com/51891267/235597033-931b34c5-34bf-4cda-9577-6717f0f93cb4.png)


## Why It's Good For The Game

Not only will this give more clarity when actions are done from one individual to another, this will also help with upstream porting, due to most if not all of skyrat and TG code having Action_Verb_Continuous = ("A", "B", "C") & Action_Verb_Simple = ("A", "B", "C"), this will help with implementation of items as well without needing to do too many code changes. 

Also for clarification, I know there may be errors/indescrepencies when doing actions to another person/s, however, due to the size of this code as is and my limited knowledge on SS13 coding, I will attempt to do fixes, further implementation, and grammar checks to help ease things but as of now I have full confidence this WILL properly work as intended. This is mainly due to the great difference in Splurt being old code and TG-mainstream constantly changing. However, if the moderators are a bit more hesitant to merge, Id like to suggest a potential Test Merge, to see if the code is to the liking of the people.

## A Port?

Skyrat:
https://github.com/Skyrat-SS13/Skyrat-tg/pull/334

TG-Main:
Pt1: https://github.com/tgstation/tgstation/pull/46388
Pt2: https://github.com/tgstation/tgstation/pull/52890
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
config: changes a heavy amount of items and player interactions from Advert_Verb to Advert_Verb_Continuous & Advert_Verb_Simple.
expansion: expands the item interaction with players.
qol: allows players to have clarification and developers to have better managing of ports.
/:cl: