### PR TITLE
Remove telescopic baton from peacekeeper loadout selecton

### DIFF
--- a/modular_splurt/code/modules/jobs/job_types/peacekeeper.dm
+++ b/modular_splurt/code/modules/jobs/job_types/peacekeeper.dm
@@ -259,13 +259,6 @@ Peacekeeper Hypospray
 	new /obj/item/melee/baton/prova(src)
 	new /obj/item/stock_parts/cell/high/plus(src)
 
-/obj/item/storage/secure/briefcase/pkbaton/tbaton
-	name = "\improper Telescopic Baton box"
-	desc = "Storage box containing a single telescopic baton, just like the big boy riot police get!"
-
-/obj/item/storage/secure/briefcase/pkbaton/tbaton/PopulateContents()
-	new /obj/item/melee/classic_baton/telescopic(src)
-
 // Peacekeeper Locker
 
 /obj/structure/closet/secure_closet/peacekeeper


### PR DESCRIPTION
Overpowered weapon removed from what is supposed to be a hall monitor.

Simply removes the choice of getting the telescopic baton (which is supposed to be reserved only for heads)