### PR TITLE
[NON-MODULAR] [READY] Snaxi Security Shutters Fix

### DIFF
--- a/_maps/splurt_maps/map_files/Smexistation/Snaxi_Splurt.dmm
+++ b/_maps/splurt_maps/map_files/Smexistation/Snaxi_Splurt.dmm
@@ -21585,6 +21585,10 @@
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
+	},
 /turf/open/floor/plating,
 /area/security/warden)
 "hTY" = (
@@ -27275,6 +27279,10 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
+	},
 /turf/open/floor/plating,
 /area/security/warden)
 "kqE" = (
@@ -37955,6 +37963,10 @@
 "pdc" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
+	},
 /turf/open/floor/plating,
 /area/security/warden)
 "pdj" = (


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Fixs the security shutters in Snaxi's warden room, because instead of enclosing all the windows they only closed the top and right hand side windows.

## Why It's Good For The Game

Just fixs and reinforces the warden room incase of emergencies.

## A Port?

No

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
fix: fixs security shutters.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
