### PR TITLE
Adds RPED to Hacked Autolathes, Adds T1-3 Parts & RPEDs to All TechFabs

### DIFF
--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
@@ -50,6 +50,14 @@
 	build_path = /obj/item/flamethrower/full
 	category = list("hacked", "Security")
 
+/datum/design/RPED
+	name = "Rapid Part Exchange Device (RPED)"
+	id = "rped"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 10000, /datum/material/glass = 5000) //hardcore
+	build_path = /obj/item/storage/part_replacer
+	category = list("hacked", "Construction")
+
 /datum/design/rcd
 	name = "Rapid Construction Device (RCD)"
 	id = "rcd"

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -11,7 +11,7 @@
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/empty
 	category = list("Misc","Power Designs","Machinery","initial")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/high_cell
 	name = "High-Capacity Power Cell"
@@ -22,7 +22,7 @@
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/high/empty
 	category = list("Misc","Power Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/super_cell
 	name = "Super-Capacity Power Cell"
@@ -33,7 +33,7 @@
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/super/empty
 	category = list("Misc","Power Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/hyper_cell
 	name = "Hyper-Capacity Power Cell"
@@ -44,7 +44,7 @@
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/hyper/empty
 	category = list("Misc","Power Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/bluespace_cell
 	name = "Bluespace Power Cell"

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -10,7 +10,7 @@
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 5000) //hardcore
 	build_path = /obj/item/storage/part_replacer
 	category = list("Stock Parts")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/BS_RPED
 	name = "Bluespace RPED"
@@ -20,7 +20,7 @@
 	materials = list(/datum/material/iron = 15000, /datum/material/glass = 5000, /datum/material/silver = 2500) //hardcore
 	build_path = /obj/item/storage/part_replacer/bluespace
 	category = list("Stock Parts")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 //Capacitors
 /datum/design/basic_capacitor
@@ -32,7 +32,7 @@
 	build_path = /obj/item/stock_parts/capacitor
 	category = list("Stock Parts","Machinery","initial")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/adv_capacitor
 	name = "Advanced Capacitor"
@@ -43,7 +43,7 @@
 	build_path = /obj/item/stock_parts/capacitor/adv
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/super_capacitor
 	name = "Super Capacitor"
@@ -54,7 +54,7 @@
 	build_path = /obj/item/stock_parts/capacitor/super
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/quadratic_capacitor
 	name = "Quadratic Capacitor"
@@ -77,7 +77,7 @@
 	build_path = /obj/item/stock_parts/scanning_module
 	category = list("Stock Parts","Machinery","initial")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/adv_scanning
 	name = "Advanced Scanning Module"
@@ -88,7 +88,7 @@
 	build_path = /obj/item/stock_parts/scanning_module/adv
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/phasic_scanning
 	name = "Phasic Scanning Module"
@@ -99,7 +99,7 @@
 	build_path = /obj/item/stock_parts/scanning_module/phasic
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/triphasic_scanning
 	name = "Triphasic Scanning Module"
@@ -122,7 +122,7 @@
 	build_path = /obj/item/stock_parts/manipulator
 	category = list("Stock Parts","Machinery","initial")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/nano_mani
 	name = "Nano Manipulator"
@@ -133,7 +133,7 @@
 	build_path = /obj/item/stock_parts/manipulator/nano
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/pico_mani
 	name = "Pico Manipulator"
@@ -144,7 +144,7 @@
 	build_path = /obj/item/stock_parts/manipulator/pico
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/femto_mani
 	name = "Femto Manipulator"
@@ -167,7 +167,7 @@
 	build_path = /obj/item/stock_parts/micro_laser
 	category = list("Stock Parts","Machinery","initial")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/high_micro_laser
 	name = "High-Power Micro-Laser"
@@ -178,7 +178,7 @@
 	build_path = /obj/item/stock_parts/micro_laser/high
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/ultra_micro_laser
 	name = "Ultra-High-Power Micro-Laser"
@@ -189,7 +189,7 @@
 	build_path = /obj/item/stock_parts/micro_laser/ultra
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/quadultra_micro_laser
 	name = "Quad-Ultra Micro-Laser"
@@ -212,7 +212,7 @@
 	build_path = /obj/item/stock_parts/matter_bin
 	category = list("Stock Parts","Machinery","initial")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/adv_matter_bin
 	name = "Advanced Matter Bin"
@@ -223,7 +223,7 @@
 	build_path = /obj/item/stock_parts/matter_bin/adv
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/super_matter_bin
 	name = "Super Matter Bin"
@@ -234,7 +234,7 @@
 	build_path = /obj/item/stock_parts/matter_bin/super
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/bluespace_matter_bin
 	name = "Bluespace Matter Bin"


### PR DESCRIPTION

# About The Pull Request

Adds Rapid Part Exchange Device (RPED) to Hacked Autolathes (all version) similar to how RCD and RPD are available through Hacked Lathes.

Adds RPED and BRPEDs to all Departmental TechFabs, as well as all Tier 1 (Micro), Tier 2(Nano) and Tier 3(Pico) Machine Parts to all Department Techfabs. This includes (Micro/Nano/Pico) Manipulators, (Basic/Advanced/Super) Matter Bins, (Basic/High-Power/Ultra-High-Power) Micro-Lasers, (Basic/Advanced/Super) Capacitors, (Basic/Advanced/Phasic) Scanning Modules and (Basic/High-Capacity/Super Capacity) Power Cells.

All of these items are researched very early most shifts (usually some of the first) but rarely ever get built or distributed as most Science and Engineering players prefer to wait for Tier 4 aka Diamond Tier parts, typically adding over 30 minutes of waiting for upgrades to most departments, if they happen at all.

TL;DR Changed Department Flags on above machinery from Science | Engineering to DEPARTMENTAL_FLAG_ALL

## Why It's Good For The Game

As stated above, when upgrades do happen (not a guarantee), the upgrades usually do not come until AFTER diamond tier parts are available and Bluespace Miners are operational. This often adds 30 minutes or more of waiting for these upgrades to happen, when many jobs that rely on these machines get noticeable improvements just from Tier 2 and Tier 3 parts.

This allows players who want faster upgrades for their department to facilitate this without trying to get Science or Engineering to do something, and also makes it easier to build departmental machines and just ask for Science or Engineering to come do T4/T5 upgrades at their convenience, instead of having run half way across the station to try and get the requisite parts to even build a machine.

Cargo can get Cryptominers started, Medical can improve their machines or build things like autodocs, Security can make more chargers and improve the ones they have, and Service can upgrade all of their machines all without having to wait on Science or Engineering and adding to what ever to do list those people have, assuming they have any interest helping other departments to begin with.

Additionally, Autolathe RPEDs would also greatly boost Assistants and other misc crew looking to do maintenance setups and wanting to build multiple machines.

## A Port?

N/A

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
add: Rapid Part Exchange Device (RPED) can now be printed from a hacked autolathe.
add: RPED, BRPED and Tier 1-3 Manipulators, Matter Bins, Micro-Lasers, Capacitors, Scanning Modules and Power Cells can now be printed at all Department TechFabs
/:cl:
