### PR TITLE
Poly workout shorts digileg fix

### DIFF
--- a/code/modules/clothing/under/shorts.dm
+++ b/code/modules/clothing/under/shorts.dm
@@ -36,7 +36,7 @@
 	desc = "95% Polychrome, 5% Spandex!"
 	icon_state = "polyshortpants"
 	item_state = "rainbow"
-	mutantrace_variation = NONE
+	mutantrace_variation = STYLE_DIGITIGRADE
 	var/list/poly_colors = list("#FFFFFF", "#F08080")
 
 /obj/item/clothing/under/shorts/polychromic/ComponentInitialize()


### PR DESCRIPTION

# About The Pull Request

Yet another piece of clothing that has no mutantrace style so digi legs get forced into this weird shitty plantigrade style

## Why It's Good For The Game

My OCD and so it doesn't look shit when digitigrade leg people wear it.

## A Port?

No

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
## Changelog

:cl:
tweak: Fixed digilegs on polychromic workout shorts.
/:cl: