### PR TITLE
Remove Syndicate Alt Titles

### DIFF
--- a/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
+++ b/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
@@ -4,10 +4,8 @@
 		"Station Director",
 		"Station Commander",
 		"Station Overseer",
-		"Sectorial Commander",
 		"Station Mistress",
 		"Station Master",
-		"Syndicate Admiral",
 		"Cockpitain",
 		"Cuntpitain",
 		"Senator",
@@ -24,8 +22,6 @@
 		"Construction Coordinator",
 		"Project Manager",
 		"Power Plant Director",
-		"Aunt Syndi Pet",
-		"Big Iron",
 		"Magos",
 		"Magos Biologis"
 
@@ -41,8 +37,6 @@
 		"Headpat Of Personnel",
 		"Headgiver To Personnel",
 		"Personnel Manager",
-		"Syndicate Administrator",
-		"Personnel Manager of Syndicate",
 		"Staff Administrator",
 		"Records Administrator",
 		"Captain Attachment"
@@ -55,9 +49,9 @@
 		"Security Commander",
 		"Head of Slutcurity",
 		"Division Leader",
-		"Syndicate Field Commander",
 		"Cerberus Leader",
 		"Head of Studcurity",
+		"Big Iron",
 		"Commissar"
 	)
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
@@ -70,7 +64,6 @@
 		"Supply Chief",
 		"Cargonia Chief",
 		"Brigadier",
-		"Logistics Syndicate Supervisor",
 		"Manager of Shipping Sex"
 	)
 	LAZYADD(alt_titles, extra_titles)
@@ -79,9 +72,7 @@
 /datum/job/rd/New()
 	var/list/extra_titles = list(
 		"Science Administrator",
-		"CEO of Sex",
 		"Sex Research Director",
-		"Cybersun Lead Specialist",
 		"Research Manager"
 	)
 	LAZYADD(alt_titles, extra_titles)
@@ -93,7 +84,6 @@
 		"Medical Administrator",
 		"Healing Fleshlight Mistress",
 		"Healing Fleshlight Master",
-		"Specialist Of Interdyne",
 		"Chief Heal Stud",
 		"Chief Heal Slut"
 	) // Sandcode do not have alt titles for CMO at the moment.
@@ -104,7 +94,6 @@
 	var/list/extra_titles = list(
 		"Atmos Plumber",
 		"Anal Plumber",
-		"Syndicate Atmospherics Master",
 		"Atmos-Slut",
 		"Buttplug",
 		"Disposals Technician"
@@ -118,7 +107,6 @@
 		"Astromechanic",
 		"Station Architect",
 		"Hazardous Material Operator",
-		"Syndicate Constructing Master",
 		"Junior Engineer",
 		"Engi-Slut",
 		"Apprentice Engineer",
@@ -136,8 +124,6 @@
 		"Stripper",
 		"Escort",
 		"Tourist",
-		"SolFed Tourist",
-		"USSP Tourist",
 		"Clerk",
 		"Secretary",
 		"Blacksmith",
@@ -167,7 +153,6 @@
 		"Sommelier",
 		"Bar Owner",
 		"Barmaid",
-		"Crocin Terrorist",
 		"Expediter"
 	)
 	LAZYADD(alt_titles, extra_titles)
@@ -201,7 +186,6 @@
 		"Keeper of Cum",
 		"Counselor",
 		"Techpriest",
-		"Syndicate Techpriest"
 	)
 	LAZYADD(alt_titles, extra_titles)
 	LAZYREMOVE(alt_titles, rem_titles)
@@ -253,7 +237,6 @@
 /datum/job/lawyer/New()
 	var/list/extra_titles = list(
 		"Law-Slut",
-		"Syndicate Attorney",
 		"Internal Affairs Agent",
 		"Attorney"
 	)
@@ -363,7 +346,6 @@
 		"Emergency Horny Technical",
 		"Emergency Cum Receiver",
 		"Emergency Condom Team",
-		"Field Medic Of Interdyne",
 		"Para-Stud"
 	)
 	LAZYADD(alt_titles, extra_titles)
@@ -374,7 +356,6 @@
 		"Microbiologist",
 		"Biochemist",
 		"Viro-Slut",
-		"Syndicate Bioweapon Scientist",
 		"Plague Doctor",
 		"Monkey Destroyer",
 		"Viro-Stud"
@@ -389,7 +370,6 @@
 		"Gumshoe",
 		"Slutective",
 		"Studective",
-		"Syndicate Survey Specialist",
 		"Van Dorn Agent",
 		"Forensic Investigator",
 		"Cinder Dick",
@@ -407,10 +387,6 @@
 		"Guardsman",
 		"Police Officer",
 		"Civil Protection",
-		"SAARE Operative",
-		"PCRC Operative",
-		"Syndicate Combatant",
-		"Gorlex Marauders Trainee",
 		"Tyranny Lover",
 		"Cerberus",
 		"Slutcurity Officer",
@@ -432,9 +408,7 @@
 		"Prison Administrator",
 		"Dungeon Master",
 		"Brig Superintendent",
-		"High-Ranked Security Officer",
 		"Brig Overwatch",
-		"Syndicate Supervisor",
 		"Slutcurity Captain",
 		"Voreden"
 	)


### PR DESCRIPTION
# About The Pull Request

Some alt titles recently introduced in PR 1108 do not fit the lore of SPLURT. This PR aims to fix this.


## Why It's Good For The Game

Because otherwise players will say "Oh I don't respond to CentCom. I respond to the Syndicate. Look at my title." and make people go through hoops.

## A Port?

No.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
code: Made some chages following PR 1108
/:cl:

