### PR TITLE
Fix bug preventing broadcast to all

### DIFF
--- a/code/modules/NTNet/network.dm
+++ b/code/modules/NTNet/network.dm
@@ -103,7 +103,7 @@
 	data.network_id = src
 	log_data_transfer(data)
 	var/list/datum/component/ntnet_interface/receiving = list()
-	if((length(data.recipient_ids == 1) && data.recipient_ids[1] == NETWORK_BROADCAST_ID) || data.recipient_ids == NETWORK_BROADCAST_ID)
+	if((length(data.recipient_ids) == 1 && data.recipient_ids[1] == NETWORK_BROADCAST_ID) || data.recipient_ids == NETWORK_BROADCAST_ID)
 		data.broadcast = TRUE
 		for(var/i in connected_interfaces_by_id)
 			receiving |= connected_interfaces_by_id[i]


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

Fixes a long-standing bug. NTNet transmitters are supposed to be able to transmit to all others, but a single-line bug prevented it.


## Why It's Good For The Game
Being able to send to all other NTNet receivers is a useful thing for making circuits involving many individual parts, and was an originally intended feature.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Fixed this a while ago on the Syndication downstream, with https://github.com/TheSyndication/Syndication/commit/eebe5293bd0232ff47433ac5982024e3efa803dd
This is just a cherry-pick of that commit.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
fix: NTNet broadcast to all
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
