### PR TITLE
Fix jackets forcing plantigrade legs

### DIFF
--- a/modular_splurt/code/modules/clothing/suits/miscellaneous.dm
+++ b/modular_splurt/code/modules/clothing/suits/miscellaneous.dm
@@ -43,7 +43,7 @@
 	item_state = "jacket_yellow"
 	body_parts_covered = CHEST|ARMS
 	cold_protection = CHEST|ARMS
-	mutantrace_variation = NONE
+	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 
 /obj/item/clothing/suit/toggle/rp_jacket/orange


### PR DESCRIPTION
# About The Pull Request

Unfucks a line in the code that makes jackets force plantigrade legs on digitigrades. Just a simple pre-vacation fix so I recommend a TM first. Issue also literally only exists on the colored version because the department ones already have the fix.

## Why It's Good For The Game

Fixes my OCD and stuff looking stupid because I was about to remove it from my loadout.

## A Port?

No

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
fix: The colored jackets no longer force plantigrade legs on digitigrades.
/:cl: