### PR TITLE
Fix thighjobs

### DIFF
--- a/modular_splurt/code/datums/interactions/lewd/lewd_datums.dm
+++ b/modular_splurt/code/datums/interactions/lewd/lewd_datums.dm
@@ -748,9 +748,9 @@
 	description = "Give them a thighjob."
 	require_user_legs = REQUIRE_ANY
 	require_user_num_legs = 2
-	required_from_target_exposed = NONE
+	required_from_target_exposed = INTERACTION_REQUIRE_PENIS
 	required_from_target_unexposed = NONE
-	required_from_user_exposed = INTERACTION_REQUIRE_PENIS
+	required_from_user_exposed = NONE
 	required_from_user_unexposed = NONE
 	write_log_user = "Gave a thighjob"
 	write_log_target = "Got a thighjob from"


### PR DESCRIPTION
# About The Pull Request

Fixes the thighjobs requiring the person giving it to have a penis but not the one receiving.

## Why It's Good For The Game

Thighfucking itself already exists, this is just a bug.

## A Port?
No.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
fix: Fixed thighjobs to make the receiver need a penis, not the person giving it.
/:cl:
