### PR TITLE
Fix incorrect EVA storage areastring

### DIFF
--- a/_maps/map_files/Snaxi/Snaxi.dmm
+++ b/_maps/map_files/Snaxi/Snaxi.dmm
@@ -5625,7 +5625,7 @@
 	},
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/power/apc{
-	areastring = "/obj/item/paper/fluff/cogstation/eva";
+	areastring = "/area/ai_monitored/command/storage/eva";
 	dir = 1;
 	name = "EVA Storage APC";
 	pixel_y = 24


### PR DESCRIPTION
# About The Pull Request
Fixes an invalid areastring causing linters to fail.

## Why It's Good For The Game
Linters will pass again.