### PR TITLE
OOC always visible

### DIFF
--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -32,6 +32,8 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		addendum = _addendum
 	show_on_naked = _show_on_naked
 	always_show = _always_show
+	if(flavor_name == "OOC Notes") //SPLURT EDIT make it so ooc notes are always visible
+		always_show = TRUE
 	can_edit = _edit
 	save_key = _save_key
 	examine_no_preview = _examine_no_preview

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -32,8 +32,6 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		addendum = _addendum
 	show_on_naked = _show_on_naked
 	always_show = _always_show
-	if(flavor_name == "OOC Notes") //SPLURT EDIT make it so ooc notes are always visible
-		always_show = TRUE
 	can_edit = _edit
 	save_key = _save_key
 	examine_no_preview = _examine_no_preview

--- a/modular_splurt/code/datums/elements/flavor_text.dm
+++ b/modular_splurt/code/datums/elements/flavor_text.dm
@@ -1,30 +1,4 @@
 /datum/element/flavor_text/Attach(datum/target, text = "", _name = "Flavor Text", _addendum, _max_len = MAX_FLAVOR_LEN, _always_show = FALSE, _edit = TRUE, _save_key, _examine_no_preview = FALSE, _show_on_naked)
-	. = ..()
-
-	if(. == ELEMENT_INCOMPATIBLE || !isatom(target)) //no reason why this shouldn't work on atoms too.
-		return ELEMENT_INCOMPATIBLE
-
-	if(_max_len)
-		max_len = _max_len
-	texts_by_atom[target] = copytext(text, 1, max_len)
-	if(_name)
-		flavor_name = _name
-	if(!isnull(addendum))
-		addendum = _addendum
-	show_on_naked = _show_on_naked
-	always_show = _always_show
-	if(flavor_name == "OOC Notes")
+	if(flavor_name == "OOC Notes") //SPLURT EDIT make it so ooc notes are always visible
 		always_show = TRUE
-	can_edit = _edit
-	save_key = _save_key
-	examine_no_preview = _examine_no_preview
-
-	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/show_flavor)
-
-	if(can_edit && ismob(target)) //but only mobs receive the proc/verb for the time being
-		var/mob/M = target
-		LAZYOR(GLOB.mobs_with_editable_flavor_text[M], src)
-		add_verb(M, /mob/proc/manage_flavor_tests)
-
-	if(save_key && ishuman(target))
-		RegisterSignal(target, COMSIG_HUMAN_PREFS_COPIED_TO, .proc/update_prefs_flavor_text)
+	. = ..()

--- a/modular_splurt/code/datums/elements/flavor_text.dm
+++ b/modular_splurt/code/datums/elements/flavor_text.dm
@@ -1,0 +1,30 @@
+/datum/element/flavor_text/Attach(datum/target, text = "", _name = "Flavor Text", _addendum, _max_len = MAX_FLAVOR_LEN, _always_show = FALSE, _edit = TRUE, _save_key, _examine_no_preview = FALSE, _show_on_naked)
+	. = ..()
+
+	if(. == ELEMENT_INCOMPATIBLE || !isatom(target)) //no reason why this shouldn't work on atoms too.
+		return ELEMENT_INCOMPATIBLE
+
+	if(_max_len)
+		max_len = _max_len
+	texts_by_atom[target] = copytext(text, 1, max_len)
+	if(_name)
+		flavor_name = _name
+	if(!isnull(addendum))
+		addendum = _addendum
+	show_on_naked = _show_on_naked
+	always_show = _always_show
+	if(flavor_name == "OOC Notes")
+		always_show = TRUE
+	can_edit = _edit
+	save_key = _save_key
+	examine_no_preview = _examine_no_preview
+
+	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/show_flavor)
+
+	if(can_edit && ismob(target)) //but only mobs receive the proc/verb for the time being
+		var/mob/M = target
+		LAZYOR(GLOB.mobs_with_editable_flavor_text[M], src)
+		add_verb(M, /mob/proc/manage_flavor_tests)
+
+	if(save_key && ishuman(target))
+		RegisterSignal(target, COMSIG_HUMAN_PREFS_COPIED_TO, .proc/update_prefs_flavor_text)

--- a/modular_splurt/code/datums/elements/flavor_text.dm
+++ b/modular_splurt/code/datums/elements/flavor_text.dm
@@ -1,4 +1,5 @@
 /datum/element/flavor_text/Attach(datum/target, text = "", _name = "Flavor Text", _addendum, _max_len = MAX_FLAVOR_LEN, _always_show = FALSE, _edit = TRUE, _save_key, _examine_no_preview = FALSE, _show_on_naked)
+	. = ..()
 	if(flavor_name == "OOC Notes") //SPLURT EDIT make it so ooc notes are always visible
 		always_show = TRUE
-	. = ..()
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4378,6 +4378,7 @@
 #include "modular_splurt\code\datums\components\storage\concrete\pockets.dm"
 #include "modular_splurt\code\datums\elements\crawl_under.dm"
 #include "modular_splurt\code\datums\elements\mob_holder.dm"
+#include "modular_splurt\code\datums\elements\flavor_text.dm"
 #include "modular_splurt\code\datums\elements\smalltalk.dm"
 #include "modular_splurt\code\datums\elements\spooky.dm"
 #include "modular_splurt\code\datums\elements\wuv.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Makes OOC notes visible even when face is covered
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
Avoids pre-breaking problems 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
nope
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:

tweak: Modified flavor_text.dm to make OOC notes always visible

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
