### PR TITLE
Socks and Cocks layer

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -40,12 +40,12 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define BODYPARTS_LAYER			37		//Initially "AUGMENTS", this was repurposed to be a catch-all bodyparts flag
 #define MARKING_LAYER			36		//Matrixed body markings because clashing with snouts?
 #define BODY_ADJ_LAYER			35		//certain mutantrace features (snout, body markings) that must appear above the body parts
-#define GENITALS_FRONT_LAYER	34		//Draws some genitalia above clothes and the TAUR body if need be.
-#define BODY_LAYER				33		//underwear, undershirts, socks, eyes, lips(makeup)
-#define BODY_ADJ_UPPER_LAYER	32
-#define FRONT_MUTATIONS_LAYER	31		//mutations that should appear above body, body_adj and bodyparts layer (e.g. laser eyes)
-#define UNDERWEAR_LAYER			30
-#define SOCKS_LAYER				29
+#define BODY_LAYER				34		//underwear, undershirts, socks, eyes, lips(makeup)
+#define BODY_ADJ_UPPER_LAYER	33
+#define FRONT_MUTATIONS_LAYER	32		//mutations that should appear above body, body_adj and bodyparts layer (e.g. laser eyes)
+#define SOCKS_LAYER				31
+#define GENITALS_FRONT_LAYER	30		//Draws some genitalia above clothes and the TAUR body if need be.
+#define UNDERWEAR_LAYER			29
 #define SHIRT_LAYER				28
 #define UNIFORM_LAYER			27
 #define ID_LAYER				26


### PR DESCRIPTION
# About The Pull Request

Fixes socks drawing over genitals
Yes this is solely something I've done because it annoys me that I'd have to set them to always exposed for them to draw over socks when running around in nothing but socks.
While I myself haven't encountered any issues with stuff drawing wrongly I still **highly** recommend merely testmerging this at first in case any issues do appear so that I can see about fixing it.

## Why It's Good For The Game

This is literally just a convenience thing for the most part.

## A Port?

No

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
tweak: Modified socks' appearance layer define to not render over genitals
/:cl: