### PR TITLE
Fixes the dom and sub quirks

### DIFF
--- a/modular_splurt/code/datums/traits/good.dm
+++ b/modular_splurt/code/datums/traits/good.dm
@@ -92,12 +92,11 @@
 		sub.dir = turn(get_dir(sub, quirk_holder), pick(-90, 90))
 		sub.emote("blush")
 
-/datum/quirk/dominant_aura/proc/handle_snap(datum/source, list/emote_args)
+/datum/quirk/dominant_aura/proc/handle_snap(datum/source, datum/emote/emote)
 	SIGNAL_HANDLER
 
 	. = FALSE
-	var/key = GLOB.emote_list[lowertext(emote_args[EMOTE_ACT])]
-	if(TIMER_COOLDOWN_CHECK(quirk_holder, COOLDOWN_DOMINANT_SNAP) || !findtext(key, "snap"))
+	if(TIMER_COOLDOWN_CHECK(quirk_holder, COOLDOWN_DOMINANT_SNAP) || !findtext(emote.key, "snap"))
 		return
 	for(var/mob/living/carbon/human/sub in hearers(DOMINANT_DETECT_RANGE, quirk_holder))
 		if(!sub.has_quirk(/datum/quirk/well_trained) || (sub == quirk_holder))
@@ -108,7 +107,7 @@
 				good_x = "boy"
 			if(FEMALE)
 				good_x = "girl"
-		switch(key)
+		switch(emote.key)
 			if("snap")
 				sub.dir = get_dir(sub, quirk_holder)
 				sub.emote(pick("blush", "pant"))

--- a/modular_splurt/code/modules/mob/emote.dm
+++ b/modular_splurt/code/modules/mob/emote.dm
@@ -1,3 +1,0 @@
-/mob/emote(act, m_type, message, intentional)
-	. = ..()
-	SEND_SIGNAL(src, COMSIG_MOB_EMOTE, args)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4922,7 +4922,6 @@
 #include "modular_splurt\code\modules\mining\equipment\kinetic_crusher.dm"
 #include "modular_splurt\code\modules\mining\equipment\machine_vending.dm"
 #include "modular_splurt\code\modules\mining\lavaland\necropolis_chests.dm"
-#include "modular_splurt\code\modules\mob\emote.dm"
 #include "modular_splurt\code\modules\mob\femclaw.dm"
 #include "modular_splurt\code\modules\mob\inventory.dm"
 #include "modular_splurt\code\modules\mob\mob.dm"


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
I better get a dommy mommy for this
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
fix: Fixes the snap on dominant aura
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
