### PR TITLE
Quick Xenobiological Slime Hybrid fix

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 #define ismammal(A) (is_species(A, /datum/species/mammal))
 #define isinsect(A) (is_species(A, /datum/species/insect))
 #define isxenoperson(A) (is_species(A, /datum/species/xeno))
-#define isstartjelly(A) (is_species(A, /datum/species/jelly/roundstartslime))
+#define isstartjelly(A) (is_species(A, /datum/species/jelly/slime/roundstartslime))
 #define isarachnid(A) (is_species(A, /datum/species/arachnid) || HAS_TRAIT(A, TRAIT_ARACHNID)) // SPLURT Edit: for the Arachnid trait
 
 //more carbon mobs

--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -144,8 +144,8 @@
 /obj/effect/gibspawner/slime
 	gibtypes = list(/obj/effect/decal/cleanable/blood/gibs/slime/up, /obj/effect/decal/cleanable/blood/gibs/slime/down, /obj/effect/decal/cleanable/blood/gibs/slime, /obj/effect/decal/cleanable/blood/gibs/slime, /obj/effect/decal/cleanable/blood/gibs/slime/body, /obj/effect/decal/cleanable/blood/gibs/slime/limb, /obj/effect/decal/cleanable/blood/gibs/slime/core)
 	gibamounts = list(1, 1, 1, 1, 1, 1, 1)
-	gib_mob_type = /mob/living/carbon/human/species/roundstartslime
-	gib_mob_species = /datum/species/jelly/roundstartslime
+	gib_mob_type = /mob/living/carbon/human/species/slime/roundstartslime
+	gib_mob_species = /datum/species/jelly/slime/roundstartslime
 	sound_vol = 50
 
 /obj/effect/gibspawner/slime/Initialize(mapload)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1178,8 +1178,8 @@ Mark this mob, then navigate to the preferences of the client you desire and cal
 /mob/living/carbon/human/species/ipc
 	race = /datum/species/ipc
 
-/mob/living/carbon/human/species/roundstartslime
-	race = /datum/species/jelly/roundstartslime
+/mob/living/carbon/human/species/slime/roundstartslime
+	race = /datum/species/jelly/slime/roundstartslime
 
 /mob/living/carbon/human/species/arachnid
 	race = /datum/species/arachnid

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -414,7 +414,7 @@
 
 ////////////////////////////////////////////////////////Round Start Slimes///////////////////////////////////////////////////////////////////
 
-/datum/species/jelly/roundstartslime
+/datum/species/jelly/slime/roundstartslime
 	name = "Xenobiological Slime Hybrid"
 	id = SPECIES_SLIME_HYBRID
 	limbs_id = SPECIES_SLIME


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Xenobiological Slime Hybrids are a separate race from Xenobiological Slime Entity, which I believe is because Xenobiological Slime Entity wasn't playable in the past. This change makes it so that Xenobiological Slime Hybrid inherits abilities from Xenobiological Slime Entity.

## Why It's Good For The Game

It allows people that want the body markings from Xenobiological Slime Hybrid to play a proper slime character, plus it's a fix of something unintentional from what I can tell. It's also a simple change so it should merge without any trouble.

## A Port?

Nope.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
code: replaced all "/datum/species/jelly/roundstartslime" with "/datum/species/jelly/slime/roundstartslime"

code: replaced all "/mob/living/carbon/human/species/roundstartslime" with "/mob/living/carbon/human/species/slime/roundstartslime"

roundstartslime species inherits code from the already existing & playable slime species this way
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
