### PR TITLE
yippee - I spent 2 hours looking for security exploits

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/genpop.dm
+++ b/code/game/objects/structures/crates_lockers/closets/genpop.dm
@@ -46,7 +46,7 @@
 	var/sentence_length = input(user, "Please input the length of their sentence in minutes (0 for perma).", "Sentence Length", registered_id.sentence) as num|null
 	if(sentence_length == null | !user.Adjacent(src))
 		return FALSE
-	var/crimes = sanitize(input(user, "Please input their crimes.", "Crimes", registered_id.crime)) as text|null
+	var/crimes = sanitize(input(user, "Please input their crimes.", "Crimes", registered_id.crime) as text|null) 
 	if(crimes == null | !user.Adjacent(src))
 		return FALSE
 

--- a/code/game/objects/structures/crates_lockers/closets/genpop.dm
+++ b/code/game/objects/structures/crates_lockers/closets/genpop.dm
@@ -40,7 +40,7 @@
 	return TRUE
 
 /obj/structure/closet/secure_closet/genpop/proc/handle_edit_sentence(mob/user)
-	var/prisoner_name = sanitize(input(user, "Please input the name of the prisoner.", "Prisoner Name", registered_id.registered_name)) as text|null
+	var/prisoner_name = sanitize(input(user, "Please input the name of the prisoner.", "Prisoner Name", registered_id.registered_name) as text|null)
 	if(prisoner_name == null | !user.Adjacent(src))
 		return FALSE
 	var/sentence_length = input(user, "Please input the length of their sentence in minutes (0 for perma).", "Sentence Length", registered_id.sentence) as num|null

--- a/code/game/objects/structures/crates_lockers/closets/genpop.dm
+++ b/code/game/objects/structures/crates_lockers/closets/genpop.dm
@@ -40,13 +40,13 @@
 	return TRUE
 
 /obj/structure/closet/secure_closet/genpop/proc/handle_edit_sentence(mob/user)
-	var/prisoner_name = input(user, "Please input the name of the prisoner.", "Prisoner Name", registered_id.registered_name) as text|null
+	var/prisoner_name = sanitize(input(user, "Please input the name of the prisoner.", "Prisoner Name", registered_id.registered_name)) as text|null
 	if(prisoner_name == null | !user.Adjacent(src))
 		return FALSE
 	var/sentence_length = input(user, "Please input the length of their sentence in minutes (0 for perma).", "Sentence Length", registered_id.sentence) as num|null
 	if(sentence_length == null | !user.Adjacent(src))
 		return FALSE
-	var/crimes = input(user, "Please input their crimes.", "Crimes", registered_id.crime) as text|null
+	var/crimes = sanitize(input(user, "Please input their crimes.", "Crimes", registered_id.crime)) as text|null
 	if(crimes == null | !user.Adjacent(src))
 		return FALSE
 


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
hooray
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
critical security fix :3
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
no
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
fix: EZfix: Sanitises prisoner names on old lockers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
