### PR TITLE
Removes Combat Mode mousetracking.

### DIFF
--- a/code/datums/components/combat_mode.dm
+++ b/code/datums/components/combat_mode.dm
@@ -2,6 +2,7 @@
   * Combat mode component. It makes the user face whichever atom the mouse pointer is hovering,
   * amongst other things designed outside of this file, namely PvP and PvE stuff, hence the name.
   * Can be toggled on and off by clicking the screen hud object or by pressing the assigned hotkey (default 'C')
+  * SPLURT COMMENT: Removes line 130-142 (ALWAYS RE-DO). This is for MAJOR performance reasons.
   */
 /datum/component/combat_mode
 	var/mode_flags = COMBAT_MODE_INACTIVE
@@ -89,8 +90,8 @@
 		if(playsound)
 			playsound(source, 'sound/machines/chime.ogg', 10) 	//sandstorm stuff - combat mode indicator
 			flick_emote_popup_on_mob(source, "combat", 10)	//sandstorm stuff - combat mode indicator
-	RegisterSignal(source, COMSIG_MOB_CLIENT_MOUSEMOVE, .proc/onMouseMove)
-	RegisterSignal(source, COMSIG_MOVABLE_MOVED, .proc/on_move)
+	//RegisterSignal(source, COMSIG_MOB_CLIENT_MOUSEMOVE, .proc/onMouseMove) //SPLURT EDIT: Helps optimise combat mode.
+	//RegisterSignal(source, COMSIG_MOVABLE_MOVED, .proc/on_move) //SPLURT EDIT: Helps optimise combat mode.
 	if(hud_icon)
 		hud_icon.combat_on = TRUE
 		hud_icon.update_icon()
@@ -117,7 +118,7 @@
 			to_chat(source, self_message)
 		if(playsound)
 			source.playsound_local(source, 'sound/misc/ui_toggleoff.ogg', 50, FALSE, pressure_affected = FALSE) //Slightly modified version of the toggleon sound!
-	UnregisterSignal(source, list(COMSIG_MOB_CLIENT_MOUSEMOVE, COMSIG_MOVABLE_MOVED))
+	//UnregisterSignal(source, list(COMSIG_MOB_CLIENT_MOUSEMOVE, COMSIG_MOVABLE_MOVED))
 	if(hud_icon)
 		hud_icon.combat_on = FALSE
 		hud_icon.update_icon()
@@ -125,8 +126,8 @@
 	source.end_parry_sequence()
 
 	source.set_combat_indicator(FALSE) //sandstorm stuff - combat mode indicator
-
-///Changes the user direction to (try) keep match the pointer.
+/*
+///Changes the user direction to (try) keep match the pointer. SPLURT COMMENT: This is EXTREMELY expensive to calculate per mob in combat mode, and causes a ton of lag!!
 /datum/component/combat_mode/proc/on_move(atom/movable/source, dir, atom/oldloc, forced)
 	var/mob/living/L = source
 	if((mode_flags & COMBAT_MODE_ACTIVE) && L.client)
@@ -138,7 +139,7 @@
 		return
 	source.face_atom(object, TRUE)
 	lastmousedir = source.dir
-
+*/
 /// Toggles whether the user is intentionally in combat mode. THIS should be the proc you generally use! Has built in visual/to other player feedback, as well as an audible cue to ourselves.
 /datum/component/combat_mode/proc/user_toggle_intentional_combat_mode(mob/living/source)
 	if(mode_flags & COMBAT_MODE_TOGGLED)


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
major performance fix
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
40+ people using combat mode shouldn't crash the server
this fixes that
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
no (technically yes, I remembered skyrat-cit did it and it majorly helped combat)
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
del: Facing where you are aiming in combat mode (uses a very expensive proc).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
