### PR TITLE
Radfiend Adjustments

### DIFF
--- a/code/__SPLURTCODE/DEFINES/traits.dm
+++ b/code/__SPLURTCODE/DEFINES/traits.dm
@@ -42,5 +42,6 @@
 #define TRAIT_DUMB_CUM			"dumb_for_cum_base"
 #define TRAIT_DUMB_CUM_CRAVE	"dumb_for_cum_need"
 #define TRAIT_RAD_FIEND     	"RadFiend"
+#define TRAIT_COSGLOW			"cosmetic_glow"
 #define TRAIT_BODY_MORPHER		"body_morpher"
 #define TRAIT_HALLOWED			"hallowed"

--- a/modular_splurt/code/datums/traits/good.dm
+++ b/modular_splurt/code/datums/traits/good.dm
@@ -50,8 +50,8 @@
 
 /datum/quirk/rad_fiend
 	name = "Rad Fiend"
-	desc = "You've been blessed by Cherenkov's warming light, causing you to emit a subtle glow at all times. Only intense radiation is capable of penetrating your protective barrier."
-	value = 2
+	desc = "You've been blessed by Cherenkov's warming light, causing you to emit a subtle glow at all times. Only -very- intense radiation is capable of penetrating your protective barrier."
+	value = 4 //To balance for the fact it is, in essence, rad immunity.
 	mob_trait = TRAIT_RAD_FIEND
 	gain_text = span_notice("You feel empowered by Cherenkov's glow.")
 	lose_text = span_notice("You realize that rads aren't so rad.")
@@ -62,26 +62,9 @@
 /datum/quirk/rad_fiend/add()
 	// Define quirk holder mob
 	var/mob/living/carbon/human/quirk_mob = quirk_holder
-
-	// Check for any radiation immunity
-	if(HAS_TRAIT(quirk_mob, TRAIT_RADIMMUNE))
-		// Set gain status
-		can_gain = FALSE
-
-		// Return without doing anything
-		return
-
 	// Add glow control action
 	var/datum/action/rad_fiend/update_glow/quirk_action = new
 	quirk_action.Grant(quirk_mob)
-
-/datum/quirk/rad_fiend/post_add()
-	// Check if quirk effect was gained
-	if(can_gain)
-		return
-
-	// Alert quirk holder of gain status
-	to_chat(quirk_holder, span_warning("As you are immune to radiation, you were unable to gain Cherenkov's blessing. Please discuss alternatives with a medical professional."))
 
 /datum/quirk/rad_fiend/remove()
 	// Define quirk holder mob

--- a/modular_splurt/code/datums/traits/good.dm
+++ b/modular_splurt/code/datums/traits/good.dm
@@ -51,7 +51,7 @@
 /datum/quirk/rad_fiend
 	name = "Rad Fiend"
 	desc = "You've been blessed by Cherenkov's warming light, causing you to emit a subtle glow at all times. Only -very- intense radiation is capable of penetrating your protective barrier."
-	value = 4 //To balance for the fact it is, in essence, rad immunity.
+	value = 2 //Was commented to lower this.
 	mob_trait = TRAIT_RAD_FIEND
 	gain_text = span_notice("You feel empowered by Cherenkov's glow.")
 	lose_text = span_notice("You realize that rads aren't so rad.")

--- a/modular_splurt/code/datums/traits/good.dm
+++ b/modular_splurt/code/datums/traits/good.dm
@@ -51,7 +51,7 @@
 /datum/quirk/rad_fiend
 	name = "Rad Fiend"
 	desc = "You've been blessed by Cherenkov's warming light, causing you to emit a subtle glow at all times. Only -very- intense radiation is capable of penetrating your protective barrier."
-	value = 2 //Was commented to lower this.
+	value = 2
 	mob_trait = TRAIT_RAD_FIEND
 	gain_text = span_notice("You feel empowered by Cherenkov's glow.")
 	lose_text = span_notice("You realize that rads aren't so rad.")

--- a/modular_splurt/code/datums/traits/good.dm
+++ b/modular_splurt/code/datums/traits/good.dm
@@ -56,9 +56,6 @@
 	gain_text = span_notice("You feel empowered by Cherenkov's glow.")
 	lose_text = span_notice("You realize that rads aren't so rad.")
 
-	// Variable for the radiation immunity check
-	var/can_gain = TRUE
-
 /datum/quirk/rad_fiend/add()
 	// Define quirk holder mob
 	var/mob/living/carbon/human/quirk_mob = quirk_holder

--- a/modular_splurt/code/datums/traits/neutral.dm
+++ b/modular_splurt/code/datums/traits/neutral.dm
@@ -164,6 +164,33 @@
 			T.fluid_mult = 1.5 //Base is 0.133
 			T.fluid_max_volume = 5
 
+//You are a CIA agent.
+/datum/quirk/cosglow
+	name = "Cosmetic Glow"
+	desc = "You glow! Be it an obscure radiation emission, or simple Bioluminescent properties.."
+	value = 0
+	mob_trait = TRAIT_COSGLOW
+	gain_text = span_notice("You feel empowered by a three-letter agency!")
+	lose_text = span_notice("You realize that working for the space CIA sucks!")
+
+/datum/quirk/cosglow/add()
+	// Define quirk holder mob
+	var/mob/living/carbon/human/quirk_mob = quirk_holder
+	// Add glow control action
+	var/datum/action/cosglow/update_glow/quirk_action = new
+	quirk_action.Grant(quirk_mob)
+
+/datum/quirk/cosglow/remove()
+	// Define quirk holder mob
+	var/mob/living/carbon/human/quirk_mob = quirk_holder
+
+	// Remove glow control action
+	var/datum/action/cosglow/update_glow/quirk_action = locate() in quirk_mob.actions
+	quirk_action.Remove(quirk_mob)
+
+	// Remove glow effect
+	quirk_mob.remove_filter("rad_fiend_glow")
+
 //well-trained moved to neutral to stop the awkward situation of a dom snapping and the 30 trait powergamers fall to the floor.
 /datum/quirk/well_trained
 	name = "Well-Trained"

--- a/modular_splurt/code/datums/traits/trait_actions.dm
+++ b/modular_splurt/code/datums/traits/trait_actions.dm
@@ -1490,7 +1490,7 @@
 
 /datum/action/cosglow/update_glow
 	name = "Modify Glow"
-	desc = "Change your radioactive glow color."
+	desc = "Change your glow color."
 	button_icon_state = "blank"
 
 	// Glow color to use

--- a/modular_splurt/code/datums/traits/trait_actions.dm
+++ b/modular_splurt/code/datums/traits/trait_actions.dm
@@ -1480,6 +1480,69 @@
 	else
 		to_chat(H, span_warning("You are already conserving your energy!"))
 
+//Quirk: Cosmetic Glow
+//Copy and pasted. Cry about it.
+/datum/action/cosglow
+	name = "Broken Glow Action"
+	desc = "Report this to a coder."
+	icon_icon = 'icons/effects/effects.dmi'
+	button_icon_state = "static"
+
+/datum/action/cosglow/update_glow
+	name = "Modify Glow"
+	desc = "Change your radioactive glow color."
+	button_icon_state = "blank"
+
+	// Glow color to use
+	var/glow_color = "#39ff14" // Neon green
+
+	// Thickness of glow outline
+	var/glow_range = 1 //Less than radfiend
+
+
+/datum/action/cosglow/update_glow/Grant()
+	. = ..()
+
+	// Define user mob
+	var/mob/living/carbon/human/action_mob = owner
+
+	// Add outline effect
+	action_mob.add_filter("rad_fiend_glow", 1, list("type" = "outline", "color" = glow_color+"30", "size" = glow_range))
+
+/datum/action/cosglow/update_glow/Remove()
+	. = ..()
+
+	// Define user mob
+	var/mob/living/carbon/human/action_mob = owner
+
+	// Remove glow
+	action_mob.remove_filter("rad_fiend_glow")
+
+/datum/action/cosglow/update_glow/Trigger()
+	. = ..()
+
+	// Define user mob
+	var/mob/living/carbon/human/action_mob = owner
+
+	// Ask user for color input
+	var/input_color = input(action_mob, "Select a color to use for your glow outline.", "Select Glow Color", glow_color) as color|null
+
+	// Check if color input was given
+	// Reset to stored color when not given input
+	glow_color = (input_color ? input_color : glow_color)
+
+	// Ask user for range input
+	var/input_range = input(action_mob, "How much do you glow? Value may range between 1 to 2.", "Select Glow Range", glow_range) as num|null
+
+	// Check if range input was given
+	// Reset to stored color when not given input
+	// Input is clamped in the 1-4 range
+	glow_range = (input_range ? clamp(input_range, 0, 4) : glow_range) //More customisable, so you know when you're looking at someone with Radfiend (doom) or a normal player.
+
+	// Update outline effect
+	action_mob.remove_filter("rad_fiend_glow")
+	action_mob.add_filter("rad_fiend_glow", 1, list("type" = "outline", "color" = glow_color+"30", "size" = glow_range))
+
 //
 // Quirk: Rad Fiend
 //
@@ -1500,6 +1563,7 @@
 
 	// Thickness of glow outline
 	var/glow_range = 2
+
 
 /datum/action/rad_fiend/update_glow/Grant()
 	. = ..()

--- a/modular_splurt/code/datums/traits/trait_actions.dm
+++ b/modular_splurt/code/datums/traits/trait_actions.dm
@@ -1537,8 +1537,8 @@
 
 	// Check if range input was given
 	// Reset to stored color when not given input
-	// Input is clamped in the 1-2 range
-	glow_range = (input_range ? clamp(input_range, 1, 2) : glow_range)
+	// Input is clamped in the 1-4 range
+	glow_range = (input_range ? clamp(input_range, 1, 4) : glow_range)
 
 	// Update outline effect
 	action_mob.remove_filter("rad_fiend_glow")

--- a/modular_splurt/code/modules/mob/living/carbon/human/species.dm
+++ b/modular_splurt/code/modules/mob/living/carbon/human/species.dm
@@ -35,9 +35,8 @@
 		H.adjust_thirst(-thirst_rate)
 
 /datum/species/handle_mutations_and_radiation(mob/living/carbon/human/H)
-	// Check for rad fiend quirk
-	// Note: Rad Fiend was readjusted to not need a maximum ceiling on radiation. View the Undead Species as to why.
-	if(HAS_TRAIT(H, TRAIT_RAD_FIEND)) //Note. This proc occurs after the radiation damage proc. Which means above like 1e+06 rads/sec they'll still die.
+	//Note: In the future, we should probably make radfiend assign TRAIT_RADIMMUME, but this is a good balancing aspect for now.
+	if(HAS_TRAIT(H, TRAIT_RAD_FIEND)) //Note. Due to how radiation code works, this does not provide FULL immunity.
 		// Return without effects
 		return TRUE
 

--- a/modular_splurt/code/modules/mob/living/carbon/human/species.dm
+++ b/modular_splurt/code/modules/mob/living/carbon/human/species.dm
@@ -36,8 +36,8 @@
 
 /datum/species/handle_mutations_and_radiation(mob/living/carbon/human/H)
 	// Check for rad fiend quirk
-	// Check for radiation resist threshold
-	if(HAS_TRAIT(H, TRAIT_RAD_FIEND) && (H.radiation < RAD_BURN_THRESHOLD))
+	// Note: Rad Fiend was readjusted to not need a maximum ceiling on radiation. View the Undead Species as to why.
+	if(HAS_TRAIT(H, TRAIT_RAD_FIEND)) //Note. This proc occurs after the radiation damage proc. Which means above like 1e+06 rads/sec they'll still die.
 		// Return without effects
 		return TRUE
 


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Makes Radfiend function more similar to full radiation immunity (while still allowing for contamination, and the consequences therein). Keep in mind, as is stated in a file; that rads can STILL kill someone if they have this... It just takes near-fusion levels.

Also makes a separate perk to maintain the Radfiend glow for no cost or advantage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
The Undead, and anyone with the undead trait are already immune to rads, and that is a COMPLETELY FREE thing. Their only downside is being unable to use meds - which is... entirely negatable with just self-surgery to tend wounds. This puts Radfiend back to where it should have been, increases its cost - and generally allows a tad more of a glow.

Plus, considering how often admins/staff already hand out similar stuff for personal projects, this just helps streamline funny stuffs.

Also lets the undead take it, incase they want to **glow**. Plus allows staff to give people the rad-Immunity trait and radfiend for things like super-rad events (pun intended).
+ Makes the ability to glow free
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->
N o
## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
tweak: Radfiend has been adjusted to be more in-line with its original vision, while still retaining what makes it different from full radiation immunity. Report any and all unintended consequences.
add: Glowie Trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
