### PR TITLE
Add Tracy profiler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,6 @@ Temporary Items
 /tools/LinuxOneShot/TGS_Logs
 tools/UnstandardnessTestForDM/UnstandardnessTestForDM/obj/x86/Debug/UnstandardnessTestForDM.csproj.AssemblyReference.cache
 tools/UnstandardnessTestForDM/UnstandardnessTestForDM/obj/x86/Debug/.NETFramework,Version=v4.0,Profile=Client.AssemblyAttributes.cs
+
+#Tracy profiler DLL
+/prof.dll

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -103,3 +103,8 @@
 #warn In order to build, run BUILD.bat in the root directory.
 #warn Consider switching to VSCode editor instead, where you can press Ctrl+Shift+B to build.
 #endif
+
+// Uncomment this to enable profiling via Tracy.
+// You will need to compile your own copy of prof.dll in order to use it.
+// Find the source code and build instructions here: https://github.com/mafemergency/byond-tracy/
+// #define TRACY_PROFILING

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -374,3 +374,20 @@ GLOBAL_LIST(topic_status_cache)
 
 /world/proc/on_tickrate_change()
 	SStimer?.reset_buckets()
+
+#ifdef TRACY_PROFILING
+/proc/prof_init()
+	var/lib
+
+	switch(world.system_type)
+		if(MS_WINDOWS) lib = "prof.dll"
+		if(UNIX) lib = "libprof.so"
+		else CRASH("unsupported platform")
+
+	var/init = call(lib, "init")()
+	if("0" != init) CRASH("[lib] init error: [init]")
+
+/world/New()
+	prof_init()
+	. = ..()
+#endif


### PR DESCRIPTION
# About The Pull Request
Adds support for enabling the Tracy profiler in local testing.

## Why It's Good For The Game
Makes profiling code easier locally, has no effect on the live server.

## A Port?
No, but it uses example code given in https://github.com/mafemergency/byond-tracy.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.