### PR TITLE
A workaround to fix loadout masks getting removed due Bane Syndrome quirk

### DIFF
--- a/modular_splurt/code/datums/traits/neutral.dm
+++ b/modular_splurt/code/datums/traits/neutral.dm
@@ -885,7 +885,7 @@
 	. = ..()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/mask/gas/cosmetic/gasmask = new(get_turf(quirk_holder)) // Uses a custom gas mask
-	H.equip_to_slot(gasmask, ITEM_SLOT_MASK)
+	H.equip_to_slot_if_possible(gasmask, ITEM_SLOT_MASK) // If character have a loadout mask, the custom one will not overwrite it but instead will be dropped on floor
 	H.regenerate_icons()
 
 /datum/quirk/body_morpher

--- a/modular_splurt/code/modules/client/loadout/mask.dm
+++ b/modular_splurt/code/modules/client/loadout/mask.dm
@@ -1,3 +1,3 @@
 /datum/gear/mask/gas
-  restricted_roles = list()
+	restricted_roles = list()
 


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Due `H.equip_to_slot` forces aesthetic gas mask onto mask slot, it also removes loadout mask. This PR fixes the issue by using `H.equip_to_slot_if_possible` instead for the quirk, making the aesthetic drop onto floor while character get their mask of choice.

Also, sorry K4rlox, but I changed your file to have proper indentation.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
Bane/Gasmask Mooks will no longer suffer for being forced to wear aesthetic gasmask, even when they pick the liberated one from the loadout.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl: Anonymous
fix: Fixes Bane Syndrome quirk overwriting loadout's masks. Now the mask from the quirk will be dropped onto floor if you use loadout one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
