### PR TITLE
A little check to help stop the broken-headshot epidemic

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -4028,10 +4028,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if(findtext(usr_input, "discordapp"))
 						to_chat(usr, span_admin("You cannot use Discord images, as they are auto-deleted regularly! Try Catbox.moe or Gyazo instead!"))
 						return
+					// Discord will auto-delete images often, meaning users will see their headshot show up, think all is fine, but three days later their link will be broken.
 
 					if(findtext(usr_input, "imgur"))
-						to_chat(usr, span_warning("Please only use Imgur links if your image is SFW! Imgur will delete NSFW images!"))
-						// Don't return! It's fine, just tell the user that this is kinda iffy.
+						to_chat(usr, span_admin("You cannot use Imgur images, as they regularly delete NSFW images as well as many borderline SFW too! Try Catbox.moe or Gyazo instead!"))
+						return
+					// Whilst Imgur does not ban SFW images, many SFW images that look questionable will be nuked.
 
 					if(!findtext(usr_input, end_regex, -8))
 						to_chat(usr, span_warning("You need either \".png\", \".jpg\", or \".jpeg\" in the link!"))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -4024,6 +4024,15 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if(!findtext(usr_input, link_regex))
 						to_chat(usr, span_warning("You need a valid link!"))
 						return
+
+					if(findtext(usr_input, "discordapp"))
+						to_chat(usr, span_admin("You cannot use Discord images, as they are auto-deleted regularly! Try Catbox.moe or Gyazo instead!"))
+						return
+
+					if(findtext(usr_input, "imgur"))
+						to_chat(usr, span_warning("Please only use Imgur links if your image is SFW! Imgur will delete NSFW images!"))
+						// Don't return! It's fine, just tell the user that this is kinda iffy.
+
 					if(!findtext(usr_input, end_regex, -8))
 						to_chat(usr, span_warning("You need either \".png\", \".jpg\", or \".jpeg\" in the link!"))
 						return


### PR DESCRIPTION
# About The Pull Request
• Stops users from uploading Discord images as Headshots, as they regularly auto-delete after a few days. Users will upload images, see it work, but not realise that the image will be gone after a few days.
• Stops users from uploading Imgur images as Headshots, same reason as above but Imgur instead just deletes NSFW images. Many SFW images will also be deleted, due to looking NSFW.
![image](https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/assets/53862927/a01463b7-2072-4dfe-bfaa-a42fd7c45d58)
![image](https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/assets/53862927/c31ea61e-cdd7-4190-ad8b-7ca5e2c76c02)


## Why It's Good For The Game
Maybe more than a handful of players will actually have headshots now?

## A Port?
Nop

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
fix: You can no longer upload Discord/Imgur links as Headshots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
