### PR TITLE
Allow custom shuttles to get to centcom

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -5,7 +5,6 @@ SUBSYSTEM_DEF(shuttle)
 	wait = 10
 	init_order = INIT_ORDER_SHUTTLE
 	flags = SS_KEEP_TIMING|SS_NO_TICK_CHECK
-	runlevels = RUNLEVEL_SETUP | RUNLEVEL_GAME
 
 	var/list/mobile = list()
 	var/list/stationary = list()
@@ -79,6 +78,9 @@ SUBSYSTEM_DEF(shuttle)
 	var/problem_computer_charge_time = 90 SECONDS
 	var/problem_computer_next_charge_time = 0
 	//END SKYRAT CHANGE
+	//SPLURT CHANGE
+	var/list/navigation_locked_traits = list(ZTRAIT_RESERVED, ZTRAIT_CENTCOM, ZTRAIT_AWAY, ZTRAIT_REEBE) //traits forbided for custom docking
+	//END SPLURT CHANGE
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
 	ordernum = rand(1, 9000)

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -11,7 +11,6 @@
 	var/list/jumpto_ports = list() //hashset of ports to jump to and ignore for collision purposes
 	var/obj/docking_port/stationary/my_port //the custom docking port placed by this console
 	var/obj/docking_port/mobile/shuttle_port //the mobile docking port of the connected shuttle
-	var/list/locked_traits = list(ZTRAIT_RESERVED, ZTRAIT_CENTCOM, ZTRAIT_AWAY, ZTRAIT_REEBE) //traits forbided for custom docking
 	var/view_range = 0
 	var/x_offset = 0
 	var/y_offset = 0
@@ -201,7 +200,7 @@
 	var/turf/eyeturf = get_turf(the_eye)
 	if(!eyeturf)
 		return SHUTTLE_DOCKER_BLOCKED
-	if(!eyeturf.z || SSmapping.level_has_any_trait(eyeturf.z, locked_traits))
+	if(!eyeturf.z || SSmapping.level_has_any_trait(eyeturf.z, SSshuttle.navigation_locked_traits))
 		return SHUTTLE_DOCKER_BLOCKED
 
 	. = SHUTTLE_DOCKER_LANDING_CLEAR
@@ -352,7 +351,7 @@
 			stack_trace("SSshuttle.beacons have null entry!")
 			continue
 		var/obj/machinery/spaceship_navigation_beacon/nav_beacon = V
-		if(!nav_beacon.z || SSmapping.level_has_any_trait(nav_beacon.z, console.locked_traits))
+		if(!nav_beacon.z || SSmapping.level_has_any_trait(nav_beacon.z, SSshuttle.navigation_locked_traits))
 			break
 		if(!nav_beacon.locked)
 			L["([L.len]) [nav_beacon.name] located: [nav_beacon.x] [nav_beacon.y] [nav_beacon.z]"] = nav_beacon

--- a/modular_splurt/code/controllers/subsystem/shuttle.dm
+++ b/modular_splurt/code/controllers/subsystem/shuttle.dm
@@ -1,0 +1,6 @@
+/datum/controller/subsystem/shuttle/Initialize(timeofday)
+	. = ..(timeofday)
+	SSticker.OnRoundend(CALLBACK(src, .proc/roundend_callback))
+
+/datum/controller/subsystem/shuttle/proc/roundend_callback()
+	SSshuttle.navigation_locked_traits.Remove(ZTRAIT_CENTCOM)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4426,6 +4426,7 @@
 #include "modular_splurt\code\controllers\subsystem\afk.dm"
 #include "modular_splurt\code\controllers\subsystem\discord.dm"
 #include "modular_splurt\code\controllers\subsystem\redbot.dm"
+#include "modular_splurt\code\controllers\subsystem\shuttle.dm"
 #include "modular_splurt\code\controllers\subsystem\ticker.dm"
 #include "modular_splurt\code\controllers\subsystem\processing\quirks.dm"
 #include "modular_splurt\code\controllers\subsystem\processing\station.dm"


### PR DESCRIPTION
# About The Pull Request

Allow custom shuttles to move after the round has ended, and allow them to get to CentCom if a gigabeacon is set up (only after roundend).

Suggestion #5766

## Why It's Good For The Game

It has always been strange to me that despite being able to build custom shuttles that can go just about anywhere, they arbitrarily cannot get to CentCom. While it makes sense for balance purposes before the round has ended, after that it really does not.

Also, custom shuttles currently just stop working after the round has ended, which this fixes.

## A Port?

No.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

:cl:
tweak: Allow custom shuttles to move after round end
tweak: Allow navigation consoles to see gigabeacons in CentCom after round end
/:cl:
