### PR TITLE
Pins can now be removed again

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -373,6 +373,7 @@
 		constantly trying to mentally probe you."
 	fail_message = "<span class='abductor'>\
 		Firing error, please contact Command.</span>"
+	pin_removeable = FALSE
 
 /obj/item/firing_pin/abductor/pin_auth(mob/living/user)
 	. = isabductor(user)

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -373,7 +373,6 @@
 		constantly trying to mentally probe you."
 	fail_message = "<span class='abductor'>\
 		Firing error, please contact Command.</span>"
-	pin_removeable = FALSE
 
 /obj/item/firing_pin/abductor/pin_auth(mob/living/user)
 	. = isabductor(user)

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -202,7 +202,7 @@
 /obj/item/firing_pin/holy
 	name = "blessed pin"
 	desc = "A firing pin that only responds to those who are holier than thou."
-	pin_removeable = TRUE
+	pin_removeable = FALSE
 
 /obj/item/firing_pin/holy/pin_auth(mob/living/user)
 	if(user.mind.isholy)
@@ -216,6 +216,7 @@
 	fail_message = "<span class='warning'>SUIT CHECK FAILED.</span>"
 	var/obj/item/clothing/suit/suit_requirement = null
 	var/tagcolor = ""
+	pin_removeable = FALSE
 
 /obj/item/firing_pin/tag/pin_auth(mob/living/user)
 	if(ishuman(user))
@@ -245,6 +246,7 @@
 	var/max_sec_level = SEC_LEVEL_DELTA
 	var/only_lethals = FALSE
 	var/can_toggle = TRUE
+	pin_removeable = TRUE
 
 /obj/item/firing_pin/security_level/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -202,7 +202,7 @@
 /obj/item/firing_pin/holy
 	name = "blessed pin"
 	desc = "A firing pin that only responds to those who are holier than thou."
-	pin_removeable = FALSE
+	pin_removeable = TRUE
 
 /obj/item/firing_pin/holy/pin_auth(mob/living/user)
 	if(user.mind.isholy)
@@ -216,7 +216,6 @@
 	fail_message = "<span class='warning'>SUIT CHECK FAILED.</span>"
 	var/obj/item/clothing/suit/suit_requirement = null
 	var/tagcolor = ""
-	pin_removeable = FALSE
 
 /obj/item/firing_pin/tag/pin_auth(mob/living/user)
 	if(ishuman(user))
@@ -246,7 +245,6 @@
 	var/max_sec_level = SEC_LEVEL_DELTA
 	var/only_lethals = FALSE
 	var/can_toggle = TRUE
-	pin_removeable = TRUE
 
 /obj/item/firing_pin/security_level/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -12,6 +12,7 @@
 	var/force_replace = 0 // Can forcefully replace other pins.
 	var/pin_removeable = 0 // Can be replaced by any pin.
 	var/obj/item/gun/gun
+	pin_removeable = TRUE
 
 /obj/item/firing_pin/Initialize(mapload, newloc)
 	. = ..()
@@ -79,6 +80,7 @@
 /obj/item/firing_pin/magic
 	name = "magic crystal shard"
 	desc = "A small enchanted shard which allows magical weapons to fire."
+	pin_removeable = FALSE
 
 // Test pin, works only near firing range.
 /obj/item/firing_pin/test_range
@@ -101,6 +103,7 @@
 	desc = "This is a security firing pin which only authorizes users who are implanted with a certain device."
 	fail_message = "<span class='warning'>IMPLANT CHECK FAILED.</span>"
 	var/obj/item/implant/req_implant = null
+	pin_removeable = TRUE
 
 /obj/item/firing_pin/implant/pin_auth(mob/living/user)
 	if(user)
@@ -114,12 +117,13 @@
 	desc = "This Security firing pin authorizes the weapon for only mindshield-implanted users."
 	icon_state = "firing_pin_loyalty"
 	req_implant = /obj/item/implant/mindshield
+	pin_removeable = TRUE
 
 /obj/item/firing_pin/implant/pindicate
 	name = "syndicate firing pin"
 	icon_state = "firing_pin_pindi"
 	req_implant = /obj/item/implant/weapons_auth
-
+	pin_removeable = TRUE
 
 
 // Honk pin, clown's joke item.
@@ -130,6 +134,7 @@
 	color = "#FFFF00"
 	fail_message = "<span class='warning'>HONK!</span>"
 	force_replace = TRUE
+	pin_removeable = FALSE
 
 /obj/item/firing_pin/clown/pin_auth(mob/living/user)
 	playsound(src, 'sound/items/bikehorn.ogg', 50, 1)
@@ -165,6 +170,7 @@
 	icon_state = "firing_pin_dna"
 	fail_message = "<span class='warning'>DNA CHECK FAILED.</span>"
 	var/unique_enzymes = null
+	pin_removeable = FALSE
 
 /obj/item/firing_pin/dna/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
@@ -191,10 +197,12 @@
 /obj/item/firing_pin/dna/dredd
 	desc = "This is a DNA-locked firing pin which only authorizes one user. Attempt to fire once to DNA-link. It has a small explosive charge on it."
 	selfdestruct = TRUE
+	pin_removeable = FALSE
 
 /obj/item/firing_pin/holy
 	name = "blessed pin"
 	desc = "A firing pin that only responds to those who are holier than thou."
+	pin_removeable = TRUE
 
 /obj/item/firing_pin/holy/pin_auth(mob/living/user)
 	if(user.mind.isholy)
@@ -319,6 +327,7 @@
 	desc = "A firing pin used by the austrailian defense force, retrofit to prevent weapon discharge on the station."
 	icon_state = "firing_pin_explorer"
 	fail_message = "<span class='warning'>CANNOT FIRE WHILE ON STATION, MATE!</span>"
+	pin_removeable = TRUE
 
 // This checks that the user isn't on the station Z-level.
 /obj/item/firing_pin/explorer/pin_auth(mob/living/user)


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

With the addition of the kaiju gun, some logic on firing pins were changed, and we goofed some stuff, so here's the fix~

## Why It's Good For The Game

Makes you remove certain firing pins, whoever a list of which pins cannot be removed follows: Kaiju, both DNA firing pins, Clown firing pins, Magic crystal (yes, thats a firing pin), Holy, Blue and Red team pins

## A Port?

Non

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
tweak: Fixed firing pins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
