### PR TITLE
Adds One Alternate Job Title For The Blueshield.

### DIFF
--- a/modular_splurt/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_splurt/code/modules/jobs/job_types/blueshield.dm
@@ -14,7 +14,7 @@
 	exp_type = EXP_TYPE_COMMAND
 	considered_combat_role = TRUE //Brigger then shit yes it is
 	exp_type_department = EXP_TYPE_COMMAND
-	alt_titles = list("Command Security", "Command Guard", "Command Bodyguard", "Sweet Boy", "Sweet Girl", "Penis Case", "Blueguard", "Blueshit", "Captain Mattress", "Blueslut", "Bluestud")
+	alt_titles = list("Command Security", "Command Guard", "Command Bodyguard", "Sweet Boy", "Sweet Girl", "Penis Case", "Blueguard", "Blueshit", "Captain Mattress", "Blueslut", "Bluestud", "Bluemaid")
 	//SPLURT CHANGES (Tells the blueshield they are command, and just a bodyguard, not security)
 	custom_spawn_text = "<font color='red'><b>You are a member of command, meant to act as a bodyguard for all Heads of Staff. However, you are not a member of security nor a Head of Staff yourself - avoid acting as either.</b></font>"
 	outfit = /datum/outfit/job/blueshield


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

Adds one alternate job title for the blueshield: Bluemaid. For all of those blueshield maid enjoyers.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Allows players more freedom in their customization; always nice to have.

## A Port?

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

Not a port.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
add: Added a new alternate blueshield job title: Bluemaid.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
