### PR TITLE
Adds decker headphones to the loadout selection.

### DIFF
--- a/modular_splurt/code/modules/client/loadout/head.dm
+++ b/modular_splurt/code/modules/client/loadout/head.dm
@@ -77,3 +77,10 @@
 	cost = 2
 	path = /obj/item/reagent_containers/food/snacks/grown/poppy/geranium
 	loadout_flags = LOADOUT_CAN_NAME | LOADOUT_CAN_DESCRIPTION
+
+/datum/gear/head/deckers
+	name = "Decker Headphones"
+	description = "A sweet pair of headphones."
+	cost = 2
+	path = /obj/item/clothing/head/deckers
+	loadout_flags = LOADOUT_CAN_NAME | LOADOUT_CAN_DESCRIPTION


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

Adds the decker headphones to the loadout selection (head slot).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Decker headphones are cool and some people (like me) might want to spawn with and customize them.

## A Port?

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

Not a port.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
add: Adds decker headphones to the loadout selection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
