### PR TITLE
[Semi-Modular] Silicon Flavor Text

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -120,7 +120,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/gender = MALE					//gender of character (well duh)
 	var/age = 30						//age of character
 	//Sandstorm CHANGES BEGIN
-	var/ooc_prefs = ""
 	var/erppref = "Ask"
 	var/nonconpref = "Ask"
 	var/vorepref = "Ask"
@@ -2228,10 +2227,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if(!isnull(msg))
 						features["silicon_flavor_text"] = strip_html_simple(msg, MAX_FLAVOR_LEN, TRUE)
 
-				if("ooc_prefs")
-					var/msg = input(usr, "Set your OOC preferences.", "OOC Prefs", ooc_prefs) as message|null
+				if("ooc_notes")
+					var/msg = stripped_multiline_input(usr, "Set always-visible OOC notes related to content preferences. THIS IS NOT FOR CHARACTER DESCRIPTIONS!", "OOC notes", html_decode(features["ooc_notes"]), MAX_FLAVOR_LEN, TRUE)
 					if(!isnull(msg))
-						ooc_prefs = strip_html_simple(msg, MAX_FLAVOR_LEN, TRUE)
+						features["ooc_notes"] = msg
 
 				if("hide_ckey")
 					hide_ckey = !hide_ckey
@@ -4288,8 +4287,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			return
 		else
 			custom_names[name_id] = sanitized_name
-
-	ooc_prefs = sanitize_text(ooc_prefs)
 
 /datum/preferences/proc/get_filtered_holoform(filter_type)
 	if(!custom_holoform_icon)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -120,6 +120,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/gender = MALE					//gender of character (well duh)
 	var/age = 30						//age of character
 	//Sandstorm CHANGES BEGIN
+	var/ooc_prefs = ""
 	var/erppref = "Ask"
 	var/nonconpref = "Ask"
 	var/vorepref = "Ask"
@@ -2223,14 +2224,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						features["naked_flavor_text"] = strip_html_simple(msg, MAX_FLAVOR_LEN, TRUE)
 				//SPLURT edit end
 				if("silicon_flavor_text")
-					var/msg = input(usr, "Set the silicon flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Silicon Flavor Text", features["silicon_flavor_text"]) as message|null //Skyrat edit, removed stripped_multiline_input()
+					var/msg = input(usr, "Set the flavor text in your 'examine' verb. This is for describing what people can tell by looking at your character.", "Silicon Flavor Text", features["silicon_flavor_text"]) as message|null
 					if(!isnull(msg))
-						features["silicon_flavor_text"] = strip_html_simple(msg, MAX_FLAVOR_LEN, TRUE) //Skyrat edit, uses strip_html_simple()
+						features["silicon_flavor_text"] = strip_html_simple(msg, MAX_FLAVOR_LEN, TRUE)
 
-				if("ooc_notes")
-					var/msg = stripped_multiline_input(usr, "Set always-visible OOC notes related to content preferences. THIS IS NOT FOR CHARACTER DESCRIPTIONS!", "OOC notes", html_decode(features["ooc_notes"]), MAX_FLAVOR_LEN, TRUE)
+				if("ooc_prefs")
+					var/msg = input(usr, "Set your OOC preferences.", "OOC Prefs", ooc_prefs) as message|null
 					if(!isnull(msg))
-						features["ooc_notes"] = msg
+						ooc_prefs = strip_html_simple(msg, MAX_FLAVOR_LEN, TRUE)
 
 				if("hide_ckey")
 					hide_ckey = !hide_ckey
@@ -4287,6 +4288,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			return
 		else
 			custom_names[name_id] = sanitized_name
+
+	ooc_prefs = sanitize_text(ooc_prefs)
 
 /datum/preferences/proc/get_filtered_holoform(filter_type)
 	if(!custom_holoform_icon)

--- a/code/modules/mob/living/silicon/examine.dm
+++ b/code/modules/mob/living/silicon/examine.dm
@@ -4,7 +4,7 @@
 		for(var/law in laws.get_law_list(include_zeroth = TRUE))
 			. += law
 
-	//SKYRAT EDIT ADDITION BEGIN - CUSTOMIZATION
+	//SPLURT EDIT ADDITION BEGIN - CUSTOMIZATION
 	if(client)
 		var/line
 		if(length(client.prefs.features["silicon_flavor_text"]))
@@ -13,6 +13,6 @@
 				line = "<span class='notice'>[message]</span>"
 			else
 				line = "<span class='notice'>[copytext_char(message, 1, 37)]... <a href='?src=[REF(src)];lookup_info=silicon_flavor_text'>More...</a></span>"
-		line += " <span class='notice'><a href='?src=[REF(src)];lookup_info=ooc_prefs'>\[OOC\]</a></span>"
+		line += " <span class='notice'><a href='?src=[REF(src)];lookup_info=ooc_notes'>\[OOC\]</a></span>"
 		. += line
-	//SKYRAT EDIT ADDITION END
+	//SPLURT EDIT ADDITION END

--- a/code/modules/mob/living/silicon/examine.dm
+++ b/code/modules/mob/living/silicon/examine.dm
@@ -3,3 +3,16 @@
 		. += "<b>[src] has the following laws:</b>"
 		for(var/law in laws.get_law_list(include_zeroth = TRUE))
 			. += law
+
+	//SKYRAT EDIT ADDITION BEGIN - CUSTOMIZATION
+	if(client)
+		var/line
+		if(length(client.prefs.features["silicon_flavor_text"]))
+			var/message = client.prefs.features["silicon_flavor_text"]
+			if(length_char(message) <= 40)
+				line = "<span class='notice'>[message]</span>"
+			else
+				line = "<span class='notice'>[copytext_char(message, 1, 37)]... <a href='?src=[REF(src)];lookup_info=silicon_flavor_text'>More...</a></span>"
+		line += " <span class='notice'><a href='?src=[REF(src)];lookup_info=ooc_prefs'>\[OOC\]</a></span>"
+		. += line
+	//SKYRAT EDIT ADDITION END

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -61,12 +61,6 @@
 	diag_hud_set_health()
 	ADD_TRAIT(src, TRAIT_ASHSTORM_IMMUNE, ROUNDSTART_TRAIT)
 
-/mob/living/silicon/ComponentInitialize()
-	. = ..()
-	AddElement(/datum/element/flavor_text, _name = "Silicon Flavor Text", _save_key = "silicon_flavor_text")
-	AddElement(/datum/element/flavor_text, "", "Temporary Flavor Text", "This should be used only for things pertaining to the current round!", _save_key = null)
-	AddElement(/datum/element/flavor_text, _name = "OOC Notes", _addendum = "Put information on ERP/vore/lewd-related preferences here. THIS SHOULD NOT CONTAIN REGULAR FLAVORTEXT!!", _save_key = "ooc_notes", _examine_no_preview = TRUE)
-
 /mob/living/silicon/med_hud_set_health()
 	return //we use a different hud
 
@@ -221,8 +215,25 @@
 	if (href_list["laws"]) // With how my law selection code works, I changed statelaws from a verb to a proc, and call it through my law selection panel. --NeoFite
 		statelaws()
 
-	return
+	//SKYRAT EDIT ADDITION BEGIN - CUSTOMIZATION
+	if(href_list["lookup_info"])
+		switch(href_list["lookup_info"])
+			if("ooc_prefs")
+				if(client)
+					var/str = "[src]'s OOC Notes : <br> <b>ERP :</b> [client.prefs.erppref] <b>| Non-Con :</b> [client.prefs.nonconpref] <b>| Vore :</b> [client.prefs.vorepref]"
+					str += "<br>[html_encode(client.prefs.ooc_prefs)]"
+					var/datum/browser/popup = new(usr, "[name]'s ooc info", "[name]'s OOC Information", 500, 200)
+					popup.set_content(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s ooc info", replacetext(client.prefs.features["ooc_notes"], "\n", "<BR>")))
+					popup.open()
+					return
 
+			if("silicon_flavor_text")
+				if(client && length(client.prefs.features["silicon_flavor_text"]))
+					var/datum/browser/popup = new(usr, "[name]'s flavor text", "[name]'s Flavor Text", 500, 200)
+					popup.set_content(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s flavor text", replacetext(client.prefs.features["silicon_flavor_text"], "\n", "<BR>")))
+					popup.open()
+					return
+					//SKYRAT EDIT ADDITION END
 
 /mob/living/silicon/proc/statelaws(force = 0)
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -215,15 +215,13 @@
 	if (href_list["laws"]) // With how my law selection code works, I changed statelaws from a verb to a proc, and call it through my law selection panel. --NeoFite
 		statelaws()
 
-	//SKYRAT EDIT ADDITION BEGIN - CUSTOMIZATION
+	//SPLURT EDIT ADDITION BEGIN - CUSTOMIZATION
 	if(href_list["lookup_info"])
 		switch(href_list["lookup_info"])
-			if("ooc_prefs")
-				if(client)
-					var/str = "[src]'s OOC Notes : <br> <b>ERP :</b> [client.prefs.erppref] <b>| Non-Con :</b> [client.prefs.nonconpref] <b>| Vore :</b> [client.prefs.vorepref]"
-					str += "<br>[html_encode(client.prefs.ooc_prefs)]"
+			if("ooc_notes")
+				if(client && length(client.prefs.features["ooc_notes"]))
 					var/datum/browser/popup = new(usr, "[name]'s ooc info", "[name]'s OOC Information", 500, 200)
-					popup.set_content(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s ooc info", replacetext(client.prefs.features["ooc_notes"], "\n", "<BR>")))
+					popup.set_content(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s OOC information", replacetext(client.prefs.features["ooc_notes"], "\n", "<BR>")))
 					popup.open()
 					return
 
@@ -233,7 +231,7 @@
 					popup.set_content(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s flavor text", replacetext(client.prefs.features["silicon_flavor_text"], "\n", "<BR>")))
 					popup.open()
 					return
-					//SKYRAT EDIT ADDITION END
+					//SPLURT EDIT ADDITION END
 
 /mob/living/silicon/proc/statelaws(force = 0)
 

--- a/modular_splurt/code/modules/client/preferences.dm
+++ b/modular_splurt/code/modules/client/preferences.dm
@@ -146,6 +146,7 @@
 
 			dat += "<table><tr><td width='20%' height='300px' valign='top'>"
 			dat += "<h2>Flavor Text</h2>"
+			// Carbon flavor text
 			dat += "<a href='?_src_=prefs;preference=flavor_text;task=input'><b>Set Examine Text</b></a><br>"
 			if(length(features["flavor_text"]) <= MAX_FLAVOR_PREVIEW_LEN)
 				if(!length(features["flavor_text"]))
@@ -165,15 +166,16 @@
 			else
 				dat += "[TextPreview(html_encode(features["naked_flavor_text"]))]...<BR>"
 			//SPLURT edit end
+			// Silicon flavor text
 			dat += "<h2>Silicon Flavor Text</h2>"
 			dat += "<a href='?_src_=prefs;preference=silicon_flavor_text;task=input'><b>Set Silicon Examine Text</b></a><br>"
-			if(length(features["silicon_flavor_text"]) <= MAX_FLAVOR_PREVIEW_LEN)
+			if(length(features["silicon_flavor_text"]) <= 40)
 				if(!length(features["silicon_flavor_text"]))
-					dat += "\[...\]<BR>"
+					dat += "\[...\]"
 				else
-					dat += "[features["silicon_flavor_text"]]<BR>"
+					dat += "[html_encode(features["silicon_flavor_text"])]"
 			else
-				dat += "[TextPreview(features["silicon_flavor_text"])]...<BR>"
+				dat += "[copytext(html_encode(features["silicon_flavor_text"]), 1, 40)]..."
 			dat += "<h2>OOC notes</h2>"
 			dat += "<a href='?_src_=prefs;preference=ooc_notes;task=input'><b>Set OOC notes</b></a><br>"
 			var/ooc_notes_len = length(features["ooc_notes"])


### PR DESCRIPTION
# About The Pull Request

Good evening, I present to the fine people of this station a fix to the silicon flavor text issues on borgs. Meaning, you SHOULD be able to transfer your Silicon Flavor Text and OOC text to your cyborg characters! However, as a downside other players wont be able to see your preferences, I tried fixing it, I have no clue even after dedicating what appears to be 4-5 hours of my life in trying to trace down code and rework some areas. So it was either the preferences showing up or it was no OOC notes at all! 

![Screenshot 2023-10-11 063517](https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/assets/51891267/99f5ca93-71ad-42a3-8ebe-2f3953200b0f)

![Screenshot 2023-10-11 063528](https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/assets/51891267/6d23d16e-0d78-48db-aaf0-c3497203c099)

![Screenshot 2023-10-11 183600](https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/assets/51891267/d430cc5c-db78-46af-9ae8-5399b5807527)

## Why It's Good For The Game

We all know what this is for, Dogborg ERP 2023 edition! But on a serious note, alot of people were getting a bit agitated having to copy pasta their flavor text and OOC into their temporary texts which disappears after the round, now we don't have to deal with it!

## A Port?

Silicon Flavor Text (#1928)
https://github.com/Skyrat-SS13/Skyrat-tg/pull/1928/files#diff-9e29fac756d308085f2f87b508af980fc7557caad973a1cff81099ef18219aeb

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
tweak: reverts I believe a previous PR additon from sandstorm/cit.
qol: reworks a tad bit of silicon text to function.
/:cl:
