### PR TITLE
Adding Messy trait, Pref for getting splashed with cum

### DIFF
--- a/code/__DEFINES/citadel_defines.dm
+++ b/code/__DEFINES/citadel_defines.dm
@@ -132,6 +132,7 @@
 #define CHASTITY			(1<<18)
 #define STIMULATION			(1<<19)
 #define EDGING				(1<<20)
+#define CUM_ONTO			(1<<21)
 //Note: reminder, if you're a coder adding more bitflags here in the event we add more horny things, the maximum is (1<<23).
 #define TOGGLES_CITADEL 0
 

--- a/code/__SPLURTCODE/DEFINES/traits.dm
+++ b/code/__SPLURTCODE/DEFINES/traits.dm
@@ -45,3 +45,4 @@
 #define TRAIT_COSGLOW			"cosmetic_glow"
 #define TRAIT_BODY_MORPHER		"body_morpher"
 #define TRAIT_HALLOWED			"hallowed"
+#define TRAIT_MESSY				"messy"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1521,6 +1521,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "<b>Chastity Interactions :</b> <a href='?_src_=prefs;preference=chastitypref'>[(cit_toggles & CHASTITY) ? "Allowed" : "Disallowed"]</a><br>"
 					dat += "<b>Genital Stimulation Modifiers :</b> <a href='?_src_=prefs;preference=stimulationpref'>[(cit_toggles & STIMULATION) ? "Allowed" : "Disallowed"]</a><br>"
 					dat += "<b>Edging :</b> <a href='?_src_=prefs;preference=edgingpref'>[(cit_toggles & EDGING) ? "Allowed" : "Disallowed"]</a><br>"
+					dat += "<b>Receive Cum Covering :</b> <a href='?_src_=prefs;preference=cumontopref'>[(cit_toggles & CUM_ONTO) ? "Allowed" : "Disallowed"]</a><br>"
 					dat += "<span style='border-radius: 2px;border:1px dotted white;cursor:help;' title='Enables verbs involving farts, shit and piss.'>?</span> "
 					dat += "<b>Unholy ERP verbs :</b> <a href='?_src_=prefs;preference=unholypref'>[unholypref]</a><br>" //https://www.youtube.com/watch?v=OHKARc-GObU
 					//END OF SPLURT EDIT
@@ -3912,6 +3913,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					cit_toggles ^= STIMULATION
 				if("edgingpref")
 					cit_toggles ^= EDGING
+				if("cumontopref")
+					cit_toggles ^= CUM_ONTO
 				//
 
 	if(href_list["preference"] == "gear")

--- a/modular_sand/code/datums/components/interaction_menu_granter.dm
+++ b/modular_sand/code/datums/components/interaction_menu_granter.dm
@@ -199,6 +199,7 @@
 		.["chastity_pref"] = 		!!CHECK_BITFIELD(prefs.cit_toggles, CHASTITY)
 		.["stimulation_pref"] = 	!!CHECK_BITFIELD(prefs.cit_toggles, STIMULATION)
 		.["edging_pref"] =			!!CHECK_BITFIELD(prefs.cit_toggles, EDGING)
+		.["cum_onto_pref"] = 		!!CHECK_BITFIELD(prefs.cit_toggles, CUM_ONTO)
 
 /proc/num_to_pref(num)
 	switch(num)
@@ -353,6 +354,8 @@
 					TOGGLE_BITFIELD(prefs.cit_toggles, STIMULATION)
 				if("edging_pref")
 					TOGGLE_BITFIELD(prefs.cit_toggles, EDGING)
+				if("cum_onto_pref")
+					TOGGLE_BITFIELD(prefs.cit_toggles, CUM_ONTO)
 				//
 				else
 					return FALSE

--- a/modular_splurt/code/datums/traits/neutral.dm
+++ b/modular_splurt/code/datums/traits/neutral.dm
@@ -886,3 +886,12 @@
 /datum/quirk/modular/remove()
 	var/mob/living/carbon/human/C = quirk_holder
 	remove_verb(C,/mob/living/proc/alterlimbs)
+
+/datum/quirk/messy
+	name = "Messy"
+	desc = "Due to your unique biology/construction/bluespace magic you always manage to make a mess when you cum, even if it's not possible in normal circumstances."
+	value = 0
+	mob_trait = TRAIT_MESSY
+	gain_text = span_lewd("You feel like covering something in layer of your fluids.")
+	lose_text = span_notice("You don't feel 'messy' anymore.")
+	medical_record_text = "Had to be sedated after covering entire hospital wing with cum."

--- a/modular_splurt/code/modules/arousal/organs/breasts.dm
+++ b/modular_splurt/code/modules/arousal/organs/breasts.dm
@@ -63,6 +63,10 @@
 			width_multiplier = 1
 		if(20 to INFINITY)
 			width_multiplier = 2
+	if(HAS_TRAIT(owner,TRAIT_MESSY))
+		width_multiplier = 3
+
+
 
 	// get affected objects
 	var/turf/target_turf = owner.loc

--- a/modular_splurt/code/modules/arousal/organs/breasts.dm
+++ b/modular_splurt/code/modules/arousal/organs/breasts.dm
@@ -66,8 +66,8 @@
 				width_multiplier = 1
 			if(20 to INFINITY)
 				width_multiplier = 2
-
-
+			else
+				return
 
 	// get affected objects
 	var/turf/target_turf = owner.loc

--- a/modular_splurt/code/modules/arousal/organs/breasts.dm
+++ b/modular_splurt/code/modules/arousal/organs/breasts.dm
@@ -58,13 +58,15 @@
 
 	// determine size stage
 	var/width_multiplier = 0
-	switch(round(size * get_size(owner)))
-		if(10 to 20)
-			width_multiplier = 1
-		if(20 to INFINITY)
-			width_multiplier = 2
 	if(HAS_TRAIT(owner,TRAIT_MESSY))
-		width_multiplier = 3
+		width_multiplier = 2
+		to_chat(world, "trait got!")
+	else
+		switch(round(size * get_size(owner)))
+			if(10 to 20)
+				width_multiplier = 1
+			if(20 to INFINITY)
+				width_multiplier = 2
 
 
 
@@ -78,6 +80,10 @@
 		for(var/object in target_turf.contents)
 			if(isturf(object))
 				continue
+			if(ishuman(object))
+				var/mob/living/carbon/human/H = object
+				if(!(H.client?.prefs.cit_toggles & CUM_ONTO))
+					continue
 			LAZYADD(cumsplashed_items, object)
 		if(cumsplashed_items.len)
 			break

--- a/modular_splurt/code/modules/arousal/organs/breasts.dm
+++ b/modular_splurt/code/modules/arousal/organs/breasts.dm
@@ -60,7 +60,6 @@
 	var/width_multiplier = 0
 	if(HAS_TRAIT(owner,TRAIT_MESSY))
 		width_multiplier = 2
-		to_chat(world, "trait got!")
 	else
 		switch(round(size * get_size(owner)))
 			if(10 to 20)

--- a/modular_splurt/code/modules/arousal/organs/penis.dm
+++ b/modular_splurt/code/modules/arousal/organs/penis.dm
@@ -55,15 +55,18 @@
 
 	// determine size stage
 	var/length_multiplier = 0
-	switch(round(length * get_size(owner)))
-		if(16 to 32)
-			length_multiplier = 1
-		if(32 to INFINITY)
-			length_multiplier = 2
-		if(HAS_TRAIT(owner,TRAIT_MESSY))
-		width_multiplier = 3
-		else
-			return
+	to_chat(world, "splash!")
+	if(HAS_TRAIT(owner,TRAIT_MESSY))
+		length_multiplier = 2
+		to_chat(world, "trait got!")
+	else
+		switch(round(length * get_size(owner)))
+			if(16 to 32)
+				length_multiplier = 1
+				to_chat(world, "size1")
+			if(32 to INFINITY)
+				length_multiplier = 2
+				to_chat(world, "size2")
 
 	// get affected objects
 	var/turf/target_turf = owner.loc
@@ -75,6 +78,10 @@
 		for(var/object in target_turf.contents)
 			if(isturf(object))
 				continue
+			if(ishuman(object))
+				var/mob/living/carbon/human/H = object
+				if(!(H.client?.prefs.cit_toggles & CUM_ONTO))
+					continue
 			LAZYADD(cumsplashed_items, object)
 		if(cumsplashed_items.len)
 			break

--- a/modular_splurt/code/modules/arousal/organs/penis.dm
+++ b/modular_splurt/code/modules/arousal/organs/penis.dm
@@ -60,6 +60,8 @@
 			length_multiplier = 1
 		if(32 to INFINITY)
 			length_multiplier = 2
+		if(HAS_TRAIT(owner,TRAIT_MESSY))
+		width_multiplier = 3
 		else
 			return
 

--- a/modular_splurt/code/modules/arousal/organs/penis.dm
+++ b/modular_splurt/code/modules/arousal/organs/penis.dm
@@ -63,6 +63,8 @@
 				length_multiplier = 1
 			if(32 to INFINITY)
 				length_multiplier = 2
+			else
+				return
 
 	// get affected objects
 	var/turf/target_turf = owner.loc

--- a/modular_splurt/code/modules/arousal/organs/penis.dm
+++ b/modular_splurt/code/modules/arousal/organs/penis.dm
@@ -55,18 +55,14 @@
 
 	// determine size stage
 	var/length_multiplier = 0
-	to_chat(world, "splash!")
 	if(HAS_TRAIT(owner,TRAIT_MESSY))
 		length_multiplier = 2
-		to_chat(world, "trait got!")
 	else
 		switch(round(length * get_size(owner)))
 			if(16 to 32)
 				length_multiplier = 1
-				to_chat(world, "size1")
 			if(32 to INFINITY)
 				length_multiplier = 2
-				to_chat(world, "size2")
 
 	// get affected objects
 	var/turf/target_turf = owner.loc

--- a/modular_splurt/code/modules/arousal/organs/vagina.dm
+++ b/modular_splurt/code/modules/arousal/organs/vagina.dm
@@ -15,7 +15,7 @@
 	if(!. || !linked_organ)
 		return
 
-	if(get_size(owner) < 1.25)
+	if(get_size(owner) < 1.25 && HAS_TRAIT(owner,TRAIT_MESSY))
 		return
 
 	// get target objects

--- a/modular_splurt/code/modules/arousal/organs/vagina.dm
+++ b/modular_splurt/code/modules/arousal/organs/vagina.dm
@@ -15,9 +15,8 @@
 	if(!. || !linked_organ)
 		return
 
-	if(get_size(owner) < 1.25 && HAS_TRAIT(owner,TRAIT_MESSY))
+	if(get_size(owner) < 1.25 && !HAS_TRAIT(owner,TRAIT_MESSY))
 		return
-
 	// get target objects
 	var/turf/target_turf = get_turf(owner)
 	if(!istype(target_turf))
@@ -27,4 +26,8 @@
 	for(var/atom/object in target_turf.contents)
 		if(!istype(object) || isturf(object) || object == owner)
 			continue
+		if(ishuman(object))
+			var/mob/living/carbon/human/H = object
+			if(!(H.client?.prefs.cit_toggles & CUM_ONTO))
+				continue
 		object.add_cum_overlay(initial(linked_organ.fluid_id.color), get_size(owner) >= 1.5)

--- a/tgui/packages/tgui/interfaces/MobInteraction.tsx
+++ b/tgui/packages/tgui/interfaces/MobInteraction.tsx
@@ -76,6 +76,7 @@ type ContentPrefsInfo = {
   chastity_pref: boolean,
   stimulation_pref: boolean,
   edging_pref: boolean,
+  cum_onto_pref: boolean,
 }
 
 export const MobInteraction = (props, context) => {
@@ -510,6 +511,7 @@ const ContentPreferencesTab = (props, context) => {
     chastity_pref,
     stimulation_pref,
     edging_pref,
+    cum_onto_pref,
   } = data;
   return (
     <Table>
@@ -798,6 +800,18 @@ const ContentPreferencesTab = (props, context) => {
           selected={edging_pref}
           onClick={() => act('pref', {
             pref: 'edging_pref',
+          })}
+        />
+      </Table.Row>
+      <Table.Row>
+        <Button
+          fluid
+          mb={0.3}
+          content="Receive Cum Covering"
+          icon={cum_onto_pref ? "toggle-on" : "toggle-off"}
+          selected={cum_onto_pref}
+          onClick={() => act('pref', {
+            pref: 'cum_onto_pref',
           })}
         />
       </Table.Row>


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Added new trait called Messy. It bypasses checks for size when determining when checking if player can cover items with their cum.
Added preference toggle if someone doesn't like getting covered in cum.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
More options is good! It's fun to cover stuff with cum but not everyone wants to have a giant shaft just to do it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Not a port! Original. No steal.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
add: Added Messy trait, allowing you to cover stuff with cum while not meeting size requirements.
expansion: added new preference "Recieve cum covering", in case you don't want to be painted white.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
