### PR TITLE
(Almost) Any song in the jukebox, take two

### DIFF
--- a/code/controllers/subsystem/jukeboxes.dm
+++ b/code/controllers/subsystem/jukeboxes.dm
@@ -66,7 +66,7 @@ SUBSYSTEM_DEF(jukeboxes)
 
 
 //Updates jukebox by transferring to different object or modifying falloff.
-/datum/controller/subsystem/jukeboxes/proc/updatejukebox(IDtoupdate, obj/jukebox, jukefalloff) 
+/datum/controller/subsystem/jukeboxes/proc/updatejukebox(IDtoupdate, obj/jukebox, jukefalloff)
 	if(islist(activejukeboxes[IDtoupdate]))
 		if(istype(jukebox))
 			activejukeboxes[IDtoupdate][JUKE_BOX] = jukebox
@@ -95,6 +95,12 @@ SUBSYSTEM_DEF(jukeboxes)
 
 /datum/controller/subsystem/jukeboxes/Initialize()
 	var/list/tracks = flist("config/jukebox_music/sounds/")
+	//SPLURT EDIT
+	var/max_tracks = CONFIG_GET(number/max_jukebox_songs)
+	if(max_tracks >= 0)
+		while(tracks.len > max_tracks)
+			LAZYREMOVE(tracks, pick(tracks))
+	//SPLURT EDIT END
 	for(var/S in tracks)
 		var/datum/track/T = new()
 		T.song_path = file("config/jukebox_music/sounds/[S]")

--- a/config/splurt/general.txt
+++ b/config/splurt/general.txt
@@ -26,3 +26,8 @@ PROTOLOCK_ALL_ACCESS
 # Character color limits
 # Uncomment to disallow players from making characters with colors that are too dark
 CHARACTER_COLOR_LIMITS
+
+# Jukebox song limit
+# Max amount of songs that can be added to the jukebox each round.
+# -1 or comment to unlimit
+#MAX_JUKEBOX_SONGS -1

--- a/modular_splurt/code/controllers/configuration/entries/splurt_general.dm
+++ b/modular_splurt/code/controllers/configuration/entries/splurt_general.dm
@@ -13,3 +13,6 @@
 /datum/config_entry/flag/protolock_all_access
 
 /datum/config_entry/flag/character_color_limits
+
+/datum/config_entry/number/max_jukebox_songs
+	config_entry_value = -1


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
So, last time a more automated way of adding songs to the jukebox was attempted (https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/pull/891) it had unforseen consequences due to how byond's rsc system works. Most notably, these consequences were:
- Massive amounts of lag deep into the round
- RSC downloads eventually going past 600 mb
- frank sinatra fnaf 1 song being played every minute (very good song btw)

This attempts to make jukebox suggestions more optimized agan, but taking a different approach at it.
This pr works in tandem with https://github.com/SPLURT-Station/Mal0-cogs/pull/7, allowing players to suggest songs like they'd do with the suggestions command, and then letting admins review them and accept them if they feel those suggestions are good, or rejecting them otherwise.
On the game's side (this pr), there'll now be a config to limit the amount of songs the jukebox can load each round, if there's more songs than the limit allowed, it will randomly remove songs from the list to load until said list fits the limit, creating a song rotation of sorts each round. This is mostly to avoid the same issue we had last time with the rsc file bloating like hecc and causing lag.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
People want more songs in the jukebox, but no one wants more lag, so this is a middle ground in that regard. (hopefully)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
add: Now players can suggest songs to be automatically added to the jukebox (after being reviewed)
tweak: The amount of songs for jukeboxes can now be limited to avoid lag and issues
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
