### PR TITLE
Renames Pinches and Searing tool designs

### DIFF
--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -246,7 +246,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/retractor_adv
-	name = "Advanced Retractor"
+	name = "Mechanical Pinches"
 	desc = "An almagation of rods and gears, able to function as both a surgical clamp and retractor. "
 	id = "retractor_adv"
 	build_type = PROTOLATHE
@@ -256,7 +256,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/surgicaldrill_adv
-	name = "Surgical Laser Drill"
+	name = "Searing Tool"
 	desc = "It projects a high power laser used for medical applications."
 	id = "surgicaldrill_adv"
 	build_type = PROTOLATHE

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -246,7 +246,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/retractor_adv
-	name = "Mechanical Pinches"
+	name = "Advanced Retractor"
 	desc = "An almagation of rods and gears, able to function as both a surgical clamp and retractor. "
 	id = "retractor_adv"
 	build_type = PROTOLATHE
@@ -256,7 +256,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/surgicaldrill_adv
-	name = "Searing Tool"
+	name = "Surgical Laser Drill"
 	desc = "It projects a high power laser used for medical applications."
 	id = "surgicaldrill_adv"
 	build_type = PROTOLATHE

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -19,7 +19,7 @@
 	return ..()
 
 /obj/item/retractor/advanced
-	name = "mechanical pinches"
+	name = "advanced retractor"
 	desc = "An agglomerate of rods and gears."
 	icon_state = "retractor_a"
 	toolspeed = 0.7
@@ -154,7 +154,7 @@
 	return ..()
 
 /obj/item/surgicaldrill/advanced
-	name = "searing tool"
+	name = "surgical laser drill"
 	desc = "It projects a high power laser used for medical application."
 	icon_state = "surgicaldrill_a"
 	hitsound = 'sound/items/welder.ogg'


### PR DESCRIPTION
# About The Pull Request
Just makes it so they're found under their actual name in the lathes not whatever else. They don't call it "Advanced Scalpel" anyhow (outside of the fake-alien ones but those are unaffected)

## Why It's Good For The Game

Because people have struggled to find them in the lathe because of the way they're named (Advanced Retractor and Laser Surgical Drill respectively which they aren't even called when you print them)

## A Port?

No.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
## Changelog

:cl:
spellcheck: Fixes naming of the Mechanical Pinches and Searing Tool in lathes.
/:cl:
