### PR TITLE
Kinkmate Nerf.dm

### DIFF
--- a/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
@@ -29,7 +29,7 @@
 	inverse_chem_val 		= 0.35
 	inverse_chem		= /datum/reagent/fermi/BEsmaller //At really impure vols, it just becomes 100% inverse
 	can_synth = FALSE
-	value = REAGENT_VALUE_RARE
+	value = REAGENT_VALUE_COMMON
 
 /datum/reagent/fermi/breast_enlarger/on_mob_metabolize(mob/living/M)
 	. = ..()
@@ -112,7 +112,7 @@
 	taste_description = "a milky ice cream like flavour"
 	metabolization_rate = 0.25
 	can_synth = FALSE
-	value = REAGENT_VALUE_RARE
+	value = REAGENT_VALUE_COMMON
 
 /datum/reagent/fermi/BEsmaller/on_mob_life(mob/living/carbon/M)
 	var/obj/item/organ/genital/breasts/B = M.getorganslot(ORGAN_SLOT_BREASTS)
@@ -170,7 +170,7 @@
 	inverse_chem_val 		= 0.35
 	inverse_chem		= /datum/reagent/fermi/PEsmaller //At really impure vols, it just becomes 100% inverse and shrinks instead.
 	can_synth = FALSE
-	value = REAGENT_VALUE_RARE
+	value = REAGENT_VALUE_COMMON
 
 /datum/reagent/fermi/penis_enlarger/on_mob_metabolize(mob/living/M)
 	. = ..()
@@ -253,7 +253,7 @@
 	taste_description = "chinese dragon powder"
 	metabolization_rate = 0.5
 	can_synth = FALSE
-	value = REAGENT_VALUE_RARE
+	value = REAGENT_VALUE_COMMON
 
 /datum/reagent/fermi/PEsmaller/on_mob_life(mob/living/carbon/M)
 	if(!ishuman(M))


### PR DESCRIPTION
Kinkmate Chem Sell Value Nerf so Cargo doesn't get ban he'd for selling viagra.


# About The Pull Request
Citadel's genital expansion chems sold for a high value, but were easily accessible by buying from a kinkmate.
Cargo abused this, the values are being dropped massively and if there is still further abuse the value can be removed entirely.
The four chems which gave the pills value have been dropped in value from Rare to Common, which is an 80% drop in value.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Nope.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
balance: Citadel Expansion Chem value reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
