### PR TITLE
Makes bounty consoles printable

### DIFF
--- a/code/modules/research/techweb/nodes/computer_hud_nodes.dm
+++ b/code/modules/research/techweb/nodes/computer_hud_nodes.dm
@@ -5,7 +5,7 @@
 	display_name = "Computer Consoles"
 	description = "Computers and how they work."
 	prereq_ids = list("datatheory")
-	design_ids = list("cargo", "cargorequest", "libraryconsole", "mining", "miningshuttle", "crewconsole", "rdcamera", "comconsole", "idcardconsole", "seccamera")
+	design_ids = list("cargo", "cargorequest", "bounty", "libraryconsole", "mining", "miningshuttle", "crewconsole", "rdcamera", "comconsole", "idcardconsole", "seccamera")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 
 /datum/techweb_node/computer_hardware_basic				//Modular computers are shitty and nearly useless so until someone makes them actually useful this can be easy to get.


### PR DESCRIPTION
# About The Pull Request

Adds regular cargo bounty consoles to research because you can't print them otherwise from what I've seen.

## Why It's Good For The Game

Lets you fix em in case the board's gone and also smexy doesn't have any from what I've seen.

## A Port?

No

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
## Changelog

:cl:
add: Regular bounty console added to research, letting you print it.
/:cl: