### PR TITLE
[TESTMERGE THIS!] Dramatically reduce cost of jungle turf generation

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		newTurf.air.copy_from(stashed_air)
 		newTurf.update_air_ref(planetary_atmos ? 1 : 2)
 		QDEL_NULL(stashed_air)
-	else
+	else if (!(flags & CHANGETURF_SKIP))
 		flags |= CHANGETURF_RECALC_ADJACENT
 		if(ispath(path,/turf/closed))
 			. = ..()
@@ -166,6 +166,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			. = ..()
 			var/turf/open/newTurf = .
 			newTurf.Initalize_Atmos(0)
+	else
+		. = ..()
 
 // Take off the top layer turf and replace it with the next baseturf down
 /turf/proc/ScrapeAway(amount=1, flags)

--- a/code/game/turfs/simulated/river.dm
+++ b/code/game/turfs/simulated/river.dm
@@ -19,7 +19,7 @@
 		else
 			river_nodes += new /obj/effect/landmark/river_waypoint(T)
 			num_spawned++
-	
+
 	safety = 0
 	//make some randomly pathing rivers
 	for(var/A in river_nodes)
@@ -76,8 +76,7 @@
 	var/list/cardinal_turfs = list()
 	var/list/diagonal_turfs = list()
 	var/logged_turf_type
-	for(var/F in RANGE_TURFS(1, src) - src)
-		var/turf/T = F
+	for(var/turf/T in orange(1, src))
 		var/area/new_area = get_area(T)
 		if(!T || (T.density && !ismineralturf(T)) || istype(T, /turf/open/indestructible) || (whitelisted_area && !istype(new_area, whitelisted_area)) || (T.flags_1 & NO_LAVA_GEN_1) )
 			continue
@@ -86,18 +85,16 @@
 			var/turf/closed/mineral/M = T
 			logged_turf_type = M.turf_type
 
-		if(get_dir(src, F) in GLOB.cardinals)
-			cardinal_turfs += F
+		if(get_dir(src, T) in GLOB.cardinals)
+			cardinal_turfs += T
 		else
-			diagonal_turfs += F
+			diagonal_turfs += T
 
-	for(var/F in cardinal_turfs) //cardinal turfs are always changed but don't always spread
-		var/turf/T = F
+	for(var/turf/T as anything in cardinal_turfs) //cardinal turfs are always changed but don't always spread
 		if(!istype(T, logged_turf_type) && T.ChangeTurf(type, baseturfs, CHANGETURF_IGNORE_AIR) && prob(probability))
 			T.Spread(probability - prob_loss, prob_loss, whitelisted_area)
 
-	for(var/F in diagonal_turfs) //diagonal turfs only sometimes change, but will always spread if changed
-		var/turf/T = F
+	for(var/turf/T as anything in diagonal_turfs) //diagonal turfs only sometimes change, but will always spread if changed
 		if(!istype(T, logged_turf_type) && prob(probability) && T.ChangeTurf(type, baseturfs, CHANGETURF_IGNORE_AIR))
 			T.Spread(probability - prob_loss, prob_loss, whitelisted_area)
 		else if(ismineralturf(T))

--- a/code/game/turfs/simulated/river.dm
+++ b/code/game/turfs/simulated/river.dm
@@ -73,33 +73,35 @@
 /turf/proc/Spread(probability = 30, prob_loss = 25, whitelisted_area)
 	if(probability <= 0)
 		return
-	var/list/cardinal_turfs = list()
-	var/list/diagonal_turfs = list()
 	var/logged_turf_type
 	for(var/turf/T in orange(1, src))
 		var/area/new_area = get_area(T)
-		if(!T || (T.density && !ismineralturf(T)) || istype(T, /turf/open/indestructible) || (whitelisted_area && !istype(new_area, whitelisted_area)) || (T.flags_1 & NO_LAVA_GEN_1) )
+		if((T.density && !ismineralturf(T)) || istype(T, /turf/open/indestructible) || (whitelisted_area && !istype(new_area, whitelisted_area)) || (T.flags_1 & NO_LAVA_GEN_1) )
 			continue
 
 		if(!logged_turf_type && ismineralturf(T))
 			var/turf/closed/mineral/M = T
 			logged_turf_type = M.turf_type
 
-		if(get_dir(src, T) in GLOB.cardinals)
-			cardinal_turfs += T
-		else
-			diagonal_turfs += T
-
-	for(var/turf/T as anything in cardinal_turfs) //cardinal turfs are always changed but don't always spread
-		if(!istype(T, logged_turf_type) && T.ChangeTurf(type, baseturfs, CHANGETURF_IGNORE_AIR) && prob(probability))
-			T.Spread(probability - prob_loss, prob_loss, whitelisted_area)
-
-	for(var/turf/T as anything in diagonal_turfs) //diagonal turfs only sometimes change, but will always spread if changed
-		if(!istype(T, logged_turf_type) && prob(probability) && T.ChangeTurf(type, baseturfs, CHANGETURF_IGNORE_AIR))
-			T.Spread(probability - prob_loss, prob_loss, whitelisted_area)
-		else if(ismineralturf(T))
-			var/turf/closed/mineral/M = T
-			M.ChangeTurf(M.turf_type, M.baseturfs, CHANGETURF_IGNORE_AIR)
+	for(var/turf/T in orange(1, src))
+		var/area/new_area = get_area(T)
+		if((T.density && !ismineralturf(T)) || istype(T, /turf/open/indestructible) || (whitelisted_area && !istype(new_area, whitelisted_area)) || (T.flags_1 & NO_LAVA_GEN_1) )
+			continue
+		var/opponent_dir = get_dir(src, T) // Use some clever bitmath to check if the direction is diagonal.
+		if(opponent_dir & (opponent_dir - 1)) //diagonal turfs only sometimes change, but will always spread if changed
+			// NOTE: WE ARE SKIPPING CHANGETURF HERE
+			// The calls in this proc only serve to provide a satisfactory (if it's not ALREADY this) check. They do not actually call changeturf
+			// This is safe because this proc can only be run during mapload, and nothing has initialized by now so there's nothing to inherit or delete
+			if(!istype(T, logged_turf_type) && !istype(T, type) && prob(probability) && T.ChangeTurf(type, baseturfs, CHANGETURF_SKIP))
+				T.Spread(probability - prob_loss, prob_loss, whitelisted_area)
+			else if(ismineralturf(T))
+				var/turf/closed/mineral/M = T
+				// SEE ABOVE, THIS IS ONLY VERY RARELY SAFE
+				M.ChangeTurf(M.turf_type, M.baseturfs, CHANGETURF_SKIP)
+		else //cardinal turfs are always changed but don't always spread
+			// Important NOTE: SEE ABOVE
+			if(!istype(T, logged_turf_type) && !istype(T, type) && T.ChangeTurf(type, baseturfs, CHANGETURF_SKIP) && prob(probability))
+				T.Spread(probability - prob_loss, prob_loss, whitelisted_area)
 
 
 #undef RANDOM_UPPER_X

--- a/modular_splurt/code/modules/mapping/lavaland_jungle_gen.dm
+++ b/modular_splurt/code/modules/mapping/lavaland_jungle_gen.dm
@@ -27,7 +27,7 @@
 			continue
 		W.connected = 1
 		var/turf/cur_turf = get_turf(W)
-		cur_turf.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_IGNORE_AIR)
+		cur_turf.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_SKIP) // HEY! Don't use CHANGETURF_SKIP unless you're SURE it can only ever run prior to turf init!
 		var/turf/target_turf = get_turf(pick(river_nodes - W))
 		if(!target_turf)
 			break
@@ -56,7 +56,7 @@
 				cur_turf = get_step(cur_turf, cur_dir)
 				continue
 			else
-				var/turf/river_turf = cur_turf.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_IGNORE_AIR)
+				var/turf/river_turf = cur_turf.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_SKIP) // HEY! Don't use CHANGETURF_SKIP unless you're SURE it can only ever run prior to turf init!
 				river_turf.Spread(30, 11, whitelist_area)
 
 	for(var/WP in river_nodes)
@@ -111,7 +111,7 @@
 					if(Trange <= radius + 0.5)
 						var/circ_area = get_area(T)
 						if(istype(circ_area, whitelist_area))
-							T.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_IGNORE_AIR)
+							T.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_SKIP) // HEY! Don't use CHANGETURF_SKIP unless you're SURE it can only ever run prior to turf init!
 							affected |= T
 							if(Trange > radius - 1)
 								T.Spread(21, 11, whitelist_area)
@@ -126,21 +126,21 @@
 						dir_turf = get_step(dir_turf, dir)
 						var/dir_area = get_area(dir_turf)
 						if(istype(dir_area, whitelist_area))
-							dir_turf = dir_turf.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_IGNORE_AIR)
+							dir_turf = dir_turf.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_SKIP) // HEY! Don't use CHANGETURF_SKIP unless you're SURE it can only ever run prior to turf init!
 							affected |= dir_turf
 							if(i == radius)
 								dir_turf.Spread(21, 11, whitelist_area)
 						//Fixes to diagional checker board
-						if(dir in GLOB.diagonals)
+						if(dir & (dir-1))
 							var/turf/diag_turf = locate(dir_turf.x,(dir_turf.y-1),target_z)
 							var/diag_area = get_area(diag_turf)
 							if(istype(diag_area, whitelist_area))
-								diag_turf = diag_turf.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_IGNORE_AIR)
+								diag_turf = diag_turf.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_SKIP) // HEY! Don't use CHANGETURF_SKIP unless you're SURE it can only ever run prior to turf init!
 								affected |= diag_turf
 
 			var/area/new_area = get_area(cur_turf)
 			if(istype(new_area, whitelist_area))
-				cur_turf.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_IGNORE_AIR)
+				cur_turf.ChangeTurf(turf_type, new_baseturfs, CHANGETURF_SKIP) // HEY! Don't use CHANGETURF_SKIP unless you're SURE it can only ever run prior to turf init!
 				affected |= cur_turf
 			else
 				detouring = 0


### PR DESCRIPTION
# About The Pull Request
Ports a few optimisations and creates a bunch of novel ones, for the purpose of making xenoarch jungle turf generation much, much faster. It went from about 10 seconds to 0.6 seconds. The optimisations also made other things slightly faster as well, resulting in a total init time save of about 14 seconds out of 72 on my machine, or almost 20%.

This does make some relatively invasive changes to ChangeTurf and a few atmos procs, so it MUST be testmerged to ensure nothing is subtly broken. I didn't immediately start suffocating when I spawned in, and lavaland appeared to have the right airmix, but better safe than sorry.

## Why It's Good For The Game
Hopefully shaves about 20% off of init time.

## A Port?
LemonInTheDark was the original one to optimise Spread() by using `CHANGETURF_SKIP`.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
